### PR TITLE
Start line selection at 0th cell

### DIFF
--- a/wezterm-gui/src/termwindow/selection.rs
+++ b/wezterm-gui/src/termwindow/selection.rs
@@ -247,7 +247,7 @@ impl super::TermWindow {
         };
         match mode {
             SelectionMode::Line => {
-                let start = SelectionCoordinate::x_y(x, y);
+                let start = SelectionCoordinate::x_y(0, y);
                 let selection_range = SelectionRange::line_around(start, &**pane);
 
                 self.selection(pane.pane_id()).origin = Some(start);


### PR DESCRIPTION
Starting line selection at 0th cell allows line selection to be extended using Shift+Mouse without breaking the selection start. This mostly happens when selecting a line then scrolling down and extending the selection.