### PR TITLE
Improve integrated titlebar buttons on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,10 +1276,11 @@ checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "deranged"
-version = "0.3.8"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
+ "powerfmt",
  "serde",
 ]
 
@@ -3469,6 +3470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3967,6 +3974,12 @@ dependencies = [
  "winapi",
  "winreg 0.10.1",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -5323,12 +5336,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.28"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -5336,9 +5351,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-funcs"
@@ -5357,10 +5372,11 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/wezterm-font/src/ftwrap.rs
+++ b/wezterm-font/src/ftwrap.rs
@@ -431,7 +431,13 @@ impl Face {
     pub fn pixel_sizes(&self) -> Vec<u16> {
         let sizes = unsafe {
             let rec = &(*self.face);
-            std::slice::from_raw_parts(rec.available_sizes, rec.num_fixed_sizes as usize)
+            // std::slice::from_raw_parts(rec.available_sizes, rec.num_fixed_sizes as usize)
+            // TODO: Stop violating unsafe precondition
+            if !rec.available_sizes.is_null() {
+                std::slice::from_raw_parts(rec.available_sizes, rec.num_fixed_sizes as usize)
+            } else {
+                &[]
+            }
         };
         sizes
             .iter()

--- a/wezterm-font/src/hbwrap.rs
+++ b/wezterm-font/src/hbwrap.rs
@@ -1052,7 +1052,11 @@ impl Buffer {
         unsafe {
             let mut len: u32 = 0;
             let info = hb_buffer_get_glyph_infos(self.buf, &mut len as *mut _);
-            slice::from_raw_parts(info, len as usize)
+            if info.is_null() {
+                &[]
+            } else {
+                slice::from_raw_parts(info, len as usize)
+            }
         }
     }
 
@@ -1062,7 +1066,11 @@ impl Buffer {
         unsafe {
             let mut len: u32 = 0;
             let pos = hb_buffer_get_glyph_positions(self.buf, &mut len as *mut _);
-            slice::from_raw_parts(pos, len as usize)
+            if pos.is_null() {
+                &[]
+            } else {
+                slice::from_raw_parts(pos, len as usize)
+            }
         }
     }
 

--- a/wezterm-font/src/rasterizer/freetype.rs
+++ b/wezterm-font/src/rasterizer/freetype.rs
@@ -92,10 +92,15 @@ impl FontRasterizer for FreeTypeRasterizer {
         // pitch is the number of bytes per source row
         let pitch = ft_glyph.bitmap.pitch.abs() as usize;
         let data = unsafe {
-            slice::from_raw_parts_mut(
-                ft_glyph.bitmap.buffer,
-                ft_glyph.bitmap.rows as usize * pitch,
-            )
+            // TODO: Stop violating precondition
+            if !ft_glyph.bitmap.buffer.is_null() {
+                slice::from_raw_parts_mut(
+                    ft_glyph.bitmap.buffer,
+                    ft_glyph.bitmap.rows as usize * pitch,
+                )
+            } else {
+                &mut []
+            }
         };
 
         let glyph = match mode {

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -321,6 +321,27 @@ pub trait WindowOps {
     ) -> anyhow::Result<Option<os::parameters::Parameters>> {
         Ok(None)
     }
+
+    // Used for macos, to calculate the traffic lights padding
+    fn get_title_bar_horizontal_padding(
+        &self,
+        config: &ConfigHandle,
+        _window_state: WindowState,
+        _tab_bar_height: f32,
+    ) -> (Dimension, Dimension) {
+        let window_buttons_at_left = config
+            .window_decorations
+            .contains(wezterm_input_types::WindowDecorations::INTEGRATED_BUTTONS)
+            && config.integrated_title_button_alignment == IntegratedTitleButtonAlignment::Left;
+
+        let left_padding = if window_buttons_at_left {
+            Dimension::Pixels(0.0)
+        } else {
+            Dimension::Cells(0.5)
+        };
+
+        (left_padding, Default::default())
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/window/src/os/macos/mod.rs
+++ b/window/src/os/macos/mod.rs
@@ -1,3 +1,4 @@
+use cocoa::appkit::NSApplication;
 use cocoa::base::{id, nil};
 use cocoa::foundation::NSString;
 use objc::rc::StrongPtr;
@@ -31,4 +32,17 @@ unsafe fn nsstring_to_str<'a>(mut ns: *mut Object) -> &'a str {
     let len = NSString::len(ns as id);
     let bytes = std::slice::from_raw_parts(data, len);
     std::str::from_utf8_unchecked(bytes)
+}
+
+unsafe fn nsapplication_shared_direction_is_rtl() -> bool {
+    // 0 -> Left to Right
+    // 1 -> Right to Left
+    let layout_direction: cocoa::foundation::NSInteger = unsafe {
+        msg_send![
+            NSApplication::sharedApplication(nil),
+            userInterfaceLayoutDirection
+        ]
+    };
+
+    layout_direction != 0
 }

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -429,7 +429,7 @@ impl Window {
         name: &str,
         geometry: RequestedWindowGeometry,
         config: Option<&ConfigHandle>,
-        _font_config: Rc<FontConfiguration>,
+        font_config: Rc<FontConfiguration>,
         event_handler: F,
     ) -> anyhow::Result<Window>
     where
@@ -485,6 +485,7 @@ impl Window {
                 dead_pending: None,
                 fullscreen: None,
                 config: config.clone(),
+                font_config: font_config.clone(),
                 ime_state: ImeDisposition::None,
                 ime_last_event: None,
                 live_resizing: false,
@@ -499,12 +500,6 @@ impl Window {
                 NSBackingStoreBuffered,
                 NO,
             ));
-
-            apply_decorations_to_window(
-                &window,
-                config.window_decorations,
-                config.integrated_title_button_style,
-            );
 
             // Prevent Cocoa native tabs from being used
             let _: () = msg_send![*window, setTabbingMode:2 /* NSWindowTabbingModeDisallowed */];
@@ -615,6 +610,7 @@ impl Window {
                 ns_window: *window,
                 ns_view: *view,
             };
+
             let window_inner = Rc::new(RefCell::new(WindowInner {
                 window,
                 view,
@@ -850,6 +846,8 @@ impl WindowOps for Window {
                     let insets: NSEdgeInsets = unsafe { msg_send![main_screen, safeAreaInsets] };
                     log::trace!("{:?}", insets);
 
+                    dbg!(&insets);
+
                     // Bleh, the API is supposed to give us the right metrics, but it needs
                     // a tweak to look good around the notch.
                     // <https://github.com/wez/wezterm/issues/1737#issuecomment-1085923867>
@@ -939,6 +937,10 @@ impl WindowInner {
                 self.config.window_decorations,
                 self.config.integrated_title_button_style,
             );
+
+            if let Some(window_view) = WindowView::get_this(unsafe { &**self.view }) {
+                window_view.update_titlebar();
+            }
         }
     }
 
@@ -987,11 +989,7 @@ impl WindowInner {
                 Some(saved_rect) => unsafe {
                     // Restore prior dimensions
                     self.window.orderOut_(nil);
-                    apply_decorations_to_window(
-                        &self.window,
-                        self.config.window_decorations,
-                        self.config.integrated_title_button_style,
-                    );
+                    self.apply_decorations();
                     self.window.setFrame_display_(saved_rect, YES);
                     self.window.makeKeyAndOrderFront_(nil);
                     self.window.setOpaque_(NO);
@@ -1082,12 +1080,7 @@ impl WindowInner {
             // stuck with a scale factor of 2 despite us having configured 1.
             self.window
                 .setStyleMask_(NSWindowStyleMask::NSBorderlessWindowMask);
-            apply_decorations_to_window(
-                &self.window,
-                self.config.window_decorations,
-                self.config.integrated_title_button_style,
-            );
-
+            self.apply_decorations();
             self.window.makeKeyAndOrderFront_(nil)
         }
     }
@@ -1370,6 +1363,9 @@ struct Inner {
 
     config: ConfigHandle,
 
+    /// Currently used only to detect the titlebar height
+    font_config: Rc<FontConfiguration>,
+
     /// Used to signal when IME really just swallowed a key
     ime_state: ImeDisposition,
     /// Captures the last event that had ImeDisposition::Acted,
@@ -1624,6 +1620,77 @@ impl Inner {
             Ok(TranslateStatus::Composing(composing.text))
         } else {
             Ok(TranslateStatus::NotDead)
+        }
+    }
+
+    fn update_title_bar_buttons_position(&mut self) {
+        let Some(window) = self.window.as_ref().map(|p| p.load()) else {
+            return;
+        };
+
+        if !self
+            .config
+            .window_decorations
+            .contains(WindowDecorations::INTEGRATED_BUTTONS)
+        {
+            return;
+        }
+
+        // Currently height detection supported only for the fancy tab bar
+        if !self.config.use_fancy_tab_bar {
+            return;
+        }
+
+        let Some(height) = self
+            .font_config
+            .title_font()
+            .map(|f| (f.metrics().cell_height.get() as f64 * 1.75 * 0.5).ceil())
+            .ok()
+        else {
+            return;
+        };
+
+        unsafe {
+            // https://github.com/stonesam92/ChitChat/blob/8aa2feb58e3467546ee5c861df53de604cb2ca96/WhatsMac/AppDelegate.m#L391
+            use appkit::*;
+
+            let titlebar_height = height;
+
+            let window_frame = NSWindow::frame(*window);
+
+            let close_button = window.standardWindowButton_(NSWindowButton::NSWindowCloseButton);
+
+            // Set size of titlebar container
+            let titlebar_container_view = NSView::superview(NSView::superview(close_button));
+
+            let mut titlebar_container_frame = NSView::frame(titlebar_container_view);
+            titlebar_container_frame.origin.y = window_frame.size.height - titlebar_height;
+            titlebar_container_frame.size.height = titlebar_height;
+            NSView::setFrameOrigin(titlebar_container_view, titlebar_container_frame.origin);
+            NSView::setFrameSize(titlebar_container_view, titlebar_container_frame.size);
+
+            let mut button_x = (height * 0.5 - 8.0).max(0.0);
+
+            let minimize_button =
+                window.standardWindowButton_(NSWindowButton::NSWindowMiniaturizeButton);
+            let zoom_button = window.standardWindowButton_(NSWindowButton::NSWindowZoomButton);
+
+            for button in [close_button, minimize_button, zoom_button] {
+                let mut button_frame = NSView::frame(button);
+
+                button_frame.origin.x = button_x;
+
+                // in fullscreen, the titlebar frame is not governed by kTitlebarHeight but rather appears to be fixed by the system.
+                // thus, we set a constant Y origin for the buttons when in fullscreen.
+
+                button_frame.origin.y =
+                    ((titlebar_height - button_frame.size.height) / 2.0).round();
+
+                // spacing for next button
+                button_x += button_frame.size.width + 6.0;
+
+                NSView::setFrameOrigin(button, button_frame.origin);
+            }
         }
     }
 }
@@ -1974,6 +2041,7 @@ impl WindowView {
                 .borrow_mut()
                 .events
                 .dispatch(WindowEvent::AppearanceChanged(appearance));
+            this.update_titlebar();
         }
     }
 
@@ -2056,6 +2124,8 @@ impl WindowView {
                 }
             }
         }
+
+        self.update_titlebar();
     }
 
     extern "C" fn did_become_key(this: &mut Object, _sel: Sel, _id: id) {
@@ -2708,6 +2778,8 @@ impl WindowView {
 
     extern "C" fn will_start_live_resize(this: &mut Object, _sel: Sel, _notification: id) {
         if let Some(this) = Self::get_this(this) {
+            this.update_titlebar();
+
             let mut inner = this.inner.borrow_mut();
             inner.live_resizing = true;
         }
@@ -2715,6 +2787,8 @@ impl WindowView {
 
     extern "C" fn did_end_live_resize(this: &mut Object, _sel: Sel, _notification: id) {
         if let Some(this) = Self::get_this(this) {
+            this.update_titlebar();
+
             let mut inner = this.inner.borrow_mut();
             inner.live_resizing = false;
         }
@@ -2722,6 +2796,8 @@ impl WindowView {
 
     extern "C" fn did_resize(this: &mut Object, _sel: Sel, _notification: id) {
         if let Some(this) = Self::get_this(this) {
+            this.update_titlebar();
+
             let inner = this.inner.borrow_mut();
 
             if let Some(gl_context_pair) = inner.gl_context_pair.as_ref() {
@@ -2921,6 +2997,10 @@ impl WindowView {
             inner.events.dispatch(WindowEvent::DroppedFile(paths));
         }
         YES
+    }
+
+    fn update_titlebar(&self) {
+        self.inner.borrow_mut().update_title_bar_buttons_position();
     }
 
     fn get_this(this: &Object) -> Option<&mut Self> {


### PR DESCRIPTION
https://github.com/wez/wezterm/assets/63008755/5caf97e6-640f-4e10-bac0-e7dc4d1128f5


I found a way to move traffic lights, it seems to work as I want to, but needs some improvements

TODO:
- [x] Correctly refresh buttons every time it's needed
- [ ] Handle not only the fancy variant
- [ ] Check how it works with other preferences
- [x] Handle RTL
- [X] Correctly handle the margin for the window buttons in the tab bar code 