### PR TITLE
Update log_error.md to include using ShowDebugOverlay to view logs

### DIFF
--- a/docs/config/lua/wezterm/log_error.md
+++ b/docs/config/lua/wezterm/log_error.md
@@ -9,7 +9,7 @@ tags:
 # `wezterm.log_error(arg, ..)`
 
 This function logs the provided message string through wezterm's logging layer
-at 'ERROR' level.  If you started wezterm from a terminal that text will print
+at 'ERROR' level, which can be displayed via [ShowDebugOverlay](../keyassignment/ShowDebugOverlay.md) action.  If you started wezterm from a terminal that text will print
 to the stdout of that terminal.  If running as a daemon for the multiplexer
 server then it will be logged to the daemon output path.
 

--- a/docs/config/lua/wezterm/log_info.md
+++ b/docs/config/lua/wezterm/log_info.md
@@ -10,7 +10,7 @@ tags:
 {{since('20210314-114017-04b7cedd')}}
 
 This function logs the provided message string through wezterm's logging layer
-at 'INFO' level.  If you started wezterm from a terminal that text will print
+at 'INFO' level, which can be displayed via [ShowDebugOverlay](../keyassignment/ShowDebugOverlay.md) action.  If you started wezterm from a terminal that text will print
 to the stdout of that terminal.  If running as a daemon for the multiplexer
 server then it will be logged to the daemon output path.
 

--- a/docs/config/lua/wezterm/log_warn.md
+++ b/docs/config/lua/wezterm/log_warn.md
@@ -10,7 +10,7 @@ tags:
 {{since('20210314-114017-04b7cedd')}}
 
 This function logs the provided message string through wezterm's logging layer
-at 'WARN' level.  If you started wezterm from a terminal that text will print
+at 'WARN' level, which can be displayed via [ShowDebugOverlay](../keyassignment/ShowDebugOverlay.md) action.  If you started wezterm from a terminal that text will print
 to the stdout of that terminal.  If running as a daemon for the multiplexer
 server then it will be logged to the daemon output path.
 


### PR DESCRIPTION
I have struggled to find how to view the logs from Wezterm.log_info (warn, error).
I propose to make a minor update in the docs.