### PR TITLE
Update leader_is_active.md

### DIFF
--- a/docs/config/lua/window/leader_is_active.md
+++ b/docs/config/lua/window/leader_is_active.md
@@ -1,4 +1,4 @@
-# wezterm:leader_is_active()
+# window:leader_is_active()
 
 {{since('20220319-142410-0fcdea07')}}
 


### PR DESCRIPTION
I think it should be `window:leader_is_active()` instead of `wezterm.leader_is_active()`