### PR TITLE
termwiz:  Kitty keyboard enhancements support

### DIFF
--- a/termwiz/examples/key_tester.rs
+++ b/termwiz/examples/key_tester.rs
@@ -1,4 +1,4 @@
-use termwiz::caps::Capabilities;
+use termwiz::caps::{Capabilities, ProbeHints};
 use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers};
 use termwiz::terminal::{new_terminal, Terminal};
 use termwiz::Error;
@@ -9,7 +9,8 @@ const CTRL_C: KeyEvent = KeyEvent {
 };
 
 fn main() -> Result<(), Error> {
-    let caps = Capabilities::new_from_env()?;
+    let caps =
+        Capabilities::new_with_hints(ProbeHints::new_from_env().probe_for_enhanced_keyboard(true))?;
     let mut terminal = new_terminal(caps)?;
     terminal.set_raw_mode()?;
 

--- a/termwiz/src/caps/mod.rs
+++ b/termwiz/src/caps/mod.rs
@@ -116,6 +116,11 @@ builder! {
         /// invisible and reset, and directly emit those sequences.
         /// This can improve rendered text compatibility with pagers.
         force_terminfo_render_to_use_ansi_sgr: Option<bool>,
+
+        /// Whether Kitty enhanced keyboard protocol should be used
+        /// Note: termcap does not report this capability so it is assumed
+        /// to be supported by `Capabilities` and enabled if possible by `Terminal`.
+        keyboard_enhancement: Option<bool>,
     }
 }
 
@@ -164,6 +169,7 @@ pub struct Capabilities {
     bracketed_paste: bool,
     mouse_reporting: bool,
     force_terminfo_render_to_use_ansi_sgr: bool,
+    keyboard_enhancement: bool,
 }
 
 impl Capabilities {
@@ -293,6 +299,7 @@ impl Capabilities {
 
         let bracketed_paste = hints.bracketed_paste.unwrap_or(true);
         let mouse_reporting = hints.mouse_reporting.unwrap_or(true);
+        let keyboard_enhancement = hints.keyboard_enhancement.unwrap_or(true);
 
         let force_terminfo_render_to_use_ansi_sgr =
             hints.force_terminfo_render_to_use_ansi_sgr.unwrap_or(false);
@@ -307,6 +314,7 @@ impl Capabilities {
             bracketed_paste,
             mouse_reporting,
             force_terminfo_render_to_use_ansi_sgr,
+            keyboard_enhancement,
         })
     }
 
@@ -357,6 +365,12 @@ impl Capabilities {
     /// SGR terminfo capabilities.
     pub fn force_terminfo_render_to_use_ansi_sgr(&self) -> bool {
         self.force_terminfo_render_to_use_ansi_sgr
+    }
+
+    /// Whether to request that the terminal enable Kitty enhanced
+    /// keyboard protocol, if supported
+    pub fn keyboard_enhancement(&self) -> bool {
+        self.keyboard_enhancement
     }
 }
 

--- a/termwiz/src/caps/mod.rs
+++ b/termwiz/src/caps/mod.rs
@@ -117,10 +117,8 @@ builder! {
         /// This can improve rendered text compatibility with pagers.
         force_terminfo_render_to_use_ansi_sgr: Option<bool>,
 
-        /// Whether Kitty enhanced keyboard protocol should be used
-        /// Note: termcap does not report this capability so it is assumed
-        /// to be supported by `Capabilities` and enabled if possible by `Terminal`.
-        keyboard_enhancement: Option<bool>,
+        /// Whether support for Kitty enhanced keyboard protocol should be probed and enabled
+        probe_for_enhanced_keyboard: bool,
     }
 }
 
