### PR TITLE
feat: implement opt-in OSC52 clipboard querying

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -461,6 +461,8 @@ pdu! {
     SendPaste: 13,
     Resize: 14,
     SetClipboard: 20,
+    QueryClipboard: 21,
+    QueryClipboardResponse: 63,
     GetLines: 22,
     GetLinesResponse: 23,
     GetPaneRenderChanges: 24,
@@ -516,6 +518,7 @@ impl Pdu {
             | Self::SendPaste(_)
             | Self::Resize(_)
             | Self::SetClipboard(_)
+            | Self::QueryClipboard(_)
             | Self::SetPaneZoomed(_)
             | Self::SpawnV2(_) => true,
             _ => false,
@@ -594,6 +597,7 @@ impl Pdu {
             | Pdu::SetPalette(SetPalette { pane_id, .. })
             | Pdu::NotifyAlert(NotifyAlert { pane_id, .. })
             | Pdu::SetClipboard(SetClipboard { pane_id, .. })
+            | Pdu::QueryClipboard(QueryClipboard { pane_id, .. })
             | Pdu::PaneFocused(PaneFocused { pane_id })
             | Pdu::PaneRemoved(PaneRemoved { pane_id }) => Some(*pane_id),
             _ => None,
@@ -767,6 +771,18 @@ pub struct SetClipboard {
     pub pane_id: PaneId,
     pub clipboard: Option<String>,
     pub selection: ClipboardSelection,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct QueryClipboard {
+    pub pane_id: PaneId,
+    pub selection: ClipboardSelection,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct QueryClipboardResponse {
+    pub pane_id: PaneId,
+    pub content: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -240,6 +240,12 @@ pub struct Config {
     #[dynamic(default)]
     pub enable_kitty_keyboard: bool,
 
+    /// Whether the terminal should respond to OSC 52 requests to read the
+    /// clipboard content.
+    /// Disabled by default for security concerns.
+    #[dynamic(default)]
+    pub enable_osc52_clipboard_reading: bool,
+
     /// Whether the terminal should respond to requests to read the
     /// title string.
     /// Disabled by default for security concerns with shells that might

--- a/config/src/terminal.rs
+++ b/config/src/terminal.rs
@@ -86,6 +86,10 @@ impl wezterm_term::TerminalConfiguration for TermConfig {
         self.configuration().enable_kitty_keyboard
     }
 
+    fn enable_osc52_clipboard_reading(&self) -> bool {
+        self.configuration().enable_osc52_clipboard_reading
+    }
+
     fn canonicalize_pasted_newlines(&self) -> wezterm_term::config::NewlineCanon {
         match self.configuration().canonicalize_pasted_newlines {
             None => wezterm_term::config::NewlineCanon::default(),

--- a/docs/config/lua/config/enable_osc52_clipboard_reading.md
+++ b/docs/config/lua/config/enable_osc52_clipboard_reading.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - osc
+  - clipboard
+---
+
+# `enable_osc52_clipboard_reading = false`
+
+{{since('nightly')}}
+
+When set to `true`, the terminal will allow access to the system clipboard by
+terminal applications via `OSC 52` [escape sequence](../../../shell-integration.md#osc-52-clipboard-paste).
+
+The default for this option is `false`.
+
+Note that it is not recommended to enable this option due to serious security
+implications.
+
+### Security Concerns
+
+Clipboards are often used to store sensitive information, and granting any
+terminal application (especially from remote machines) access to it poses a
+security risk. A malicious server could spam the terminal with OSC 52 paste
+sequences to monitor whatever you have on the clipboard, which may occasionally
+contain sensitive data.
+
+Setting clipboard data that contains escape sequences or malicious commands and
+reading it back could allow an attacker to inject harmful characters into the
+input stream. Although, the risk is somewhat mitigated as the pasted text is
+encoded in BASE64.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -3,6 +3,7 @@ wezterm supports integrating with the shell through the following means:
 * `OSC 7` Escape sequences to advise the terminal of the working directory
 * `OSC 133` Escape sequence to define Input, Output and Prompt zones
 * `OSC 1337` Escape sequences to set user vars for tracking additional shell state
+* `OSC 52` Escape sequences for writing to and reading from the clipboard
 
 `OSC` is escape sequence jargon for *Operating System Command*.
 
@@ -180,3 +181,33 @@ return config
 
 Now, rather than just running `cmd.exe` on its own, this will cause `cmd.exe`
 to self-inject the clink line editor.
+
+## OSC 52 Clipboard Copy
+
+The data can be copied to the `System Clipboard` or `Primary Selection` with a
+command like this:
+
+```bash
+printf '\033]52;c;%s\033\\' $(base64 <<< "hello world")
+```
+
+- `c` copies to the system clipboard
+- `p` copies to the primary selection buffer
+
+The second parameter provides the selection data, which is a string encoded in base64 (RFC-4648).
+
+## OSC 52 Clipboard Paste
+
+The data can be pasted from the `System Clipboard` or `Primary Selection` with a
+command like this:
+
+```bash
+printf "\033]7;c;?\033\\"
+```
+
+- `c` pastes to the system clipboard
+- `p` pastes to the primary selection buffer
+
+Note that this feature poses a potential security risk and is disabled by
+default. It requires enabling via [a configuration option](config/lua/config/enable_osc52_clipboard_reading.md).
+You should carefully consider whether you're willing to accept the associated risks before enabling it.

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -205,8 +205,8 @@ command like this:
 printf "\033]7;c;?\033\\"
 ```
 
-- `c` pastes to the system clipboard
-- `p` pastes to the primary selection buffer
+- `c` pastes from the system clipboard
+- `p` pastes from the primary selection buffer
 
 Note that this feature poses a potential security risk and is disabled by
 default. It requires enabling via [a configuration option](config/lua/config/enable_osc52_clipboard_reading.md).

--- a/docs/shell-integration.md
+++ b/docs/shell-integration.md
@@ -202,7 +202,7 @@ The data can be pasted from the `System Clipboard` or `Primary Selection` with a
 command like this:
 
 ```bash
-printf "\033]7;c;?\033\\"
+printf "\033]52;c;?\033\\"
 ```
 
 - `c` pastes from the system clipboard

--- a/term/src/config.rs
+++ b/term/src/config.rs
@@ -180,6 +180,10 @@ pub trait TerminalConfiguration: Downcast + std::fmt::Debug + Send + Sync {
         false
     }
 
+    fn enable_osc52_clipboard_reading(&self) -> bool {
+        false
+    }
+
     /// The default unicode version to assume.
     /// This affects how the width of certain sequences is interpreted.
     /// At the time of writing, we default to 9 even though the current

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -446,6 +446,7 @@ fn default_color_map() -> HashMap<u16, RgbColor> {
 /// back-pressure when there is a lot of data to read,
 /// and we're in control of the write side, which represents
 /// input from the interactive user, or pastes.
+#[derive(Debug, Clone)]
 struct ThreadedWriter {
     sender: Sender<WriterMessage>,
 }

--- a/termwiz/src/escape/osc.rs
+++ b/termwiz/src/escape/osc.rs
@@ -1393,6 +1393,22 @@ mod test {
     }
 
     #[test]
+    fn selection() {
+        assert_eq!(
+            parse(&["52", "c", "?"], "\x1b]52;c;?\x1b\\"),
+            OperatingSystemCommand::QuerySelection(Selection::CLIPBOARD)
+        );
+        assert_eq!(
+            parse(&["52", "c"], "\x1b]52;c\x1b\\"),
+            OperatingSystemCommand::ClearSelection(Selection::CLIPBOARD)
+        );
+        assert_eq!(
+            parse(&["52", "c", "eA=="], "\x1b]52;c;eA==\x1b\\"),
+            OperatingSystemCommand::SetSelection(Selection::CLIPBOARD, "x".into())
+        );
+    }
+
+    #[test]
     fn finalterm() {
         assert_eq!(
             parse(&["133", "L"], "\x1b]133;L\x1b\\"),

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1289,6 +1289,9 @@ impl TermWindow {
                 MuxNotification::AssignClipboard { .. } => {
                     // Handled by frontend
                 }
+                MuxNotification::QueryClipboard { .. } => {
+                    // Handled by frontend
+                }
                 MuxNotification::SaveToDownloads { .. } => {
                     // Handled by frontend
                 }
@@ -1507,6 +1510,7 @@ impl TermWindow {
                 ..
             }
             | MuxNotification::AssignClipboard { .. }
+            | MuxNotification::QueryClipboard { .. }
             | MuxNotification::SaveToDownloads { .. }
             | MuxNotification::WindowCreated(_)
             | MuxNotification::ActiveWorkspaceChanged(_)

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -991,6 +991,8 @@ impl SessionHandler {
             Pdu::Pong { .. }
             | Pdu::ListPanesResponse { .. }
             | Pdu::SetClipboard { .. }
+            | Pdu::QueryClipboard { .. }
+            | Pdu::QueryClipboardResponse { .. }
             | Pdu::NotifyAlert { .. }
             | Pdu::SpawnResponse { .. }
             | Pdu::GetPaneRenderChangesResponse { .. }


### PR DESCRIPTION
Closes: #2050 

Hi Wez! This is my first time contribution to the project. I've implemented the missing osc52 clipboard reading command. The feature is disabled by default and can be enabled via the config option `config.enable_osc52_clipboard_reading = true` .  I've also added the documentation with security notes and some tests related to osc52.

The clipboard content is received asynchronously through a channel, which is passed as the second parameter in the `Clipboard::get_contents` function. For the `TerminalState` it is the `ThreadedWriter` directly, for the mux client it is a tx-rx channel that than sends the pdu responce with the clipboard data back to the server and than to the server's `ThreadedWriter`. 

The waiting of the clipboard data on the mux server side is a bit clunky [wezterm-mux-server-impl/src/dispatch.rs](https://github.com/wez/wezterm/compare/main...39555:osc52-read?expand=1#diff-5f7131e27c54368222955f6e8059ba1ed6d1fae984ad36eb425be27d7c4102f8)
because there is no promise handling mechanism similar to what the client has so I left a mutable promise variable before the message loop and handled the response with `if Pdu::QueryClipboardResponce(..) =` before passing a pdu to the actual server's  message handler. I would like to hear any idea how to improve it.

I am open to any suggestions for naming, fixes and improvements.