### PR TITLE
Fix interaction between pane swapping / rotating and client domains.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,6 +3214,7 @@ dependencies = [
  "mux",
  "parking_lot 0.12.2",
  "portable-pty",
+ "promise",
  "smol",
  "termwiz",
  "termwiz-funcs",

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(feature = "cargo-clippy", allow(clippy::range_plus_one))]
 
 use anyhow::{bail, Context as _, Error};
-use config::keyassignment::{PaneDirection, ScrollbackEraseMode};
+use config::keyassignment::{PaneDirection, RotationDirection, ScrollbackEraseMode};
 use mux::client::{ClientId, ClientInfo};
 use mux::pane::PaneId;
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
@@ -493,7 +493,7 @@ pdu! {
     GetPaneRenderableDimensions: 51,
     GetPaneRenderableDimensionsResponse: 52,
     PaneFocused: 53,
-    TabResized: 54,
+    TabReflowed: 54,
     TabAddedToWindow: 55,
     TabTitleChanged: 56,
     WindowTitleChanged: 57,
@@ -502,6 +502,8 @@ pdu! {
     GetPaneDirection: 60,
     GetPaneDirectionResponse: 61,
     AdjustPaneSize: 62,
+    RotatePanes: 63,
+    SwapActivePaneWithIndex: 64,
 }
 
 impl Pdu {
@@ -803,7 +805,7 @@ pub struct TabAddedToWindow {
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
-pub struct TabResized {
+pub struct TabReflowed {
     pub tab_id: TabId,
 }
 
@@ -885,6 +887,19 @@ pub struct GetPaneDirectionResponse {
 pub struct ActivatePaneDirection {
     pub pane_id: PaneId,
     pub direction: PaneDirection,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct RotatePanes {
+    pub pane_id: PaneId,
+    pub direction: RotationDirection,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct SwapActivePaneWithIndex {
+    pub active_pane_id: PaneId,
+    pub with_pane_index: usize,
+    pub keep_focus: bool,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -641,7 +641,7 @@ impl Default for SplitSize {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, FromDynamic, ToDynamic)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, FromDynamic, ToDynamic)]
 pub enum RotationDirection {
     Clockwise,
     CounterClockwise,

--- a/lua-api-crates/mux/Cargo.toml
+++ b/lua-api-crates/mux/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 luahelper = { path = "../../luahelper" }
 parking_lot = "0.12"
 portable-pty = { path = "../../pty" }
+promise = { path = "../../promise" }
 smol = "2.0"
 termwiz = { path = "../../termwiz" }
 termwiz-funcs = { path = "../termwiz-funcs" }

--- a/lua-api-crates/mux/src/tab.rs
+++ b/lua-api-crates/mux/src/tab.rs
@@ -1,4 +1,4 @@
-use config::keyassignment::PaneDirection;
+use config::keyassignment::{PaneDirection, RotationDirection};
 
 use super::*;
 use luahelper::mlua::Value;
@@ -113,14 +113,34 @@ impl UserData for MuxTab {
         methods.add_method("rotate_counter_clockwise", |_, this, _: ()| {
             let mux = get_mux()?;
             let tab = this.resolve(&mux)?;
-            tab.rotate_counter_clockwise();
+
+            let tab_id = tab.tab_id();
+            let direction = RotationDirection::CounterClockwise;
+            promise::spawn::spawn(async move {
+                let mux = Mux::get();
+                if let Err(err) = mux.rotate_panes(tab_id, direction).await {
+                    log::error!("Unable to rotate panes: {:#}", err);
+                }
+            })
+            .detach();
+
             Ok(())
         });
 
         methods.add_method("rotate_clockwise", |_, this, _: ()| {
             let mux = get_mux()?;
             let tab = this.resolve(&mux)?;
-            tab.rotate_counter_clockwise();
+
+            let tab_id = tab.tab_id();
+            let direction = RotationDirection::CounterClockwise;
+            promise::spawn::spawn(async move {
+                let mux = Mux::get();
+                if let Err(err) = mux.rotate_panes(tab_id, direction).await {
+                    log::error!("Unable to rotate panes: {:#}", err);
+                }
+            })
+            .detach();
+
             Ok(())
         });
 

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -581,12 +581,12 @@ impl Tab {
         self.inner.lock().iter_panes_ignoring_zoom()
     }
 
-    pub fn rotate_counter_clockwise(&self) {
-        self.inner.lock().rotate_counter_clockwise()
+    pub fn local_rotate_counter_clockwise(&self) {
+        self.inner.lock().local_rotate_counter_clockwise()
     }
 
-    pub fn rotate_clockwise(&self) {
-        self.inner.lock().rotate_clockwise()
+    pub fn local_rotate_clockwise(&self) {
+        self.inner.lock().local_rotate_clockwise()
     }
 
     pub fn iter_splits(&self) -> Vec<PositionedSplit> {
@@ -714,10 +714,10 @@ impl Tab {
     }
 
     /// Swap the active pane with the specified pane_index
-    pub fn swap_active_with_index(&self, pane_index: usize, keep_focus: bool) -> Option<()> {
+    pub fn local_swap_active_with_index(&self, pane_index: usize, keep_focus: bool) -> Option<()> {
         self.inner
             .lock()
-            .swap_active_with_index(pane_index, keep_focus)
+            .local_swap_active_with_index(pane_index, keep_focus)
     }
 
     /// Computes the size of the pane that would result if the specified
@@ -908,7 +908,7 @@ impl TabInner {
                 self.zoomed.replace(pane);
             }
         }
-        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabResized(self.id)));
+        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabReflowed(self.id)));
     }
 
     fn contains_pane(&self, pane: PaneId) -> bool {
@@ -937,7 +937,7 @@ impl TabInner {
         self.iter_panes_impl(false)
     }
 
-    fn rotate_counter_clockwise(&mut self) {
+    fn local_rotate_counter_clockwise(&mut self) {
         let panes = self.iter_panes_ignoring_zoom();
         if panes.is_empty() {
             // Shouldn't happen, but we check for this here so that the
@@ -966,9 +966,10 @@ impl TabInner {
                 }
             }
         }
+        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabReflowed(self.id)));
     }
 
-    fn rotate_clockwise(&mut self) {
+    fn local_rotate_clockwise(&mut self) {
         let panes = self.iter_panes_ignoring_zoom();
         if panes.is_empty() {
             // Shouldn't happen, but we check for this here so that the
@@ -997,7 +998,7 @@ impl TabInner {
                 }
             }
         }
-        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabResized(self.id)));
+        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabReflowed(self.id)));
     }
 
     fn iter_panes_impl(&mut self, respect_zoom_state: bool) -> Vec<PositionedPane> {
@@ -1179,7 +1180,7 @@ impl TabInner {
             apply_sizes_from_splits(self.pane.as_mut().unwrap(), &size);
         }
 
-        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabResized(self.id)));
+        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabReflowed(self.id)));
     }
 
     fn apply_pane_size(&mut self, pane_size: TerminalSize, cursor: &mut Cursor) {
@@ -1255,7 +1256,7 @@ impl TabInner {
                 self.size = size;
             }
         }