@@ -169,7 +167,7 @@ pub struct Capabilities {
     bracketed_paste: bool,
     mouse_reporting: bool,
     force_terminfo_render_to_use_ansi_sgr: bool,
-    keyboard_enhancement: bool,
+    probe_for_enhanced_keyboard: bool,
 }
 
 impl Capabilities {
@@ -299,8 +297,7 @@ impl Capabilities {
 
         let bracketed_paste = hints.bracketed_paste.unwrap_or(true);
         let mouse_reporting = hints.mouse_reporting.unwrap_or(true);
-        let keyboard_enhancement = hints.keyboard_enhancement.unwrap_or(true);
-
+        let probe_for_enhanced_keyboard = hints.probe_for_enhanced_keyboard;
         let force_terminfo_render_to_use_ansi_sgr =
             hints.force_terminfo_render_to_use_ansi_sgr.unwrap_or(false);
 
@@ -314,7 +311,7 @@ impl Capabilities {
             bracketed_paste,
             mouse_reporting,
             force_terminfo_render_to_use_ansi_sgr,
-            keyboard_enhancement,
+            probe_for_enhanced_keyboard,
         })
     }
 
@@ -369,8 +366,8 @@ impl Capabilities {
 
     /// Whether to request that the terminal enable Kitty enhanced
     /// keyboard protocol, if supported
-    pub fn keyboard_enhancement(&self) -> bool {
-        self.keyboard_enhancement
+    pub fn probe_for_enhanced_keyboard(&self) -> bool {
+        self.probe_for_enhanced_keyboard
     }
 }
 

--- a/termwiz/src/caps/probed.rs
+++ b/termwiz/src/caps/probed.rs
@@ -1,4 +1,6 @@
-use crate::escape::csi::{Device, Window};
+use wezterm_input_types::KittyKeyboardFlags;
+
+use crate::escape::csi::{Device, Keyboard, Window};
 use crate::escape::parser::Parser;
 use crate::escape::{Action, DeviceControlMode, Esc, EscCode, CSI};
 use crate::terminal::ScreenSize;
@@ -82,6 +84,36 @@ impl<'a> ProbeCapabilities<'a> {
     /// of its outer terminal.
     pub fn outer_xt_version(&mut self) -> Result<XtVersion> {
         self.xt_version_impl(true)
+    }
+
+    /// Query the state of Kitty enhanced keyboard protocol for the terminal.
+    /// Returns `None` if the terminal does not support keyboard enhancement.
+    pub fn enhanced_keyboard_state(&mut self) -> Result<Option<KittyKeyboardFlags>> {
+        let query_support = CSI::Keyboard(Keyboard::QueryKittySupport);
+        let dev_attributes = CSI::Device(Box::new(Device::RequestPrimaryDeviceAttributes));
+
+        write!(self.write, "{}{}", query_support, dev_attributes)?;
+        self.write.flush()?;
+
+        let mut result = None;
+        let mut parser = Parser::new();
+        let mut done = false;
+
+        while !done {
+            let mut byte = [0u8];
+            self.read.read(&mut byte)?;
+
+            parser.parse(&byte, |action| match action {
+                Action::CSI(CSI::Keyboard(Keyboard::ReportKittyState(state))) => {
+                    result = Some(state);
+                }
+                _ => {
+                    done = true;
+                }
+            });
+        }
+
+        Ok(result)
     }
 
     fn xt_version_impl(&mut self, tmux_escape: bool) -> Result<XtVersion> {

--- a/termwiz/src/caps/probed.rs
+++ b/termwiz/src/caps/probed.rs
@@ -63,12 +63,12 @@ mod test {
 /// of the associated Terminal instance.
 /// It will write and read data to and from the associated Terminal.
 pub struct ProbeCapabilities<'a> {
-    read: Box<&'a mut dyn Read>,
-    write: Box<&'a mut dyn Write>,
+    read: Box<dyn Read + 'a>,
+    write: Box<dyn Write + 'a>,
 }
 
 impl<'a> ProbeCapabilities<'a> {
-    pub fn new<R: Read, W: Write>(read: &'a mut R, write: &'a mut W) -> Self {
+    pub fn new<R: Read + 'a, W: Write + 'a>(read: R, write: W) -> Self {
         Self {
             read: Box::new(read),
             write: Box::new(write),

--- a/termwiz/src/escape/csi.rs
+++ b/termwiz/src/escape/csi.rs
@@ -690,6 +690,25 @@ impl XtermKeyModifierResource {
     }
 }
 
+/// See https://invisible-island.net/xterm/manpage/xterm.html#VT100-Widget-Resources:modifyOtherKeys
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum XtermModifyOtherKeys {
+    Disabled,
+    Partial,
+    Enabled,
+}
+
+impl XtermModifyOtherKeys {
+    pub fn parse(value: i64) -> Option<Self> {
+        Some(match value {
+            0 => XtermModifyOtherKeys::Disabled,
+            1 => XtermModifyOtherKeys::Partial,
+            2 => XtermModifyOtherKeys::Enabled,
+            _ => return None,
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Mode {
     SetDecPrivateMode(DecPrivateMode),

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -901,7 +901,10 @@ mod test {
             unimplemented!();
         }
 
-        fn set_keyboard_encoding(&mut self, _encoding: crate::input::KeyboardEncoding) -> Result<()> {
+        fn set_keyboard_encoding(
+            &mut self,
+            _encoding: crate::input::KeyboardEncoding,
+        ) -> Result<()> {
             bail!("not implemented");
         }
     }

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -900,6 +900,10 @@ mod test {
         fn waker(&self) -> TerminalWaker {
             unimplemented!();
         }
+
+        fn set_keyboard_encoding(&mut self, _encoding: crate::input::KeyboardEncoding) -> Result<()> {
+            bail!("not implemented");
+        }
     }
 
     #[test]

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -900,13 +900,6 @@ mod test {
         fn waker(&self) -> TerminalWaker {
             unimplemented!();
         }
-
-        fn set_keyboard_encoding(
-            &mut self,
-            _encoding: crate::input::KeyboardEncoding,
-        ) -> Result<()> {
-            bail!("not implemented");
-        }
     }
 
     #[test]

--- a/termwiz/src/terminal/mod.rs
+++ b/termwiz/src/terminal/mod.rs
@@ -4,7 +4,7 @@ use crate::caps::probed::ProbeCapabilities;
 use crate::caps::Capabilities;
 use crate::input::{InputEvent, KeyboardEncoding};
 use crate::surface::Change;
-use crate::{format_err, Result};
+use crate::{bail, format_err, Result};
 use num_traits::NumCast;
 use std::fmt::Display;
 use std::time::Duration;
@@ -100,7 +100,10 @@ pub trait Terminal {
 
     fn waker(&self) -> TerminalWaker;
 
-    fn set_keyboard_encoding(&mut self, encoding: KeyboardEncoding) -> Result<()>;
+    /// Set a new keyboard encoding for the terminal.
+    fn set_keyboard_encoding(&mut self, _encoding: KeyboardEncoding) -> Result<()> {
+        bail!("terminal does't support setting keyboard encodings");
+    }
 }
 
 /// `SystemTerminal` is a concrete implementation of `Terminal`.

--- a/termwiz/src/terminal/mod.rs
+++ b/termwiz/src/terminal/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::caps::probed::ProbeCapabilities;
 use crate::caps::Capabilities;
-use crate::input::InputEvent;
+use crate::input::{InputEvent, KeyboardEncoding};
 use crate::surface::Change;
 use crate::{format_err, Result};
 use num_traits::NumCast;
@@ -99,6 +99,8 @@ pub trait Terminal {
     fn poll_input(&mut self, wait: Option<Duration>) -> Result<Option<InputEvent>>;
 
     fn waker(&self) -> TerminalWaker;
+
+    fn set_keyboard_encoding(&mut self, encoding: KeyboardEncoding) -> Result<()>;
 }
 
 /// `SystemTerminal` is a concrete implementation of `Terminal`.

--- a/termwiz/src/terminal/windows.rs
+++ b/termwiz/src/terminal/windows.rs
@@ -861,7 +861,9 @@ impl Terminal for WindowsTerminal {
     fn set_keyboard_encoding(&mut self, encoding: KeyboardEncoding) -> Result<()> {
         match encoding {
             KeyboardEncoding::Win32 => Ok(()),
-            _ => Err(anyhow::anyhow!("Unsupported keyboard encoding for terminal"))?
+            _ => Err(anyhow::anyhow!(
+                "Unsupported keyboard encoding for terminal"
+            ))?,
         }
     }
 }

--- a/termwiz/src/terminal/windows.rs
+++ b/termwiz/src/terminal/windows.rs
@@ -862,7 +862,7 @@ impl Terminal for WindowsTerminal {
         match encoding {
             KeyboardEncoding::Win32 => Ok(()),
             _ => Err(anyhow::anyhow!(
-                "Unsupported keyboard encoding for terminal"
+                "Unsupported keyboard encoding {encoding:?} for Windows terminal"
             ))?,
         }
     }

--- a/termwiz/src/terminal/windows.rs
+++ b/termwiz/src/terminal/windows.rs
@@ -27,7 +27,7 @@ use winapi::um::wincon::{
 use winapi::um::winnls::CP_UTF8;
 
 use crate::caps::Capabilities;
-use crate::input::{InputEvent, InputParser};
+use crate::input::{InputEvent, InputParser, KeyboardEncoding};
 use crate::render::terminfo::TerminfoRenderer;
 use crate::render::windows::WindowsConsoleRenderer;
 use crate::render::RenderTty;
@@ -855,6 +855,13 @@ impl Terminal for WindowsTerminal {
     fn waker(&self) -> WindowsTerminalWaker {
         WindowsTerminalWaker {
             handle: self.waker_handle.clone(),
+        }
+    }
+
+    fn set_keyboard_encoding(&mut self, encoding: KeyboardEncoding) -> Result<()> {
+        match encoding {
+            KeyboardEncoding::Win32 => Ok(()),
+            _ => Err(anyhow::anyhow!("Unsupported keyboard encoding for terminal"))?
         }
     }
 }

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -499,7 +499,6 @@ impl ImgCatCommand {
 
         let caps = Capabilities::new_from_env()?;
         let mut term = termwiz::terminal::new_terminal(caps)?;
-        term.set_raw_mode()?;
 
         let mut probe = term
             .probe_capabilities()
@@ -510,6 +509,8 @@ impl ImgCatCommand {
         let term_size = probe.screen_size()?;
 
         let is_tmux = xt_version.is_tmux();
+
+        drop(probe);
 
         // TODO: ideally we'd do some kind of probing to see if conpty
         // is in the mix. For now we just assume that if we are on windows
@@ -524,8 +525,6 @@ impl ImgCatCommand {
         let needs_force_cursor_move = !self.no_move_cursor && !self.position.is_some() && (is_tmux || is_conpty)
             // We can only use forced movement if we know the pixel geometry
             && (term_size.xpixel != 0 && term_size.ypixel != 0);
-
-        term.set_cooked_mode()?;
 
         let save_cursor = Esc::Code(EscCode::DecSaveCursorPosition);
         let restore_cursor = Esc::Code(EscCode::DecRestoreCursorPosition);


### PR DESCRIPTION
`Terminal` now enables [enhanced keyboard reporting](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) (on `set_raw_mode()`) if it is supported and enabled in capabilities. It also pops the state on `drop`.

See #4928 .


* Add `keyboard_enhancement` field to `ProbeHints` and `Capabilities`.
* Add `enhanced_keyboard_state` method to `ProbeCapabilities`.

Some questions / considerations before merging: 
- Should we keep it enabled by default? Can it break existing apps?
- Should `Capabilities` be responsible for probing instead of `Terminal`?
