### PR TITLE
Fix kitty image leaving behind images after removing image placements

### DIFF
--- a/term/src/terminalstate/kitty.rs
+++ b/term/src/terminalstate/kitty.rs
@@ -101,7 +101,11 @@ impl TerminalState {
             verbosity
         );
         if image_id != 0 {
-            self.kitty_remove_placement(image_id, placement.placement_id);
+            if let Some(place_id) = placement.placement_id {
+                if place_id != 0 {
+                    self.kitty_remove_placement(image_id, placement.placement_id);
+                }
+            }
         }
         let img = Arc::clone(self.kitty_img.id_to_data.get(&image_id).ok_or_else(|| {
             anyhow::anyhow!(

--- a/term/src/terminalstate/kitty.rs
+++ b/term/src/terminalstate/kitty.rs
@@ -301,9 +301,7 @@ impl TerminalState {
     ) {
         let seqno = self.seqno;
         let screen = self.screen_mut();
-        let range =
-            screen.stable_range(&(info.first_row..info.first_row + info.rows as StableRowIndex));
-        for idx in range {
+        for idx in 0..screen.scrollback_rows() {
             let line = screen.line_mut(idx);
             for c in line.cells_mut() {
                 c.attrs_mut()


### PR DESCRIPTION
[DRAFT] This PR is not intended to be merged right now.

This should fix https://github.com/wez/wezterm/issues/2422, but the fix in commit 319a5376e3d09587520f2550a9ca6e7e8655472c will have serious performance issues for cases with big scrollbacks and lots of image updates. The "fix" is to ignore `PlacementInfo` (that might be stale) and go through all the scrollback removing the image.

The main issues seems to be that `StableRowIndex` can become stale whenever a window resizing changes the amount of columns enough so as to add more lines by wrapping other lines. After wrapping, the image will get displaced (this is in kitty's implementation does not happen), and so the `PlacementInfo` that is stored for that `image_id` and `placement_id` is no longer valid.

It seems to me that it would be a better approach to keep the original way of removing the images by their `PlacementInfo` (instead of going through all the scrollback), and prevent the images from being moved by lines being wrapped. The problem I see here is that this handling of the cell properties of those lines will need to be done wherever the lines are being wrapped and I'm not sure you'll be too happy about adding logic about images there (for being so unrelated).

Let me know if you have any ideas or thoughts about how we could address this.

## Minimal Reproduction
### Kitty(reference):
![kitty_resize](https://github.com/wez/wezterm/assets/31407988/6a3357f3-6126-4207-b8b3-6b1a88bbfc24)


### Wezterm(main):
![wezterm_resize](https://github.com/wez/wezterm/assets/31407988/15cf2f80-2ed9-4501-9e19-208a21150b3a)


### Wezterm(this PR):
![wezterm_fix_resize](https://github.com/wez/wezterm/assets/31407988/04e37666-7966-438a-bc80-acd86db97b57)


Another issue tangentially related to this is that images are not occluded when a new pane appears:
![image](https://github.com/wez/wezterm/assets/31407988/673ef33a-2a7d-42c7-a9fe-9871ba850648)
In this case there isn't a way to update displayed images when the geometry of the pane changes. A way to handle these geometry changes in general would also solve the resizing.
