### PR TITLE
chore: resolve nit from linter

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -678,7 +678,7 @@ impl HasDisplayHandle for Window {
 
 impl HasWindowHandle for Window {
     fn window_handle(&self) -> Result<WindowHandle, HandleError> {
-        let mut handle =
+        let handle =
             AppKitWindowHandle::new(NonNull::new(self.ns_view as *mut _).expect("non-null"));
         unsafe { Ok(WindowHandle::borrow_raw(RawWindowHandle::AppKit(handle))) }
     }


### PR DESCRIPTION
Just picked up Rust, but I don't think this will be a breaking change?

```
qwarning: variable does not need to be mutable
   --> window/src/os/macos/window.rs:681:13
    |
681 |         let mut handle =
    |             ----^^^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default


```