### PR TITLE
fix: better handling of hyperlinks with parentheses

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1666,9 +1666,11 @@ pub fn default_hyperlink_rules() -> Vec<hyperlink::Rule> {
         hyperlink::Rule::with_highlight(r"\((\w+://\S+)\)", "$1", 1).unwrap(),
         hyperlink::Rule::with_highlight(r"\[(\w+://\S+)\]", "$1", 1).unwrap(),
         hyperlink::Rule::with_highlight(r"<(\w+://\S+)>", "$1", 1).unwrap(),
-        // Then handle URLs not wrapped in brackets
-        // and include terminating ), / or - characters, if any
-        hyperlink::Rule::new(r"\b\w+://\S+[)/a-zA-Z0-9-]+", "$0").unwrap(),
+        // Then handle URLs not wrapped in brackets that
+        // 1) have a balanced ending parenthesis or
+        hyperlink::Rule::new(hyperlink::CLOSING_PARENTHESIS_HYPERLINK_PATTERN, "$0").unwrap(),
+        // 2) include terminating _, / or - characters, if any
+        hyperlink::Rule::new(hyperlink::GENERIC_HYPERLINK_PATTERN, "$0").unwrap(),
         // implicit mailto link
         hyperlink::Rule::new(r"\b\w+@[\w-]+(\.[\w-]+)+\b", "mailto:$0").unwrap(),
     ]

--- a/termwiz/src/hyperlink.rs
+++ b/termwiz/src/hyperlink.rs
@@ -265,6 +265,9 @@ impl<'t> Match<'t> {
         result
     }
 }
+pub const CLOSING_PARENTHESIS_HYPERLINK_PATTERN: &str =
+    r"\b\w+://[^\s()]*\(\S*\)(?=\s|$|[^_-/a-zA-Z0-9])";
+pub const GENERIC_HYPERLINK_PATTERN: &str = r"\b\w+://\S+[_-/a-zA-Z0-9]";
 
 impl Rule {
     /// Construct a new rule.  It may fail if the regex is invalid.
@@ -345,6 +348,53 @@ mod test {
                     link: Arc::new(Hyperlink::new_implicit("mailto:foo@example.com")),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn parse_with_parentheses() {
+        fn assert_helper(test_uri: &str, expected_uri: &str, msg: &str) {
+            let rules = vec![
+                Rule::new(CLOSING_PARENTHESIS_HYPERLINK_PATTERN, "$0").unwrap(),
+                Rule::new(GENERIC_HYPERLINK_PATTERN, "$0").unwrap(),
+            ];
+
+            assert_eq!(
+                Rule::match_hyperlinks(test_uri, &rules)[0].link.uri,
+                expected_uri,
+                "{}",
+                msg,
+            );
+        }
+
+        assert_helper(
+            "   http://example.com)",
+            "http://example.com",
+            "Unblanced terminating parenthesis should not be captured.",
+        );
+
+        assert_helper(
+            "http://example.com/(complete_parentheses)",
+            "http://example.com/(complete_parentheses)",
+            "Balanced terminating parenthesis should be captureed.",
+        );
+
+        assert_helper(
+            "http://example.com/(complete_parentheses)>",
+            "http://example.com/(complete_parentheses)",
+            "Non-URL characters after a balanced terminating parenthesis should be dropped.",
+        );
+
+        assert_helper(
+            "http://example.com/(complete_parentheses))",
+            "http://example.com/(complete_parentheses))",
+            "Non-terminating parentheses should not impact matching the entire URL - Terminated with )",
+        );
+
+        assert_helper(
+            "http://example.com/(complete_parentheses)-((-)-()-_-",
+            "http://example.com/(complete_parentheses)-((-)-()-_-",
+            "Non-terminating parentheses should not impact matching the entire URL - Terminated with a valid character",
         );
     }
 }


### PR DESCRIPTION
# Problem

I noticed there're a few cases where hyperlinks aren't handled correctly (see added unit tests). The root cause is that `)` is a confusing character in the context of URL and we should probably add more checks while doing the regex matching.

Also the [example explicit link](https://github.com/psyclaudeZ/wezterm/blob/main/docs/hyperlinks.md#explicit-hyperlinks) isn't clickable. 

# Approach

Instead of handle the exhaustive list of cases of `)` (which is inefficient and complicated), I decided to focus on the case where there's a terminating `)`. Particularly, I split the original regex into two: 1) match a URL with an explicit terminating `)` 2) mach a URL  with other "safe" terminating characters.

I also added `_` to the safe terminating character list.

Also added unit tests.

# Test Plan

Unit test.

`cargo build` and ran through a few examples.

I didn't explicitly attempt to fix the explicit hyperlink example. But after this regex change, `printf '\e]8;;http://example.com\e\\This is a link\e]8;;\e\\\n'` will actually generate a clickable link.