### PR TITLE
Select active tab choice as initial choice in ShowTabNavigator

### DIFF
--- a/docs/config/lua/keyassignment/ShowTabNavigator.md
+++ b/docs/config/lua/keyassignment/ShowTabNavigator.md
@@ -10,4 +10,7 @@ config.keys = {
 }
 ```
 
+{{since('nightly')}}
+
+The choice corresponding to the current tab is initially selected.
 

--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -593,11 +593,12 @@ pub fn launcher(
     args: LauncherArgs,
     mut term: TermWizTerminal,
     window: ::window::Window,
+    initial_choice_idx: usize,
 ) -> anyhow::Result<()> {
     let size = term.get_screen_size()?;
     let max_items = size.rows.saturating_sub(ROW_OVERHEAD);
     let mut state = LauncherState {
-        active_idx: 0,
+        active_idx: initial_choice_idx,
         max_items,
         pane_id: args.pane_id,
         top_row: 0,

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2326,9 +2326,8 @@ impl TermWindow {
     }
 
     fn show_tab_navigator(&mut self) {
-        let mux_window_id = self.mux_window_id;
         let mux = Mux::get();
-        let active_tab_idx = match mux.get_window(mux_window_id) {
+        let active_tab_idx = match mux.get_window(self.mux_window_id) {
             Some(mux_window) => mux_window.get_active_idx(),
             None => return,
         };


### PR DESCRIPTION
This introduces the following changes
- In `ShowTabNavigator`, select the choice corresponding to the active tab as the initial choice