### PR TITLE
feat: Identify modifiers on Wayland/X11 (new)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6752,6 +6752,7 @@ dependencies = [
  "promise",
  "raw-window-handle",
  "resize",
+ "scopeguard",
  "serde",
  "shared_library",
  "shlex",

--- a/termwiz/src/escape/csi.rs
+++ b/termwiz/src/escape/csi.rs
@@ -46,7 +46,7 @@ fn csi_size() {
     assert_eq!(std::mem::size_of::<Cursor>(), 12);
     assert_eq!(std::mem::size_of::<Edit>(), 8);
     assert_eq!(std::mem::size_of::<Mode>(), 24);
-    assert_eq!(std::mem::size_of::<MouseReport>(), 8);
+    assert_eq!(std::mem::size_of::<MouseReport>(), 12);
     assert_eq!(std::mem::size_of::<Window>(), 40);
     assert_eq!(std::mem::size_of::<Keyboard>(), 8);
     assert_eq!(std::mem::size_of::<CSI>(), 32);

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -482,19 +482,18 @@ bitflags! {
     #[dynamic(into="String", try_from="String")]
     pub struct Modifiers: u32 {
         const NONE = 0;
-
         const SHIFT = 1<<1;
-        const LEFT_SHIFT = 1<<10;
-        const RIGHT_SHIFT = 1<<11;
         const ALT = 1<<2;
+        const CTRL = 1<<3;
+        const SUPER = 1<<4;
         const LEFT_ALT = 1<<5;
         const RIGHT_ALT = 1<<6;
-        const CTRL = 1<<3;
-        const LEFT_CTRL = 1<<8;
-        const RIGHT_CTRL = 1<<9;
-        const SUPER = 1<<4;
         /// This is a virtual modifier used by wezterm
         const LEADER = 1<<7;
+        const LEFT_CTRL = 1<<8;
+        const RIGHT_CTRL = 1<<9;
+        const LEFT_SHIFT = 1<<10;
+        const RIGHT_SHIFT = 1<<11;
         const ENHANCED_KEY = 1<<12;
 
         const META = 1<<13;

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -480,21 +480,27 @@ bitflags! {
     #[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
     #[derive(Default, FromDynamic, ToDynamic)]
     #[dynamic(into="String", try_from="String")]
-    pub struct Modifiers: u16 {
+    pub struct Modifiers: u32 {
         const NONE = 0;
+
         const SHIFT = 1<<1;
-        const ALT = 1<<2;
-        const CTRL = 1<<3;
-        const SUPER = 1<<4;
-        const LEFT_ALT = 1<<5;
-        const RIGHT_ALT = 1<<6;
-        /// This is a virtual modifier used by wezterm
-        const LEADER = 1<<7;
-        const LEFT_CTRL = 1<<8;
-        const RIGHT_CTRL = 1<<9;
         const LEFT_SHIFT = 1<<10;
         const RIGHT_SHIFT = 1<<11;
+        const ALT = 1<<2;
+        const LEFT_ALT = 1<<5;
+        const RIGHT_ALT = 1<<6;
+        const CTRL = 1<<3;
+        const LEFT_CTRL = 1<<8;
+        const RIGHT_CTRL = 1<<9;
+        const SUPER = 1<<4;
+        /// This is a virtual modifier used by wezterm
+        const LEADER = 1<<7;
         const ENHANCED_KEY = 1<<12;
+
+        const META = 1<<13;
+        const HYPER = 1<<14;
+        const CAPS_LOCK = 1<<15;
+        const NUM_LOCK = 1<<16;
     }
 }
 
@@ -1674,13 +1680,16 @@ impl KeyEvent {
         if raw_modifiers.contains(Modifiers::SUPER) {
             modifiers |= 8;
         }
-        // TODO: Hyper and Meta are not handled yet.
-        // We should somehow detect this?
-        // See: https://github.com/wez/wezterm/pull/4605#issuecomment-1823604708
-        if self.leds.contains(KeyboardLedStatus::CAPS_LOCK) {
+        if raw_modifiers.contains(Modifiers::HYPER) {
+            modifiers |= 16;
+        }
+        if raw_modifiers.contains(Modifiers::META) {
+            modifiers |= 32;
+        }
+        if raw_modifiers.contains(Modifiers::CAPS_LOCK) {
             modifiers |= 64;
         }
-        if self.leds.contains(KeyboardLedStatus::NUM_LOCK) {
+        if raw_modifiers.contains(Modifiers::NUM_LOCK) {
             modifiers |= 128;
         }
         modifiers += 1;

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -46,6 +46,7 @@ wezterm-bidi = { path = "../bidi" }
 wezterm-color-types = { path = "../color-types" }
 wezterm-font = { path = "../wezterm-font" }
 wezterm-input-types = { path = "../wezterm-input-types" }
+scopeguard = "1.2.0"
 
 [target."cfg(windows)".dependencies]
 clipboard-win = "2.2"

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1754,6 +1754,9 @@ fn key_modifiers(flags: NSEventModifierFlags) -> Modifiers {
     if flags.contains(NSEventModifierFlags::NSCommandKeyMask) {
         mods |= Modifiers::SUPER;
     }
+    if flags.contains(NSEventModifierFlags::NSAlphaShiftKeyMask) {
+        mods |= Modifiers::CAPS_LOCK;
+    }
 
     mods
 }

--- a/window/src/os/wayland/connection.rs
+++ b/window/src/os/wayland/connection.rs
@@ -1,3 +1,18 @@
+#![allow(dead_code)]
+use super::pointer::*;
+use super::window::*;
+use crate::connection::ConnectionOps;
+use crate::os::wayland::inputhandler::InputHandler;
+use crate::os::wayland::output::OutputHandler;
+use crate::os::x11::keyboard::KeyboardWithFallback;
+use crate::screen::{ScreenInfo, Screens};
+use crate::spawn::*;
+use crate::x11::ModifierInit;
+use crate::{Appearance, Connection, ScreenRect, WindowEvent};
+use anyhow::{bail, Context};
+use mio::unix::SourceFd;
+use mio::{Events, Interest, Poll, Token};
+use smithay_client_toolkit as toolkit;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::os::fd::AsRawFd;
@@ -120,7 +135,7 @@ impl WaylandConnection {
                             data.pop();
                         }
                         let s = String::from_utf8(data)?;
-                        match KeyboardWithFallback::new_from_string(s, true) {
+                        match KeyboardWithFallback::new_from_string(s, ModifierInit::Wayland) {
                             Ok(k) => {
                                 self.keyboard_mapper.replace(Some(k));
                             }

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2592,9 +2592,11 @@ unsafe fn key(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<L
 
     let mut leds = KeyboardLedStatus::empty();
     if keys[VK_CAPITAL as usize] & 1 != 0 {
+        modifiers |= Modifiers::CAPS_LOCK;
         leds |= KeyboardLedStatus::CAPS_LOCK;
     }
     if keys[VK_NUMLOCK as usize] & 1 != 0 {
+        modifiers |= Modifiers::NUM_LOCK;
         leds |= KeyboardLedStatus::NUM_LOCK;
     }
 

--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -712,8 +712,8 @@ impl XConnection {
             visual.green_mask(),
             visual.blue_mask()
         );
-        let (keyboard, kbd_ev) = Keyboard::new(&conn, ModifierInit::X11)?;
-        let keyboard = KeyboardWithFallback::new(keyboard, ModifierInit::X11)?;
+        let (keyboard, kbd_ev) = Keyboard::new(&conn, ModifierInit::X11(&conn))?;
+        let keyboard = KeyboardWithFallback::new(keyboard, ModifierInit::X11(&conn))?;
 
         let cursor_font_id = conn.generate_id();
         let cursor_font_name = "cursor";

--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -712,8 +712,8 @@ impl XConnection {
             visual.green_mask(),
             visual.blue_mask()
         );
-        let (keyboard, kbd_ev) = Keyboard::new(&conn)?;
-        let keyboard = KeyboardWithFallback::new(keyboard)?;
+        let (keyboard, kbd_ev) = Keyboard::new(&conn, false)?;
+        let keyboard = KeyboardWithFallback::new(keyboard, false)?;
 
         let cursor_font_id = conn.generate_id();
         let cursor_font_name = "cursor";

--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -1,4 +1,4 @@
-use super::keyboard::{Keyboard, KeyboardWithFallback};
+use super::keyboard::{Keyboard, KeyboardWithFallback, ModifierInit};
 use crate::connection::ConnectionOps;
 use crate::os::x11::window::XWindowInner;
 use crate::os::x11::xsettings::*;
@@ -712,8 +712,8 @@ impl XConnection {
             visual.green_mask(),
             visual.blue_mask()
         );
-        let (keyboard, kbd_ev) = Keyboard::new(&conn, false)?;
-        let keyboard = KeyboardWithFallback::new(keyboard, false)?;
+        let (keyboard, kbd_ev) = Keyboard::new(&conn, ModifierInit::X11)?;
+        let keyboard = KeyboardWithFallback::new(keyboard, ModifierInit::X11)?;
 
         let cursor_font_id = conn.generate_id();
         let cursor_font_name = "cursor";

--- a/window/src/os/x11/keyboard.rs
+++ b/window/src/os/x11/keyboard.rs
@@ -42,8 +42,8 @@ struct StateFromXcbStateNotify {
 }
 
 #[derive(Clone, Copy)]
-pub enum ModifierInit {
-    X11,
+pub enum ModifierInit<'a> {
+    X11(&'a xcb::Connection),
     Wayland,
 }
 
@@ -613,7 +613,7 @@ impl Keyboard {
 
         let mod_map = match modifier_init {
             ModifierInit::Wayland => init_modifier_table_wayland(&keymap),
-            ModifierInit::X11 => init_modifier_table_x11(&keymap),
+            ModifierInit::X11(conn) => init_modifier_table_x11(&conn, &keymap),
         };
 
         Ok(Self {
@@ -657,7 +657,7 @@ impl Keyboard {
 
         let mod_map = match modifier_init {
             ModifierInit::Wayland => init_modifier_table_wayland(&keymap),
-            ModifierInit::X11 => init_modifier_table_x11(&keymap),
+            ModifierInit::X11(conn) => init_modifier_table_x11(&conn, &keymap),
         };
 
         Ok(Self {
@@ -736,7 +736,7 @@ impl Keyboard {
 
         let mod_map = match modifier_init {
             ModifierInit::Wayland => init_modifier_table_wayland(&keymap),
-            ModifierInit::X11 => init_modifier_table_x11(&keymap),
+            ModifierInit::X11(conn) => init_modifier_table_x11(&conn, &keymap),
         };
 
         let kbd = Self {

--- a/window/src/os/x11/keyboard.rs
+++ b/window/src/os/x11/keyboard.rs
@@ -866,9 +866,13 @@ impl Keyboard {
         ensure!(!new_state.get_raw_ptr().is_null(), "problem with new state");
         let phys_code_map = build_physkeycode_map(&new_keymap);
 
+        // This function is only called from X11.
+        init_modifier_table_x11(&connection, &new_keymap);
+
         self.state.replace(new_state);
         self.keymap.replace(new_keymap);
         self.phys_code_map.replace(phys_code_map);
+
         Ok(())
     }
 }

--- a/window/src/os/x11/keyboard.rs
+++ b/window/src/os/x11/keyboard.rs
@@ -1,4 +1,7 @@
 use crate::os::xkeysyms::keysym_to_keycode;
+use crate::x11::modifiers::{
+    init_modifier_table_wayland, init_modifier_table_x11, ModifierIndex, ModifierMap,
+};
 use crate::{
     DeadKeyStatus, Handled, KeyCode, KeyEvent, Modifiers, RawKeyEvent, WindowEvent,
     WindowEventSender, WindowKeyEvent,
@@ -12,8 +15,7 @@ use std::os::unix::ffi::OsStrExt;
 use wezterm_input_types::{KeyboardLedStatus, PhysKeyCode};
 use xcb::x::KeyButMask;
 use xkb::compose::Status as ComposeStatus;
-use xkbcommon::xkb;
-use xkbcommon::xkb::{LayoutIndex, ModMask};
+use xkbcommon::xkb::{self};
 
 pub struct Keyboard {
     context: xkb::Context,
@@ -22,6 +24,7 @@ pub struct Keyboard {
 
     state: RefCell<xkb::State>,
     compose_state: RefCell<Compose>,
+    mod_map: ModifierMap,
     phys_code_map: RefCell<HashMap<xkb::Keycode, PhysKeyCode>>,
     mods_leds: RefCell<(Modifiers, KeyboardLedStatus)>,
     last_xcb_state: RefCell<StateFromXcbStateNotify>,
@@ -168,16 +171,16 @@ fn default_keymap(context: &xkb::Context) -> Option<xkb::Keymap> {
 }
 
 impl KeyboardWithFallback {
-    pub fn new(selected: Keyboard) -> anyhow::Result<Self> {
+    pub fn new(selected: Keyboard, using_wayland: bool) -> anyhow::Result<Self> {
         Ok(Self {
             selected,
-            fallback: Keyboard::new_default()?,
+            fallback: Keyboard::new_default(using_wayland)?,
         })
     }
 
-    pub fn new_from_string(s: String) -> anyhow::Result<Self> {
-        let selected = Keyboard::new_from_string(s)?;
-        Self::new(selected)
+    pub fn new_from_string(s: String, using_wayland: bool) -> anyhow::Result<Self> {
+        let selected = Keyboard::new_from_string(s, using_wayland)?;
+        Self::new(selected, using_wayland)
     }
 
     pub fn process_wayland_key(
@@ -457,12 +460,16 @@ impl KeyboardWithFallback {
         }
     }
 
-    fn mod_is_active(&self, modifier: &str) -> bool {
+    fn mod_is_active(&self, modifier: ModifierIndex) -> bool {
         // [TODO] consider state  Depressed & consumed mods
+        if modifier.idx == xkb::MOD_INVALID {
+            return false;
+        }
+
         self.selected
             .state
             .borrow()
-            .mod_name_is_active(modifier, xkb::STATE_MODS_EFFECTIVE)
+            .mod_index_is_active(modifier.idx, xkb::STATE_MODS_EFFECTIVE)
     }
     fn led_is_active(&self, led: &str) -> bool {
         self.selected.state.borrow().led_name_is_active(led)
@@ -484,20 +491,39 @@ impl KeyboardWithFallback {
     pub fn get_key_modifiers(&self) -> Modifiers {
         let mut res = Modifiers::default();
 
-        if self.mod_is_active(xkb::MOD_NAME_SHIFT) {
+        if self.mod_is_active(self.selected.mod_map.shift) {
             res |= Modifiers::SHIFT;
         }
-        if self.mod_is_active(xkb::MOD_NAME_CTRL) {
+
+        if self.mod_is_active(self.selected.mod_map.ctrl) {
             res |= Modifiers::CTRL;
         }
-        if self.mod_is_active(xkb::MOD_NAME_ALT) {
-            // Mod1
+
+        if self.mod_is_active(self.selected.mod_map.alt) {
             res |= Modifiers::ALT;
         }
-        if self.mod_is_active(xkb::MOD_NAME_LOGO) {
-            // Mod4
+
+        if self.mod_is_active(self.selected.mod_map.meta) {
+            res |= Modifiers::META;
+        }
+
+        if self.mod_is_active(self.selected.mod_map.supr) {
             res |= Modifiers::SUPER;
         }
+
+        if self.mod_is_active(self.selected.mod_map.hyper) {
+            res |= Modifiers::HYPER;
+        }
+
+        if self.mod_is_active(self.selected.mod_map.caps_lock) {
+            res |= Modifiers::CAPS_LOCK;
+        }
+
+        if self.mod_is_active(self.selected.mod_map.num_lock) {
+            res |= Modifiers::NUM_LOCK;
+        }
+
+        log::debug!("Modifiers detected: {:?}", res);
         res
     }
 
@@ -563,7 +589,7 @@ impl KeyboardWithFallback {
 }
 
 impl Keyboard {
-    pub fn new_default() -> anyhow::Result<Self> {
+    pub fn new_default(using_wayland: bool) -> anyhow::Result<Self> {
         let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
         let keymap = default_keymap(&context)
             .ok_or_else(|| anyhow!("Failed to load system default keymap"))?;
@@ -579,6 +605,12 @@ impl Keyboard {
         let phys_code_map = build_physkeycode_map(&keymap);
         let label = "fallback";
 
+        let mod_map = if using_wayland {
+            init_modifier_table_wayland(&keymap)
+        } else {
+            init_modifier_table_x11(&keymap)
+        };
+
         Ok(Self {
             context,
             device_id: -1,
@@ -589,6 +621,7 @@ impl Keyboard {
                 composition: String::new(),
                 label,
             }),
+            mod_map,
             phys_code_map: RefCell::new(phys_code_map),
             mods_leds: RefCell::new(Default::default()),
             last_xcb_state: RefCell::new(Default::default()),
@@ -596,7 +629,7 @@ impl Keyboard {
         })
     }
 
-    pub fn new_from_string(s: String) -> anyhow::Result<Self> {
+    pub fn new_from_string(s: String, using_wayland: bool) -> anyhow::Result<Self> {
         let context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
         let keymap = xkb::Keymap::new_from_string(
             &context,
@@ -617,6 +650,12 @@ impl Keyboard {
         let phys_code_map = build_physkeycode_map(&keymap);
         let label = "selected";
 
+        let mod_map = if using_wayland {
+            init_modifier_table_wayland(&keymap)
+        } else {
+            init_modifier_table_x11(&keymap)
+        };
+
         Ok(Self {
             context,
             device_id: -1,
@@ -627,6 +666,7 @@ impl Keyboard {
                 composition: String::new(),
                 label,
             }),
+            mod_map,
             phys_code_map: RefCell::new(phys_code_map),
             mods_leds: RefCell::new(Default::default()),
             last_xcb_state: RefCell::new(Default::default()),
@@ -634,7 +674,10 @@ impl Keyboard {
         })
     }
 
-    pub fn new(connection: &xcb::Connection) -> anyhow::Result<(Keyboard, u8)> {
+    pub fn new(
+        connection: &xcb::Connection,
+        using_wayland: bool,
+    ) -> anyhow::Result<(Keyboard, u8)> {
         let first_ev = xcb::xkb::get_extension_data(connection)
             .ok_or_else(|| anyhow!("could not get xkb extension data"))?
             .first_event;
@@ -687,7 +730,13 @@ impl Keyboard {
         let phys_code_map = build_physkeycode_map(&keymap);
         let label = "selected";
 
-        let kbd = Keyboard {
+        let mod_map = if using_wayland {
+            init_modifier_table_wayland(&keymap)
+        } else {
+            init_modifier_table_x11(&keymap)
+        };
+
+        let kbd = Self {
             context,
             device_id,
             keymap: RefCell::new(keymap),
@@ -697,6 +746,7 @@ impl Keyboard {
                 composition: String::new(),
                 label,
             }),
+            mod_map,
             phys_code_map: RefCell::new(phys_code_map),
             mods_leds: RefCell::new(Default::default()),
             last_xcb_state: RefCell::new(Default::default()),

--- a/window/src/os/x11/mod.rs
+++ b/window/src/os/x11/mod.rs
@@ -2,6 +2,7 @@
 pub mod connection;
 pub mod cursor;
 pub mod keyboard;
+mod modifiers;
 pub mod window;
 pub mod xcb_util;
 pub mod xrm;

--- a/window/src/os/x11/modifiers.rs
+++ b/window/src/os/x11/modifiers.rs
@@ -303,7 +303,9 @@ pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
         let mut shifted: u32 = 1;
         let mut used_bits: u32 = 0;
 
-        macro_rules! assign {
+        // Algorithm can detect the same index for multiple modifiers
+        // but we only want one assigned to each of our modifiers.
+        macro_rules! try_assign_unique_index {
             ($mod:ident, $i:ident) => {
                 if mod_map.$mod.idx == xkb::MOD_INVALID
                     && (used_bits & shifted == 0)
@@ -316,14 +318,14 @@ pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
         }
 
         for i in 0..32 {
-            assign!(ctrl, i);
-            assign!(shift, i);
-            assign!(alt, i);
-            assign!(meta, i);
-            assign!(caps_lock, i);
-            assign!(num_lock, i);
-            assign!(supr, i);
-            assign!(hyper, i);
+            try_assign_unique_index!(ctrl, i);
+            try_assign_unique_index!(shift, i);
+            try_assign_unique_index!(alt, i);
+            try_assign_unique_index!(meta, i);
+            try_assign_unique_index!(caps_lock, i);
+            try_assign_unique_index!(num_lock, i);
+            try_assign_unique_index!(supr, i);
+            try_assign_unique_index!(hyper, i);
             shifted <<= 1;
         }
     } else {

--- a/window/src/os/x11/modifiers.rs
+++ b/window/src/os/x11/modifiers.rs
@@ -3,14 +3,12 @@ use xkbcommon::xkb::{self};
 #[derive(Debug, Clone, Copy)]
 pub struct ModifierIndex {
     pub idx: xkb::ModIndex,
-    pub mask: u32,
 }
 
 impl Default for ModifierIndex {
     fn default() -> Self {
         return Self {
             idx: xkb::MOD_INVALID,
-            mask: 0,
         };
     }
 }
@@ -305,10 +303,7 @@ pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
                     && (used_bits & shifted == 0)
                     && algo.$mod == shifted
                 {
-                    mod_map.$mod = ModifierIndex {
-                        idx: $i,
-                        mask: shifted,
-                    };
+                    mod_map.$mod = ModifierIndex { idx: $i };
                     used_bits |= shifted;
                 }
             };
@@ -331,23 +326,7 @@ pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
     }
 
     log::info!(
-        "Modifier map:\n
-          - ctrl: {:?}
-          - shift: {:?}
-          - alt: {:?}
-          - meta: {:?}
-          - caps_lock: {:?}
-          - num_lock: {:?}
-          - super: {:?}
-          - hyper: {:?}",
-        mod_map.ctrl,
-        mod_map.shift,
-        mod_map.alt,
-        mod_map.meta,
-        mod_map.caps_lock,
-        mod_map.num_lock,
-        mod_map.supr,
-        mod_map.hyper,
+        "Modifier map {mod_map:#?}"
     );
 
     return mod_map;

--- a/window/src/os/x11/modifiers.rs
+++ b/window/src/os/x11/modifiers.rs
@@ -1,0 +1,354 @@
+use xkbcommon::xkb::{self};
+
+#[derive(Debug, Clone, Copy)]
+pub struct ModifierIndex {
+    pub idx: xkb::ModIndex,
+    pub mask: u32,
+}
+
+impl Default for ModifierIndex {
+    fn default() -> Self {
+        return Self {
+            idx: xkb::MOD_INVALID,
+            mask: 0,
+        };
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct ModifierMap {
+    pub ctrl: ModifierIndex,
+    pub meta: ModifierIndex,
+    pub alt: ModifierIndex,
+    pub shift: ModifierIndex,
+    pub caps_lock: ModifierIndex,
+    pub num_lock: ModifierIndex,
+    pub supr: ModifierIndex,
+    pub hyper: ModifierIndex,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Algorithm {
+    failed: bool,
+
+    try_shift: bool,
+    shift_keycode: u32,
+
+    shift: u32,
+    ctrl: u32,
+    alt: u32,
+    meta: u32,
+    caps_lock: u32,
+    num_lock: u32,
+    supr: u32,
+    hyper: u32,
+}
+
+impl Default for Algorithm {
+    fn default() -> Algorithm {
+        return Algorithm {
+            failed: false,
+            try_shift: false,
+            shift_keycode: 0,
+
+            shift: 0,
+            ctrl: 0,
+            alt: 0,
+            meta: 0,
+            caps_lock: 0,
+            num_lock: 0,
+            supr: 0,
+            hyper: 0,
+        };
+    }
+}
+
+// Algorithm for mapping virtual modifiers to real modifiers:
+//   1. create new state
+//   2. for each key in keymap
+//      a. send key down to state
+//      b. if it affected exactly one bit in modifier map
+//         i) get keysym
+//         ii) if keysym matches one of the known modifiers, save it for that modifier
+//         iii) if modifier is latched, send key up and key down to toggle again
+//      c. send key up to reset the state
+//   3. if shift key found in step 2, run step 2 with all shift+key for each key
+//   4. if shift, control, alt and super are not all found, declare failure
+//   5. if failure, use static mapping from xkbcommon-names.h
+//
+// Step 3 is needed because many popular keymaps map meta to alt+shift.
+//
+// We could do better by constructing a system of linear equations, but it should not be
+// needed in any sane system. We could also use this algorithm with X11, but X11
+// provides XkbVirtualModsToReal which is guaranteed to be accurate, while this
+// algorithm is only a heuristic.
+//
+// We don't touch level3 or level5 modifiers.
+//
+fn get_mapper_algo<'a>(
+    algo: &'a mut Algorithm,
+    state: &'a mut xkb::State,
+) -> impl FnMut(&xkb::Keymap, xkb::Keycode) + 'a {
+    return move |_: &xkb::Keymap, key: xkb::Keycode| {
+        log::debug!("Key: {:?}", key);
+
+        if algo.failed {
+            return;
+        }
+
+        if algo.try_shift {
+            if key == algo.shift_keycode {
+                return;
+            }
+
+            state.update_key(algo.shift_keycode, xkb::KeyDirection::Down);
+        }
+
+        let changed_type = state.update_key(key, xkb::KeyDirection::Down);
+
+        if changed_type
+            & (xkb::STATE_MODS_DEPRESSED | xkb::STATE_MODS_LATCHED | xkb::STATE_MODS_LOCKED)
+            != 0
+        {
+            let mods = state.serialize_mods(if algo.try_shift {
+                xkb::STATE_MODS_EFFECTIVE
+            } else {
+                xkb::STATE_MODS_DEPRESSED | xkb::STATE_MODS_LATCHED | xkb::STATE_MODS_LOCKED
+            });
+
+            let keysyms = state.key_get_syms(key);
+            log::debug!("Keysym: {:x?}", keysyms);
+
+            macro_rules! assign_left_right {
+                ($key_l:expr, $key_r:expr, $mod:ident) => {
+                    if keysyms[0] == $key_l || keysyms[0] == $key_r {
+                        if algo.$mod == 0 {
+                            log::debug!(
+                                "Keycode {:?} triggered keysym '{:x?}' for {:?}' modifier.",
+                                key,
+                                keysyms[0],
+                                stringify!($mod)
+                            );
+                            algo.$mod = mods;
+                        } else if algo.$mod != mods {
+                            log::debug!(
+                                "Keycode {:?} triggered again keysym '{:x?}' for {:?}' modifier.",
+                                key,
+                                keysyms[0],
+                                stringify!($mod)
+                            );
+                            algo.failed = true;
+                        }
+                    }
+                };
+            }
+
+            macro_rules! assign {
+                ($key:expr, $mod:ident) => {
+                    if keysyms[0] == $key && algo.$mod == 0 {
+                        log::debug!(
+                            "Key {:?} triggered keysym '{:?}' for '{:?}' modifier.",
+                            key,
+                            keysyms[0],
+                            stringify!($mod)
+                        );
+                        algo.$mod = mods;
+                    }
+                };
+            }
+
+            // We can handle exactly one keysym with exactly one bit set in the implementation
+            // below; with a lot more gymnastics, we could set up an 8x8 linear system and solve
+            // for each modifier in case there are some modifiers that are only present in
+            // combination with others, but it is not worth the effort.
+            if keysyms.len() == 1 && mods.is_power_of_two() {
+                assign_left_right!(xkb::KEY_Shift_L, xkb::KEY_Shift_R, shift);
+                assign_left_right!(xkb::KEY_Control_L, xkb::KEY_Control_R, ctrl);
+                assign!(xkb::KEY_Caps_Lock, caps_lock);
+                assign!(xkb::KEY_Shift_Lock, num_lock);
+                assign_left_right!(xkb::KEY_Alt_L, xkb::KEY_Alt_R, alt);
+                assign_left_right!(xkb::KEY_Meta_L, xkb::KEY_Meta_R, meta);
+                assign_left_right!(xkb::KEY_Super_L, xkb::KEY_Super_R, supr);
+                assign_left_right!(xkb::KEY_Hyper_L, xkb::KEY_Hyper_R, hyper);
+            }
+
+            if algo.shift_keycode == 0
+                && (keysyms[0] == xkb::KEY_Shift_L || keysyms[0] == xkb::KEY_Shift_R)
+            {
+                log::debug!("Found shift keycode.");
+                algo.shift_keycode = key;
+            }
+
+            // If this is a lock, then up and down to remove lock state
+            if changed_type & xkb::STATE_MODS_LOCKED != 0 {
+                log::debug!("Found lock state. Set up/down to remove lock state.");
+                state.update_key(key, xkb::KeyDirection::Up);
+                state.update_key(key, xkb::KeyDirection::Down);
+            }
+        }
+
+        state.update_key(key, xkb::KeyDirection::Up);
+
+        if algo.try_shift {
+            state.update_key(algo.shift_keycode, xkb::KeyDirection::Up);
+        }
+    };
+}
+
+/// This function initializes wezterm internal modifiers depending
+/// on a default mapping.
+/// This function simply queries the index for the xkb modifiers
+/// `Control`, `Lock`, `Shift`, `Mod1`, `Mod2`, `Mod4`
+/// and treats them as default (assumption) to
+/// `Ctrl`, `Caps_Lock`, `Shift`, `Alt`, `Num_Lock`, `Super`
+///
+/// Modifiers `Hyper` and `Meta` are not detected.
+fn init_modifier_table_fallback(keymap: &xkb::Keymap) -> ModifierMap {
+    let mut mod_map = ModifierMap::default();
+
+    macro_rules! assign {
+        ($mod:ident, $n:expr) => {
+            let idx = keymap.mod_get_index($n);
+            mod_map.$mod = ModifierIndex {
+                idx: idx,
+                mask: 1 << idx,
+            };
+        };
+    }
+
+    assign!(ctrl, xkb::MOD_NAME_CTRL);
+    assign!(shift, xkb::MOD_NAME_SHIFT);
+    assign!(alt, xkb::MOD_NAME_ALT);
+    assign!(caps_lock, xkb::MOD_NAME_CAPS);
+    assign!(num_lock, xkb::MOD_NAME_NUM);
+    assign!(supr, xkb::MOD_NAME_LOGO);
+
+    return mod_map;
+}
+
+/// This function initializes wezterm internal modifiers
+/// by looking up virtual modifiers (e.g. run `xmodmap -pm`)
+/// and
+/// This function initializes `xkb` modifier indices for
+/// all modifiers
+/// `Ctrl`, `Shift`, `Alt`, `Num_Lock`, `Caps_Lock`, `Super`,
+/// `Hyper`, `Meta`.
+pub fn init_modifier_table_x11(keymap: &xkb::Keymap) -> ModifierMap {
+    // TODO: This implementation needs to be done with
+    // https://github.com/kovidgoyal/kitty/blob/0248edbdb98cc3ae80d98bf5ad17fbf497a24a43/glfw/xkb_glfw.c#L321    return init_modifier_table_fallback(keymap);
+    return init_modifier_table_fallback(keymap);
+}
+
+/// This function initializes wezterm internal modifiers
+/// by probing the keyboard state for each keypress.
+///
+/// This is a workaround because under Wayland the code in
+/// [init_modifier_table_x11](init_modifier_table_x11)
+/// does not work.
+///
+/// This function tries to initialize `xkb` modifier indices for
+/// all modifiers
+/// `Ctrl`, `Shift`, `Alt`, `Num_Lock`, `Caps_Lock`, `Super`,
+/// `Hyper`, `Meta` and if it fails it uses the fallback method
+/// [init_modifier_table_fallback](init_modifier_table_fallback).
+///
+/// Implementation is taken from Kitty:
+/// https://github.com/kovidgoyal/kitty/blob/0248edbdb98cc3ae80d98bf5ad17fbf497a24a43/glfw/xkb_glfw.c#L523
+pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
+    //
+    // This is a client side hack for wayland, once
+    // https://github.com/xkbcommon/libxkbcommon/pull/36
+    // is implemented or some other solution exists
+    // this code iterates through key presses to find the
+    // activated modifiers.
+    // Check: https://github.com/wez/wezterm/issues/4626
+
+    log::info!("Detect modifiers on Wayland [with key press iterations].");
+
+    let mut algo = Algorithm::default();
+    let mut state: xkb::State = xkb::State::new(keymap);
+    let mut mod_map = ModifierMap::default();
+
+    keymap.key_for_each(get_mapper_algo(&mut algo, &mut state));
+
+    if algo.shift_keycode == 0 {
+        algo.failed = true;
+        log::debug!("Did not found shift keycode.")
+    }
+
+    if (algo.ctrl == 0
+        || algo.alt == 0
+        || algo.meta == 0
+        || algo.shift == 0
+        || algo.supr == 0
+        || algo.hyper == 0)
+        && !algo.failed
+    {
+        algo.try_shift = true;
+        log::debug!("Detect modifiers on Wayland [with Shift+key press iterations].");
+        keymap.key_for_each(get_mapper_algo(&mut algo, &mut state));
+    }
+
+    // We must have found a least those 4 modifiers.
+    if !algo.failed && (algo.ctrl == 0 || algo.shift == 0 || algo.alt == 0 || algo.supr == 0) {
+        log::debug!("Some of essential modifiers (ctrl, shift, alt, supr) have not been found.");
+        algo.failed = true;
+    }
+
+    if !algo.failed {
+        let mut shifted: u32 = 1;
+        let mut used_bits: u32 = 0;
+
+        macro_rules! assign {
+            ($mod:ident, $i:ident) => {
+                if mod_map.$mod.idx == xkb::MOD_INVALID
+                    && (used_bits & shifted == 0)
+                    && algo.$mod == shifted
+                {
+                    mod_map.$mod = ModifierIndex {
+                        idx: $i,
+                        mask: shifted,
+                    };
+                    used_bits |= shifted;
+                }
+            };
+        }
+
+        for i in 0..32 {
+            assign!(ctrl, i);
+            assign!(shift, i);
+            assign!(alt, i);
+            assign!(meta, i);
+            assign!(caps_lock, i);
+            assign!(num_lock, i);
+            assign!(supr, i);
+            assign!(hyper, i);
+            shifted <<= 1;
+        }
+    } else {
+        log::warn!("Detect modifiers on Wayland failed. Using default mapping.");
+        mod_map = init_modifier_table_fallback(keymap);
+    }
+
+    log::info!(
+        "Modifier map:\n
+          - ctrl: {:?}
+          - shift: {:?}
+          - alt: {:?}
+          - meta: {:?}
+          - caps_lock: {:?}
+          - num_lock: {:?}
+          - super: {:?}
+          - hyper: {:?}",
+        mod_map.ctrl,
+        mod_map.shift,
+        mod_map.alt,
+        mod_map.meta,
+        mod_map.caps_lock,
+        mod_map.num_lock,
+        mod_map.supr,
+        mod_map.hyper,
+    );
+
+    return mod_map;
+}

--- a/window/src/os/x11/modifiers.rs
+++ b/window/src/os/x11/modifiers.rs
@@ -25,8 +25,7 @@ pub struct ModifierMap {
     pub hyper: ModifierIndex,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct Algorithm {
+struct Algorithm<'a> {
     failed: bool,
 
     try_shift: bool,
@@ -40,10 +39,12 @@ struct Algorithm {
     num_lock: u32,
     supr: u32,
     hyper: u32,
+
+    state: &'a mut xkb::State,
 }
 
-impl Default for Algorithm {
-    fn default() -> Algorithm {
+impl<'a> Algorithm<'a> {
+    fn new(state: &'a mut xkb::State) -> Algorithm<'a> {
         return Algorithm {
             failed: false,
             try_shift: false,
@@ -57,85 +58,85 @@ impl Default for Algorithm {
             num_lock: 0,
             supr: 0,
             hyper: 0,
+
+            state,
         };
     }
 }
 
-// Algorithm for mapping virtual modifiers to real modifiers:
-//   1. create new state
-//   2. for each key in keymap
-//      a. send key down to state
-//      b. if it affected exactly one bit in modifier map
-//         i) get keysym
-//         ii) if keysym matches one of the known modifiers, save it for that modifier
-//         iii) if modifier is latched, send key up and key down to toggle again
-//      c. send key up to reset the state
-//   3. if shift key found in step 2, run step 2 with all shift+key for each key
-//   4. if shift, control, alt and super are not all found, declare failure
-//   5. if failure, use static mapping from xkbcommon-names.h
-//
-// Step 3 is needed because many popular keymaps map meta to alt+shift.
-//
-// We could do better by constructing a system of linear equations, but it should not be
-// needed in any sane system. We could also use this algorithm with X11, but X11
-// provides XkbVirtualModsToReal which is guaranteed to be accurate, while this
-// algorithm is only a heuristic.
-//
-// We don't touch level3 or level5 modifiers.
-//
-fn get_mapper_algo<'a>(
-    algo: &'a mut Algorithm,
-    state: &'a mut xkb::State,
-) -> impl FnMut(&xkb::Keymap, xkb::Keycode) + 'a {
-    return move |_: &xkb::Keymap, key: xkb::Keycode| {
+impl<'a> Algorithm<'a> {
+    /// Algorithm for mapping virtual modifiers to real modifiers:
+    ///   1. create new state
+    ///   2. for each key in keymap
+    ///      a. send key down to state
+    ///      b. if it affected exactly one bit in modifier map
+    ///         i) get keysym
+    ///         ii) if keysym matches one of the known modifiers, save it for that modifier
+    ///         iii) if modifier is latched, send key up and key down to toggle again
+    ///      c. send key up to reset the state
+    ///   3. if shift key found in step 2, run step 2 with all shift+key for each key
+    ///   4. if shift, control, alt and super are not all found, declare failure
+    ///   5. if failure, use static mapping from xkbcommon-names.h
+    ///
+    /// Step 3 is needed because many popular keymaps map meta to alt+shift.
+    ///
+    /// We could do better by constructing a system of linear equations, but it should not be
+    /// needed in any sane system. We could also use this algorithm with X11, but X11
+    /// provides XkbVirtualModsToReal which is guaranteed to be accurate, while this
+    /// algorithm is only a heuristic.
+    ///
+    /// We don't touch level3 or level5 modifiers.
+    ///
+    fn visit_key(&mut self, key: xkb::Keycode) {
         log::debug!("Key: {:?}", key);
 
-        if algo.failed {
+        if self.failed {
             return;
         }
 
-        if algo.try_shift {
-            if key == algo.shift_keycode {
+        if self.try_shift {
+            if key == self.shift_keycode {
                 return;
             }
 
-            state.update_key(algo.shift_keycode, xkb::KeyDirection::Down);
+            self.state
+                .update_key(self.shift_keycode, xkb::KeyDirection::Down);
         }
 
-        let changed_type = state.update_key(key, xkb::KeyDirection::Down);
+        let changed_type = self.state.update_key(key, xkb::KeyDirection::Down);
 
         if changed_type
             & (xkb::STATE_MODS_DEPRESSED | xkb::STATE_MODS_LATCHED | xkb::STATE_MODS_LOCKED)
             != 0
         {
-            let mods = state.serialize_mods(if algo.try_shift {
+            let mods = self.state.serialize_mods(if self.try_shift {
                 xkb::STATE_MODS_EFFECTIVE
             } else {
                 xkb::STATE_MODS_DEPRESSED | xkb::STATE_MODS_LATCHED | xkb::STATE_MODS_LOCKED
             });
 
-            let keysyms = state.key_get_syms(key);
+            let keysyms = self.state.key_get_syms(key);
             log::debug!("Keysym: {:x?}", keysyms);
 
             macro_rules! assign_left_right {
                 ($key_l:expr, $key_r:expr, $mod:ident) => {
                     if keysyms[0] == $key_l || keysyms[0] == $key_r {
-                        if algo.$mod == 0 {
+                        if self.$mod == 0 {
                             log::debug!(
                                 "Keycode {:?} triggered keysym '{:x?}' for {:?}' modifier.",
                                 key,
                                 keysyms[0],
                                 stringify!($mod)
                             );
-                            algo.$mod = mods;
-                        } else if algo.$mod != mods {
+                            self.$mod = mods;
+                        } else if self.$mod != mods {
                             log::debug!(
                                 "Keycode {:?} triggered again keysym '{:x?}' for {:?}' modifier.",
                                 key,
                                 keysyms[0],
                                 stringify!($mod)
                             );
-                            algo.failed = true;
+                            self.failed = true;
                         }
                     }
                 };
@@ -143,14 +144,14 @@ fn get_mapper_algo<'a>(
 
             macro_rules! assign {
                 ($key:expr, $mod:ident) => {
-                    if keysyms[0] == $key && algo.$mod == 0 {
+                    if keysyms[0] == $key && self.$mod == 0 {
                         log::debug!(
                             "Key {:?} triggered keysym '{:?}' for '{:?}' modifier.",
                             key,
                             keysyms[0],
                             stringify!($mod)
                         );
-                        algo.$mod = mods;
+                        self.$mod = mods;
                     }
                 };
             }
@@ -170,27 +171,34 @@ fn get_mapper_algo<'a>(
                 assign_left_right!(xkb::KEY_Hyper_L, xkb::KEY_Hyper_R, hyper);
             }
 
-            if algo.shift_keycode == 0
+            if self.shift_keycode == 0
                 && (keysyms[0] == xkb::KEY_Shift_L || keysyms[0] == xkb::KEY_Shift_R)
             {
                 log::debug!("Found shift keycode.");
-                algo.shift_keycode = key;
+                self.shift_keycode = key;
             }
 
             // If this is a lock, then up and down to remove lock state
             if changed_type & xkb::STATE_MODS_LOCKED != 0 {
-                log::debug!("Found lock state. Set up/down to remove lock state.");
-                state.update_key(key, xkb::KeyDirection::Up);
-                state.update_key(key, xkb::KeyDirection::Down);
+                log::debug!("Found lock self.state. Set up/down to remove lock self.state.");
+                self.state.update_key(key, xkb::KeyDirection::Up);
+                self.state.update_key(key, xkb::KeyDirection::Down);
             }
         }
 
-        state.update_key(key, xkb::KeyDirection::Up);
+        self.state.update_key(key, xkb::KeyDirection::Up);
 
-        if algo.try_shift {
-            state.update_key(algo.shift_keycode, xkb::KeyDirection::Up);
+        if self.try_shift {
+            self.state
+                .update_key(self.shift_keycode, xkb::KeyDirection::Up);
         }
-    };
+    }
+
+    fn visit_keymap(&mut self, keymap: &xkb::Keymap) {
+        keymap.key_for_each(|_, key| {
+            self.visit_key(key);
+        });
+    }
 }
 
 /// This function initializes wezterm internal modifiers depending
@@ -207,10 +215,7 @@ fn init_modifier_table_fallback(keymap: &xkb::Keymap) -> ModifierMap {
     macro_rules! assign {
         ($mod:ident, $n:expr) => {
             let idx = keymap.mod_get_index($n);
-            mod_map.$mod = ModifierIndex {
-                idx: idx,
-                mask: 1 << idx,
-            };
+            mod_map.$mod = ModifierIndex { idx: idx };
         };
     }
 
@@ -263,11 +268,11 @@ pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
 
     log::info!("Detect modifiers on Wayland [with key press iterations].");
 
-    let mut algo = Algorithm::default();
     let mut state: xkb::State = xkb::State::new(keymap);
+    let mut algo = Algorithm::new(&mut state);
     let mut mod_map = ModifierMap::default();
 
-    keymap.key_for_each(get_mapper_algo(&mut algo, &mut state));
+    algo.visit_keymap(&keymap);
 
     if algo.shift_keycode == 0 {
         algo.failed = true;
@@ -283,8 +288,9 @@ pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
         && !algo.failed
     {
         algo.try_shift = true;
+
         log::debug!("Detect modifiers on Wayland [with Shift+key press iterations].");
-        keymap.key_for_each(get_mapper_algo(&mut algo, &mut state));
+        algo.visit_keymap(&keymap);
     }
 
     // We must have found a least those 4 modifiers.
@@ -325,9 +331,7 @@ pub fn init_modifier_table_wayland(keymap: &xkb::Keymap) -> ModifierMap {
         mod_map = init_modifier_table_fallback(keymap);
     }
 
-    log::info!(
-        "Modifier map {mod_map:#?}"
-    );
+    log::info!("Modifier map {mod_map:#?}");
 
     return mod_map;
 }

--- a/window/src/os/xkeysyms.rs
+++ b/window/src/os/xkeysyms.rs
@@ -74,8 +74,12 @@ pub fn keysym_to_keycode(keysym: u32) -> Option<KeyCode> {
         KEY_Caps_Lock => KeyCode::CapsLock,
         KEY_Num_Lock => KeyCode::NumLock,
         KEY_Scroll_Lock => KeyCode::ScrollLock,
+        KEY_Meta_L => KeyCode::Meta,
+        KEY_Meta_R => KeyCode::Meta,
         KEY_Super_L => KeyCode::Super,
         KEY_Super_R => KeyCode::Super,
+        KEY_Hyper_R => KeyCode::Hyper,
+        KEY_Hyper_L => KeyCode::Hyper,
         KEY_Menu => KeyCode::Applications,
         KEY_Help => KeyCode::Help,
 


### PR DESCRIPTION
Fixes: #4626

- This implementation is the first modifier detection client-side workaround as Kitty does for Wayland.
- For X11 the code checks the modifier table and tries to match a single virtual modifiers to a single real modifier (ctrl, shift, capslock, mod1...mod5).
- On Wayland the workaround goes by probing the keyboard for all keys and rebuilding the missing API which is not available as in X11.

The solution is encapsulated out in file `modifiers.rs` for both X11 and Wayland.

- I am sure about how to test this, since it uses `xkb` and its state...
- @wez:  A review is appreciated to let me know if we should go on with this, or there is any better idea from your side.
   This PR contains the port of Kittys C code for Wayland.