### PR TITLE
fix(windows): closing panes sometimes freezes wezterm

### DIFF
--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -1,5 +1,5 @@
 //! This crate provides a cross platform API for working with the
-//! psuedo terminal (pty) interfaces provided by the system.
+//! pseudo terminal (pty) interfaces provided by the system.
 //! Unlike other crates in this space, this crate provides a set
 //! of traits that allow selecting from different implementations
 //! at runtime.

--- a/pty/src/win/conpty.rs
+++ b/pty/src/win/conpty.rs
@@ -1,5 +1,5 @@
 use crate::cmdbuilder::CommandBuilder;
-use crate::win::psuedocon::PsuedoCon;
+use crate::win::pseudocon::PseudoCon;
 use crate::{Child, MasterPty, PtyPair, PtySize, PtySystem, SlavePty};
 use anyhow::Error;
 use filedescriptor::{FileDescriptor, Pipe};
@@ -14,7 +14,7 @@ impl PtySystem for ConPtySystem {
         let stdin = Pipe::new()?;
         let stdout = Pipe::new()?;
 
-        let con = PsuedoCon::new(
+        let con = PseudoCon::new(
             COORD {
                 X: size.cols as i16,
                 Y: size.rows as i16,
@@ -44,7 +44,7 @@ impl PtySystem for ConPtySystem {
 }
 
 struct Inner {
-    con: PsuedoCon,
+    con: PseudoCon,
     readable: FileDescriptor,
     writable: Option<FileDescriptor>,
     size: PtySize,

--- a/pty/src/win/mod.rs
+++ b/pty/src/win/mod.rs
@@ -13,7 +13,7 @@ use winapi::um::winbase::INFINITE;
 
 pub mod conpty;
 mod procthreadattr;
-mod psuedocon;
+mod pseudocon;
 
 use filedescriptor::OwnedHandle;
 

--- a/pty/src/win/procthreadattr.rs
+++ b/pty/src/win/procthreadattr.rs
@@ -1,4 +1,4 @@
-use crate::win::psuedocon::HPCON;
+use crate::win::pseudocon::HPCON;
 use anyhow::{ensure, Error};
 use std::io::Error as IoError;
 use std::{mem, ptr};

--- a/pty/src/win/pseudocon.rs
+++ b/pty/src/win/pseudocon.rs
@@ -24,7 +24,7 @@ use winapi::um::winnt::HANDLE;
 
 pub type HPCON = HANDLE;
 
-pub const PSUEDOCONSOLE_INHERIT_CURSOR: DWORD = 0x1;
+pub const PSEUDOCONSOLE_INHERIT_CURSOR: DWORD = 0x1;
 pub const PSEUDOCONSOLE_RESIZE_QUIRK: DWORD = 0x2;
 pub const PSEUDOCONSOLE_WIN32_INPUT_MODE: DWORD = 0x4;
 #[allow(dead_code)]
@@ -63,20 +63,20 @@ lazy_static! {
     static ref CONPTY: ConPtyFuncs = load_conpty();
 }
 
-pub struct PsuedoCon {
+pub struct PseudoCon {
     con: HPCON,
 }
 
-unsafe impl Send for PsuedoCon {}
-unsafe impl Sync for PsuedoCon {}
+unsafe impl Send for PseudoCon {}
+unsafe impl Sync for PseudoCon {}
 
-impl Drop for PsuedoCon {
+impl Drop for PseudoCon {
     fn drop(&mut self) {
         unsafe { (CONPTY.ClosePseudoConsole)(self.con) };
     }
 }
 
-impl PsuedoCon {
+impl PseudoCon {
     pub fn new(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
         let mut con: HPCON = INVALID_HANDLE_VALUE;
         let result = unsafe {
@@ -84,7 +84,7 @@ impl PsuedoCon {
                 size,
                 input.as_raw_handle() as _,
                 output.as_raw_handle() as _,
-                PSUEDOCONSOLE_INHERIT_CURSOR
+                PSEUDOCONSOLE_INHERIT_CURSOR
                     | PSEUDOCONSOLE_RESIZE_QUIRK
                     | PSEUDOCONSOLE_WIN32_INPUT_MODE,
                 &mut con,
@@ -92,7 +92,7 @@ impl PsuedoCon {
         };
         ensure!(
             result == S_OK,
-            "failed to create psuedo console: HRESULT {}",
+            "failed to create pseudo console: HRESULT {}",
             result
         );
         Ok(Self { con })


### PR DESCRIPTION
Based on #5977
# Problem
On windows closing panes sometimes hangs wezterm.

These problem is related with how `conpty.dll` is being used this has been discussed in https://github.com/microsoft/terminal/discussions/17716

The problem seems to be mentioned in the docs at [creating-a-pseudoconsole-session#ending-the-pseudoconsole-session](https://learn.microsoft.com/en-us/windows/console/creating-a-pseudoconsole-session#ending-the-pseudoconsole-session)

![image](https://github.com/user-attachments/assets/6ea510e7-302a-4b44-bdb7-2283275d6e0b)


# This pr
Hopefully will close #5882, could it help with related issues too #5496 #5432?

**This pr** manually closes handles before closing pseudoconsole to avoid that call from blocking.


# Tasks
- [x] #5940 --> rename
- [x] #5977 --> read from output pipe before closing
- [ ] upgrade `conpty.dll` 
  Not strictly necessary to solve this issue in. 
  [Here](https://github.com/wez/wezterm/pull/5977#discussion_r1720490991) leonard added instructions with the necessary steps to do that upgrade.