### PR TITLE
Adjust hyperlink rules to handle links containing ")" appropriately (#3803)

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1622,7 +1622,7 @@ pub fn default_hyperlink_rules() -> Vec<hyperlink::Rule> {
         hyperlink::Rule::with_highlight(r"<(\w+://\S+)>", "$1", 1).unwrap(),
         // Then handle URLs not wrapped in brackets
         // and include terminating ), / or - characters, if any
-        hyperlink::Rule::new(r"\b\w+://\S+[)/a-zA-Z0-9-]+", "$0").unwrap(),
+        hyperlink::Rule::with_highlight(r"[^(]\b(\w+://\S+[)/a-zA-Z0-9-]+)", "$1", 1).unwrap(),
         // implicit mailto link
         hyperlink::Rule::new(r"\b\w+@[\w-]+(\.[\w-]+)+\b", "mailto:$0").unwrap(),
     ]

--- a/docs/config/lua/config/hyperlink_rules.md
+++ b/docs/config/lua/config/hyperlink_rules.md
@@ -68,8 +68,9 @@ config.hyperlink_rules = {
   },
   -- Then handle URLs not wrapped in brackets
   {
-    regex = '\\b\\w+://\\S+[)/a-zA-Z0-9-]+',
-    format = '$0',
+    regex = '[^(]\\b(\\w+://\\S+[)/a-zA-Z0-9-]+)',
+    format = '$1',
+    highlight = 1,
   },
   -- implicit mailto link
   {


### PR DESCRIPTION
The current hyperlink rules match eagerly for link that contain ")" like this:
```
- (http://localhost/foo)
   ^^^^^^^^^^^^^^^^^^^^^ --> "http://localhost/foo)"
- [FOO](http://localhost/foo)
        ^^^^^^^^^^^^^^^^^^^^^ --> "http://localhost/foo)"
```

This PR makes hyperlink rules match them appropriately like this:
```
- (http://localhost/foo)
   ^^^^^^^^^^^^^^^^^^^^ --> "http://localhost/foo"
- [FOO](http://localhost/foo)
        ^^^^^^^^^^^^^^^^^^^^ --> "http://localhost/foo"
```

See #3803 for more context.