### PR TITLE
fix: opening the InputSelector resulted in invalid pane ids

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2265,7 +2265,7 @@ impl TermWindow {
             None => return,
         };
 
-        let pane = match self.get_active_pane_or_overlay() {
+        let pane = match self.get_active_pane_no_overlay() {
             Some(pane) => pane,
             None => return,
         };

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2265,6 +2265,8 @@ impl TermWindow {
             None => return,
         };
 
+        // Ignore any current overlay: we're going to cancel it out below
+        // and we don't want this new one to reference that cancelled pane
         let pane = match self.get_active_pane_no_overlay() {
             Some(pane) => pane,
             None => return,


### PR DESCRIPTION
When starting a selector (InputSelector) overlay while having another overlay open the pane you get in the handler is the pane id of the previous overlay which is also cancelled when assigning the overlay which effectively makes it useless.
This is annoying if you need the pane from an InputSelector and the user opens the InputSelector multiple times in a row (perhaps looking to get other options if those are dynamically generated)
This is more of a band-aid I think and it might be a problem more often, maybe we/I can look into addressing this case in a better way.
Any feedback is appreciated :)