### PR TITLE
fix: don't clear ime_last_event when a key is UP

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -2560,7 +2560,7 @@ impl WindowView {
                             // but didn't call one of our callbacks.
                             // In theory, we should stop here, but the IME
                             // mysteriously swallows key repeats for certain
-                            // keys (eg: `f`) but not others.
+                            // keys (i.e. b, f, j, m, p, q, v, x) but not others.
                             // To compensate for that, if the current event
                             // is a repeat, and the IME previously generated
                             // `Acted`, we will assume that we're safe to replay
@@ -2689,7 +2689,11 @@ impl WindowView {
 
             if let Some(myself) = Self::get_this(this) {
                 let mut inner = myself.inner.borrow_mut();
-                inner.ime_last_event.take();
+                // Don't clear the last IME event when a key is up otherwise it
+                // could mess up the succeeding key repeats.
+                if key_is_down {
+                    inner.ime_last_event.take();
+                }
                 inner.events.dispatch(WindowEvent::KeyEvent(event));
             }
         }


### PR DESCRIPTION
# Issue

When certain keys [1] are pressed and held before a previously held key is released, the key up event from the previously held key will prevent the new key from repeating. More details in #4061.

# Approach

The immediate reason of this is that the key up event clears `ime_last_event` which subsequently clears `ime_state` hence breaks the logic guarded by this comment:
```
// ... if the current event
// is a repeat, and the IME previously generated
// `Acted`, we will assume that we're safe to replay
// that last action.
```

Since, IMO, IME events are generally associated with key being pressed down, I'm adding a simple check in `key_common` to prevent the event from being cleared by a key up event.

Technically there're other places that clear `ime_last_event`, but I'm limiting my change to the immediate blast radius of the issue for simplicity.

# Test Plan

1. `cargo test --all`
2. Verified the said issue wouldn't happen anymore by holding `k` -> holding `j` -> releasing `k`.

***

[1] - b, f, j, m, p, q, v, x to be exact. The accent menu won't be loaded for these characters on macOS anyway.