### PR TITLE
use surface height/width for client side decoration frame resizes

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -845,11 +845,9 @@ impl WaylandWindowInner {
 
                 log::trace!("Resizing frame");
                 if !self.window_frame.is_hidden() {
-                    // Clamp the size to at least one pixel.
-                    let width =
-                        NonZeroU32::new(pixel_width as u32).unwrap_or(NonZeroU32::new(1).unwrap());
-                    let height =
-                        NonZeroU32::new(pixel_height as u32).unwrap_or(NonZeroU32::new(1).unwrap());
+                    // Clamp the size to at least one surface heigh/width.
+                    let width = NonZeroU32::new(w).unwrap_or(NonZeroU32::new(1).unwrap());
+                    let height = NonZeroU32::new(h).unwrap_or(NonZeroU32::new(1).unwrap());
                     self.window_frame.resize(width, height);
                     pending.refresh_decorations = true
                 }


### PR DESCRIPTION
Fixes the problem with too big window frames when client side decorations are used on Wayland in combination with fractional scaling. See #5360 
However, there is still a problem when resizing the window, but I have not been able to find out why.