### PR TITLE
QuickSelectArgs: optionally bypass custom action on paste

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -446,7 +446,7 @@ pub struct QuickSelectArguments {
     pub patterns: Vec<String>,
     #[dynamic(default)]
     pub action: Option<Box<KeyAssignment>>,
-    /// Call `action` after paste is performed (capital selection)
+    /// Skip triggering `action` after paste is performed (capital selection)
     #[dynamic(default)]
     pub skip_action_on_paste: bool,
     /// Label to use in place of "copy" when `action` is set

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -446,10 +446,13 @@ pub struct QuickSelectArguments {
     pub patterns: Vec<String>,
     #[dynamic(default)]
     pub action: Option<Box<KeyAssignment>>,
+    /// Call `action` after paste is performed (capital selection)
+    #[dynamic(default)]
+    pub skip_action_on_paste: bool,
     /// Label to use in place of "copy" when `action` is set
     #[dynamic(default)]
     pub label: String,
-    /// How man lines before and how many lines after the viewport to
+    /// How many lines before and how many lines after the viewport to
     /// search to produce the quickselect results
     pub scope_lines: Option<usize>,
 }

--- a/docs/config/lua/keyassignment/QuickSelectArgs.md
+++ b/docs/config/lua/keyassignment/QuickSelectArgs.md
@@ -31,6 +31,7 @@ The `QuickSelectArgs` struct allows for the following fields:
 * `patterns` - if present, completely overrides the normal set of patterns and uses only the patterns specified
 * `alphabet` - if present, this alphabet is used instead of [quick_select_alphabet](../config/quick_select_alphabet.md)
 * `action` - if present, this key assignment action is performed as if by [window:perform_action](../window/perform_action.md) when an item is selected.  The normal clipboard action is NOT performed in this case.
+* `skip_action_on_paste` - overrides whether `action` is performed after an item is selected using a capital value (when paste occurs).
 * `label` - if present, replaces the string `"copy"` that is shown at the bottom of the overlay; you can use this to indicate which action will happen if you are using `action`.
 * `scope_lines` - Specify the number of lines to search above and below the current viewport. The default is 1000 lines. The scope will be increased to the current viewport height if it is smaller than the viewport. {{since('20220807-113146-c2fee766', inline=True)}}. In earlier releases, the entire scrollback was always searched).
 
@@ -50,6 +51,7 @@ config.keys = {
       patterns = {
         'https?://\\S+',
       },
+      skip_action_on_paste = true,
       action = wezterm.action_callback(function(window, pane)
         local url = window:get_selection_text_for_pane(pane)
         wezterm.log_info('opening: ' .. url)

--- a/docs/config/lua/keyassignment/QuickSelectArgs.md
+++ b/docs/config/lua/keyassignment/QuickSelectArgs.md
@@ -31,7 +31,7 @@ The `QuickSelectArgs` struct allows for the following fields:
 * `patterns` - if present, completely overrides the normal set of patterns and uses only the patterns specified
 * `alphabet` - if present, this alphabet is used instead of [quick_select_alphabet](../config/quick_select_alphabet.md)
 * `action` - if present, this key assignment action is performed as if by [window:perform_action](../window/perform_action.md) when an item is selected.  The normal clipboard action is NOT performed in this case.
-* `skip_action_on_paste` - overrides whether `action` is performed after an item is selected using a capital value (when paste occurs).
+* `skip_action_on_paste` - overrides whether `action` is performed after an item is selected using a capital value (when paste occurs). {{since('nightly', inline=True)}}
 * `label` - if present, replaces the string `"copy"` that is shown at the bottom of the overlay; you can use this to indicate which action will happen if you are using `action`.
 * `scope_lines` - Specify the number of lines to search above and below the current viewport. The default is 1000 lines. The scope will be increased to the current viewport height if it is smaller than the viewport. {{since('20220807-113146-c2fee766', inline=True)}}. In earlier releases, the entire scrollback was always searched).
 

--- a/docs/quickselect.md
+++ b/docs/quickselect.md
@@ -23,7 +23,7 @@ do next; typing in a highlighted prefix will cause that text to be selected and
 copied to the clipboard, and quick select mode will be cancelled.
 
 Typing in the uppercase form of the prefix will copy AND paste the highlighted
-text, and cancel quick select mod.
+text, and cancel quick select mode.
 
 Pressing `ESCAPE` will cancel quick select mode.
 

--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -914,6 +914,7 @@ impl QuickSelectRenderable {
 
         let pane_id = self.delegate.pane_id();
         let action = self.args.action.clone();
+        let skip_action_on_paste = self.args.skip_action_on_paste;
         self.window
             .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
                 let mux = mux::Mux::get();
@@ -942,7 +943,9 @@ impl QuickSelectRenderable {
                             let _ = pane.send_paste(&text);
                         }
                         if let Some(action) = action {
-                            let _ = term_window.perform_key_assignment(&pane, &action);
+                            if !paste || !skip_action_on_paste {
+                                let _ = term_window.perform_key_assignment(&pane, &action);
+                            }
                         } else {
                             term_window.copy_to_clipboard(
                                 ClipboardCopyDestination::ClipboardAndPrimarySelection,


### PR DESCRIPTION
QuickSelect will paste the selection when the capitalized selection form is used. This is fine on its own when dealing with the default actions (lower=copy upper=copy+paste), but can cause odd behavior for QuickSelectArgs when a custom action is defined.

The example used in the docs for QuickSelectArgs (opening a URL) I believe is one of those cases where we'd want to perform a paste but NOT perform the action when a capitalized selection is used. Without the option, the user would experience both a paste of the URL as well as their browser opening the link.

In this PR I'm proposing the addition of a `paste_performs_action` override option for QuickSelectArgs which will allow users to disable this behavior. For the URL open case, when disabled, capital selection would only paste and not open the URL. I've defaulted the option to `true` to persist the current behavior.