### PR TITLE
fix: skip FreshLine by semantic integration in ble.sh

### DIFF
--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -481,7 +481,14 @@ __wezterm_semantic_precmd() {
     printf "\033]133;D;%s;aid=%s\007" "$ret" "$$"
   fi
   # Fresh line and start the prompt
-  printf "\033]133;A;cl=m;aid=%s\007" "$$"
+  if [[ -n "${BLE_VERSION-}" ]]; then
+    # FreshLine breaks ble.sh's cursor position tracking.  Also, the cursor
+    # position adjustment is already performed ble.sh so unnecessary here.  We
+    # here only perform StartPrompt.
+    printf "\033]133;P\007"
+  else
+    printf "\033]133;A;cl=m;aid=%s\007" "$$"
+  fi
   __wezterm_semantic_precmd_executing=0
 }
 


### PR DESCRIPTION
A problem was originally reported in https://github.com/akinomyoga/ble.sh/issues/413. `ble.sh` (a line editor for Bash) keeps track of the cursor position in the terminal display (including the horizontal position relative to the bottom of the terminal) based on the terminal control sequences that it sends.

However, with WezTerm's semantic integration, WezTerm may insert a newline in `precmd` (FreshLine), which breaks the cursor position tracking of `ble.sh`.  The needed cursor position adjustment at the end of the command execution is already performed by `ble.sh`, so WezTerm does not need to adjust it.  In this patch, we skip the request for FreshLine in `ble.sh`.

But I'm not sure if this is the correct fix. The original sequence <kbd>OSC A</kbd> seems to perform FreshLine and StartPrompt. To only perform StartPrompt,  one seems to be able to use the sequence <kbd>OSC P ... BEL</kbd>. Although <kbd>OSC P</kbd> seems to receive a parameter `k=?`, it doesn't seem to be used in the codebase, so I just omitted the parameter `k`. Could you take a look at this?

Note: As an alternative option, we can specify the ble.sh option `bleopt prompt_command_changes_layout=1` to notify that `precmd`/`PROMPT_COMMAND` can change the cursor position (in particular horizontal position), but this adds unneeded flickering of the rendered contents. Because we can just suppress FreshLine this time, I didn't use this approach.
