### PR TITLE
termwiz: make pest an optional dependency

### DIFF
--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -39,7 +39,7 @@ serial = "0.4"
 shell-words = "1.1"
 smol = "1.2"
 terminfo = "0.8"
-termwiz = { path = "../termwiz" }
+termwiz = { path = "../termwiz", features=["tmux"] }
 termwiz-funcs = { path = "../lua-api-crates/termwiz-funcs" }
 textwrap = "0.16"
 thiserror = "1.0"

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -30,8 +30,8 @@ log = "0.4"
 memmem = "0.1"
 num-traits = "0.2"
 ordered-float = "3.0"
-pest = "2.1"
-pest_derive = "2.1"
+pest = { version="2.1", optional=true }
+pest_derive = { version="2.1", optional=true }
 phf = "0.11"
 semver = "0.11"
 serde = {version="1.0", features = ["rc", "derive"], optional=true}
@@ -54,6 +54,7 @@ widgets = ["cassowary", "fnv"]
 use_serde = ["serde", "wezterm-color-types/use_serde", "wezterm-blob-leases/serde", "bitflags/serde", "wezterm-input-types/serde"]
 use_image = ["image"]
 docs = ["widgets", "use_serde"]
+tmux = ["pest", "pest_derive"]
 
 [dev-dependencies]
 criterion = "0.4"

--- a/termwiz/src/lib.rs
+++ b/termwiz/src/lib.rs
@@ -64,6 +64,7 @@ mod readbuf;
 pub mod render;
 pub mod surface;
 pub mod terminal;
+#[cfg(feature = "tmux")]
 pub mod tmux_cc;
 #[cfg(feature = "widgets")]
 pub mod widgets;


### PR DESCRIPTION
`pest` is only used for `termwiz::tmux_cc`. Not all termwiz users are interested in tmux integration. So let's make it optional.

----

Looking at the dependencies, I also wonder if other ones can be optional (looking for feedback):
- fancy-regex: only used by auto hyperlink recognition? Maybe it can be made optional? (`regex` is not exactly lightweight)
- wezterm-blob-leases: only used by image? Could `mod image` be gated by `use_image` feature?