### PR TITLE
termwiz: revert to using semicolon when encoding 8 bit SGR colors

### DIFF
--- a/termwiz/src/escape/csi.rs
+++ b/termwiz/src/escape/csi.rs
@@ -1402,7 +1402,7 @@ impl Display for Sgr {
                         $(AnsiColor::$Ansi => code!($code) ,)*
                     }
                 } else {
-                    write!(f, "{}:5:{}m", SgrCode::$eightbit as i64, $idx)?
+                    write!(f, "{};5;{}m", SgrCode::$eightbit as i64, $idx)?
                 }
             }
         }
@@ -1564,7 +1564,7 @@ impl Display for Sgr {
                 }
             }
             Sgr::UnderlineColor(ColorSpec::PaletteIndex(idx)) => {
-                write!(f, "{}:5:{}m", SgrCode::UnderlineColor as i64, *idx)?
+                write!(f, "{};5;{}m", SgrCode::UnderlineColor as i64, *idx)?
             }
         }
         Ok(())
@@ -2879,7 +2879,7 @@ mod test {
             )))]
         );
         assert_eq!(
-            parse('m', &[58, 5, 220, 255, 255], "\x1b[58:5:220m\x1b[255;255m"),
+            parse('m', &[58, 5, 220, 255, 255], "\x1b[58;5;220m\x1b[255;255m"),
             vec![
                 CSI::Sgr(Sgr::UnderlineColor(ColorSpec::PaletteIndex(220))),
                 CSI::Unspecified(Box::new(Unspecified {
@@ -2919,7 +2919,7 @@ mod test {
             )))]
         );
         assert_eq!(
-            parse('m', &[38, 5, 220, 255, 255], "\x1b[38:5:220m\x1b[255;255m"),
+            parse('m', &[38, 5, 220, 255, 255], "\x1b[38;5;220m\x1b[255;255m"),
             vec![
                 CSI::Sgr(Sgr::Foreground(ColorSpec::PaletteIndex(220))),
                 CSI::Unspecified(Box::new(Unspecified {


### PR DESCRIPTION
Windows does not seem to support 8 bit colors using the colon separator. The intention of e1f7edaeb349dd00332fc7f100094242719c7879 seems to be around true color, so I left that alone and only changed 8 bit color back to semicolons.

Fixes #2723