### PR TITLE
add last_row in get_text_from_semantic_region

### DIFF
--- a/lua-api-crates/mux/src/pane.rs
+++ b/lua-api-crates/mux/src/pane.rs
@@ -57,7 +57,7 @@ impl MuxPane {
             let last_idx = line.physical_lines.len().saturating_sub(1);
             for (idx, phys) in line.physical_lines.iter().enumerate() {
                 let this_row = line.first_row + idx as StableRowIndex;
-                if this_row >= first_row && this_row < last_row {
+                if this_row >= first_row && this_row <= last_row {
                     let last_phys_idx = phys.len().saturating_sub(1);
 
                     let cols = cols_for_row(&zone, this_row);


### PR DESCRIPTION
This commit adds the last row into account while computing the `pane:get_text_from_semantic_region(zone)` method.

This fixes the following:
- #5806
- #5346 

I have tested the code, and the last line of semantic zone is now part of the result.

Just want to confirm that this does not conflict with anything