### PR TITLE
Decorations rework

### DIFF
--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -81,7 +81,7 @@ xcb-imdkit = { version="0.3", git="https://github.com/wez/xcb-imdkit-rs.git", re
 zbus = "3.14"
 zvariant = "3.15"
 
-smithay-client-toolkit = {version = "0.18", default-features=false, optional=true}
+smithay-client-toolkit = {version = "0.18.1", default-features=false, optional=true}
 wayland-protocols = {version="0.31", optional=true}
 wayland-client = {version="0.31", optional=true}
 wayland-egl = {version="0.32", optional=true}

--- a/window/src/os/wayland/pointer.rs
+++ b/window/src/os/wayland/pointer.rs
@@ -219,45 +219,52 @@ impl WaylandState {
                 let wid = SurfaceUserData::from_wl(parent_surface).window_id;
                 let mut inner = windows.get(&wid).unwrap().borrow_mut();
 
-                match evt.kind {
-                    PointerEventKind::Enter { .. } => {
-                        inner.window_frame.click_point_moved(
-                            Duration::ZERO,
-                            &evt.surface.id(),
-                            x,
-                            y,
-                        );
-                    }
-                    PointerEventKind::Leave { .. } => {
-                        inner.window_frame.click_point_left();
-                    }
-                    PointerEventKind::Motion { .. } => {
-                        inner.window_frame.click_point_moved(
-                            Duration::ZERO,
-                            &evt.surface.id(),
-                            x,
-                            y,
-                        );
-                    }
-                    PointerEventKind::Press { button, serial, .. }
-                    | PointerEventKind::Release { button, serial, .. } => {
-                        let pressed = if matches!(evt.kind, PointerEventKind::Press { .. }) {
-                            true
-                        } else {
-                            false
-                        };
-                        let click = match button {
-                            0x110 => FrameClick::Normal,
-                            0x111 => FrameClick::Alternate,
-                            _ => continue,
-                        };
-                        if let Some(action) =
-                            inner.window_frame.on_click(Duration::ZERO, click, pressed)
-                        {
-                            inner.frame_action(pointer, serial, action);
+                if let Some(frame) = inner.decorations.as_mut() {
+                    match evt.kind {
+                        PointerEventKind::Enter { .. } => {
+                            frame.click_point_moved(Duration::ZERO, &evt.surface.id(), x, y);
                         }
+                        PointerEventKind::Leave { .. } => {
+                            frame.click_point_left();
+                        }
+                        PointerEventKind::Motion { time, .. } => {
+                            frame.click_point_moved(
+                                Duration::from_millis(time as u64),
+                                &evt.surface.id(),
+                                x,
+                                y,
+                            );
+                        }
+                        PointerEventKind::Press {
+                            button,
+                            serial,
+                            time,
+                            ..
+                        }
+                        | PointerEventKind::Release {
+                            button,
+                            serial,
+                            time,
+                            ..
+                        } => {
+                            let pressed = if matches!(evt.kind, PointerEventKind::Press { .. }) {
+                                true
+                            } else {
+                                false
+                            };
+                            let click = match button {
+                                0x110 => FrameClick::Normal,
+                                0x111 => FrameClick::Alternate,
+                                _ => continue,
+                            };
+                            if let Some(action) =
+                                frame.on_click(Duration::from_millis(time as u64), click, pressed)
+                            {
+                                inner.frame_action(pointer, serial, action);
+                            }
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }


### PR DESCRIPTION
This avoids creating the fallback frame if server-side decorations are used, and I think might improve some things, maybe if CSD is used?

However, it is still kind of buggy, although I suspect some of that is due to using the fallback CSD. 

Since I don't use CSD, I'm not super motivated to continue working on this, but figured I'd put it up here if someone wants to take it over, or use it as a starting point.