-        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabResized(self.id)));
+        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabReflowed(self.id)));
     }
 
     fn resize_split_by(&mut self, split_index: usize, delta: isize) {
@@ -1288,7 +1289,7 @@ impl TabInner {
         // Now cursor is looking at the split
         self.adjust_node_at_cursor(&mut cursor, delta);
         self.cascade_size_from_cursor(cursor);
-        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabResized(self.id)));
+        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabReflowed(self.id)));
     }
 
     fn adjust_node_at_cursor(&mut self, cursor: &mut Cursor, delta: isize) {
@@ -1371,7 +1372,7 @@ impl TabInner {
                 }
             }
         }
-        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabResized(self.id)));
+        Mux::try_get().map(|mux| mux.notify(MuxNotification::TabReflowed(self.id)));
     }
 
     fn adjust_pane_size(&mut self, direction: PaneDirection, amount: usize) {
@@ -1807,7 +1808,7 @@ impl TabInner {
         cell_dimensions(&self.size)
     }
 
-    fn swap_active_with_index(&mut self, pane_index: usize, keep_focus: bool) -> Option<()> {
+    fn local_swap_active_with_index(&mut self, pane_index: usize, keep_focus: bool) -> Option<()> {
         let active_idx = self.get_active_idx();
         let mut pane = self.get_active_pane()?;
         log::trace!(

--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -297,7 +297,7 @@ fn process_unilateral(
             .detach();
             return Ok(());
         }
-        Pdu::TabResized(_) | Pdu::TabAddedToWindow(_) => {
+        Pdu::TabReflowed(_) | Pdu::TabAddedToWindow(_) => {
             log::trace!("resync due to {:?}", decoded.pdu);
             promise::spawn::spawn_into_main_thread(async move {
                 let mux = Mux::try_get().ok_or_else(|| anyhow!("no more mux"))?;
@@ -1354,6 +1354,12 @@ impl Client {
     rpc!(resize, Resize, UnitResponse);
     rpc!(set_zoomed, SetPaneZoomed, UnitResponse);
     rpc!(activate_pane_direction, ActivatePaneDirection, UnitResponse);
+    rpc!(
+        swap_active_pane_with_index,
+        SwapActivePaneWithIndex,
+        UnitResponse
+    );
+    rpc!(rotate_panes, RotatePanes, UnitResponse);
     rpc!(
         get_pane_render_changes,
         GetPaneRenderChanges,

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -88,7 +88,7 @@ impl GuiFrontEnd {
                 }
                 MuxNotification::TabTitleChanged { .. } => {}
                 MuxNotification::WindowTitleChanged { .. } => {}
-                MuxNotification::TabResized(_) => {}
+                MuxNotification::TabReflowed(_) => {}
                 MuxNotification::TabAddedToWindow { .. } => {}
                 MuxNotification::PaneRemoved(_) => {}
                 MuxNotification::WindowInvalidated(_) => {}

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -30,8 +30,8 @@ use ::wezterm_term::input::{ClickPosition, MouseButton as TMB};
 use ::window::*;
 use anyhow::{anyhow, ensure, Context};
 use config::keyassignment::{
-    KeyAssignment, PaneDirection, Pattern, PromptInputLine, QuickSelectArguments,
-    RotationDirection, SpawnCommand, SplitSize,
+    KeyAssignment, PaneDirection, Pattern, PromptInputLine, QuickSelectArguments, SpawnCommand,
+    SplitSize,
 };
 use config::window::WindowLevel;
 use config::{
@@ -1292,7 +1292,7 @@ impl TermWindow {
                     // Also handled by clientpane
                     self.update_title_post_status();
                 }
-                MuxNotification::TabResized(_) => {
+                MuxNotification::TabReflowed(_) => {
                     // Also handled by wezterm-client
                     self.update_title_post_status();
                 }
@@ -1489,7 +1489,7 @@ impl TermWindow {
                     return true;
                 }
             }
-            MuxNotification::TabResized(tab_id)
+            MuxNotification::TabReflowed(tab_id)
             | MuxNotification::TabTitleChanged { tab_id, .. } => {
                 let mux = Mux::get();
                 if mux.window_containing_tab(tab_id) == Some(mux_window_id) {
@@ -3013,10 +3013,15 @@ impl TermWindow {
                     Some(tab) => tab,
                     None => return Ok(PerformAssignmentResult::Handled),
                 };
-                match direction {
-                    RotationDirection::Clockwise => tab.rotate_clockwise(),
-                    RotationDirection::CounterClockwise => tab.rotate_counter_clockwise(),
-                }
+                let tab_id = tab.tab_id();
+                let direction = *direction;
+                promise::spawn::spawn(async move {
+                    let mux = Mux::get();
+                    if let Err(err) = mux.rotate_panes(tab_id, direction).await {
+                        log::error!("Unable to rotate panes: {:#}", err);
+                    }
+                })
+                .detach()
             }
             SplitPane(split) => {
                 log::trace!("SplitPane {:?}", split);

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -172,8 +172,8 @@ where
                     .await?;
                 stream.flush().await.context("flushing PDU to client")?;
             }
-            Ok(Item::Notif(MuxNotification::TabResized(tab_id))) => {
-                Pdu::TabResized(codec::TabResized { tab_id })
+            Ok(Item::Notif(MuxNotification::TabReflowed(tab_id))) => {
+                Pdu::TabReflowed(codec::TabReflowed { tab_id })
                     .encode_async(&mut stream, 0)
                     .await?;
                 stream.flush().await.context("flushing PDU to client")?;

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -1,6 +1,7 @@
 use crate::PKI;
 use anyhow::{anyhow, Context};
 use codec::*;
+use config::keyassignment::RotationDirection;
 use config::TermConfig;
 use mux::client::ClientId;
 use mux::domain::SplitSource;
@@ -629,6 +630,57 @@ impl SessionHandler {
                 .detach();
             }
 
+            Pdu::SwapActivePaneWithIndex(SwapActivePaneWithIndex {
+                active_pane_id,
+                with_pane_index,
+                keep_focus,
+            }) => {
+                spawn_into_main_thread(async move {
+                    catch(
+                        move || {
+                            let mux = Mux::get();
+                            let (_domain_id, _window_id, tab_id) = mux
+                                .resolve_pane_id(active_pane_id)
+                                .ok_or_else(|| anyhow!("no such pane {}", active_pane_id))?;
+                            let tab = mux
+                                .get_tab(tab_id)
+                                .ok_or_else(|| anyhow!("no such tab {}", tab_id))?;
+                            tab.local_swap_active_with_index(with_pane_index, keep_focus);
+                            Ok(Pdu::UnitResponse(UnitResponse {}))
+                        },
+                        send_response,
+                    )
+                })
+                .detach();
+            }
+
+            Pdu::RotatePanes(RotatePanes { pane_id, direction }) => {
+                spawn_into_main_thread(async move {
+                    catch(
+                        move || {
+                            let mux = Mux::get();
+                            let (_domain_id, _window_id, tab_id) = mux
+                                .resolve_pane_id(pane_id)
+                                .ok_or_else(|| anyhow!("no such pane {}", pane_id))?;
+                            let tab = mux
+                                .get_tab(tab_id)
+                                .ok_or_else(|| anyhow!("no such tab {}", tab_id))?;
+
+                            match direction {
+                                RotationDirection::Clockwise => tab.local_rotate_clockwise(),
+                                RotationDirection::CounterClockwise => {
+                                    tab.local_rotate_counter_clockwise()
+                                }
+                            };
+
+                            Ok(Pdu::UnitResponse(UnitResponse {}))
+                        },
+                        send_response,
+                    )
+                })
+                .detach();
+            }
+
             Pdu::Resize(Resize {
                 containing_tab_id,
                 pane_id,
@@ -1004,7 +1056,7 @@ impl SessionHandler {
             | Pdu::GetClientListResponse { .. }
             | Pdu::PaneRemoved { .. }
             | Pdu::PaneFocused { .. }
-            | Pdu::TabResized { .. }
+            | Pdu::TabReflowed { .. }
             | Pdu::GetImageCellResponse { .. }
             | Pdu::MovePaneToNewTabResponse { .. }
             | Pdu::TabAddedToWindow { .. }


### PR DESCRIPTION
This should address #4200.

Currently pane swapping and rotation only works correctly on local domains since none of the state is propagated to the remote mux server.

This patch adds a couple of RPCs for rotating panes and for swapping an active pane with the pane at a given index. Additionally, it renames the corresponding methods on the `mux::tab` module, prefixing them with `local_`, adds `remote_` versions of them to Domains and adds a convenience method on `mux`, mirroring the pattern used for `move_pane_to_new_tab`, which dispatches to the relevant method.

This incidentally fixes a typo in the Lua API which was previously always rotating panes in a single direction.