### PR TITLE
Update user-var-changed.md

### DIFF
--- a/docs/config/lua/window-events/user-var-changed.md
+++ b/docs/config/lua/window-events/user-var-changed.md
@@ -8,10 +8,15 @@ used to set a user var.
 You can use something like the following from your shell:
 
 ```bash
-printf "\033]1337;SetUserVar=%s=%s\007" foo `echo -n bar | base64 -w 0`
+printf "\033]1337;SetUserVar=%s=%s\007" foo `echo -n bar | base64`
 ```
 
 to set the user var named `foo` to the value `bar`.
+
+!!! note
+    On some systems the `base64` command wraps the output by default after some
+    amount of characters limiting the maximum length of the value. If this is
+    the case an argument like `-w 0` might help to avoid wrapping.
 
 Then, if you have this in your config:
 

--- a/docs/config/lua/window-events/user-var-changed.md
+++ b/docs/config/lua/window-events/user-var-changed.md
@@ -8,7 +8,7 @@ used to set a user var.
 You can use something like the following from your shell:
 
 ```bash
-printf "\033]1337;SetUserVar=%s=%s\007" foo `echo -n bar | base64`
+printf "\033]1337;SetUserVar=%s=%s\007" foo `echo -n bar | base64 -w 0`
 ```
 
 to set the user var named `foo` to the value `bar`.


### PR DESCRIPTION
By default base64 inserts a line break at some column which will truncate the user var. `-w 0` disables line wrapping