### PR TITLE
Allow styling of the whole new tab button

### DIFF
--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -141,6 +141,14 @@ pub struct TabBarColors {
     /// Styling for an inactive tab with a mouse hovering
     #[serde(default = "default_inactive_tab_hover")]
     pub inactive_tab_hover: TabBarColor,
+
+    /// Styling for the new tab button
+    #[serde(default = "default_inactive_tab")]
+    pub new_tab: TabBarColor,
+
+    /// Styling for the new tab button with a mouse hovering
+    #[serde(default = "default_inactive_tab_hover")]
+    pub new_tab_hover: TabBarColor,
 }
 impl_lua_conversion!(TabBarColors);
 
@@ -178,39 +186,31 @@ impl Default for TabBarColors {
             inactive_tab: default_inactive_tab(),
             inactive_tab_hover: default_inactive_tab_hover(),
             active_tab: default_active_tab(),
+            new_tab: default_inactive_tab(),
+            new_tab_hover: default_inactive_tab_hover(),
         }
     }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TabBarStyle {
-    #[serde(default = "default_tab_left")]
-    pub new_tab_left: String,
-    #[serde(default = "default_tab_right")]
-    pub new_tab_right: String,
-    #[serde(default = "default_tab_left")]
-    pub new_tab_hover_left: String,
-    #[serde(default = "default_tab_right")]
-    pub new_tab_hover_right: String,
+    #[serde(default = "default_new_tab")]
+    pub new_tab: String,
+    #[serde(default = "default_new_tab")]
+    pub new_tab_hover: String,
 }
 
 impl Default for TabBarStyle {
     fn default() -> Self {
         Self {
-            new_tab_left: default_tab_left(),
-            new_tab_right: default_tab_right(),
-            new_tab_hover_left: default_tab_left(),
-            new_tab_hover_right: default_tab_right(),
+            new_tab: default_new_tab(),
+            new_tab_hover: default_new_tab(),
         }
     }
 }
 
-fn default_tab_left() -> String {
-    format_as_escapes(vec![FormatItem::Text(" ".to_string())]).unwrap()
-}
-
-fn default_tab_right() -> String {
-    format_as_escapes(vec![FormatItem::Text(" ".to_string())]).unwrap()
+fn default_new_tab() -> String {
+    format_as_escapes(vec![FormatItem::Text(" + ".to_string())]).unwrap()
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -195,6 +195,26 @@ return {
 
         -- The same options that were listed under the `active_tab` section above
         -- can also be used for `inactive_tab_hover`.
+      },
+
+      -- The new tab button that let you create new tabs
+      new_tab = {
+        bg_color = "#1b1032",
+        fg_color = "#808080",
+
+        -- The same options that were listed under the `active_tab` section above
+        -- can also be used for `new_tab`.
+      },
+
+      -- You can configure some alternate styling when the mouse pointer
+      -- moves over the new tab button
+      new_tab_hover = {
+        bg_color = "#3b3052",
+        fg_color = "#909090",
+        italic = true,
+
+        -- The same options that were listed under the `active_tab` section above
+        -- can also be used for `new_tab_hover`.
       }
     }
   }

--- a/docs/config/lua/config/tab_bar_style.md
+++ b/docs/config/lua/config/tab_bar_style.md
@@ -1,5 +1,10 @@
 # `tab_bar_style`
 
+*Since: nightly builds only*
+
+`new_tab_left`, `new_tab_right`, `new_tab_hover_left`, `new_tab_hover_right`
+have been removed and replaced by the more flexible `new_tab` and `new_tab_hover` elements.
+
 *Since: 20210502-154244-3f7122cb*
 
 `active_tab_left`, `active_tab_right`, `inactive_tab_left`,


### PR DESCRIPTION
Replace `new_tab_left`, `new_tab_right`, `new_tab_hover_left` and `new_tab_hover_right` elements in `tab_bar_style` with more flexible `new_tab` and `new_tab_hover` elements.
Also introduce `new_tab` and `new_tab_hover` elements in `colors.tab_bar`.