### PR TITLE
Add font and window geometry settings to "Quick Start" example config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt build check test
+.PHONY: all fmt build check test docs servedocs
 
 all: build
 
@@ -22,6 +22,8 @@ build:
 fmt:
 	cargo +nightly fmt
 
-.PHONY: docs
 docs:
 	ci/build-docs.sh
+
+servedocs:
+	ci/build-docs.sh serve

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,6 @@ build:
 fmt:
 	cargo +nightly fmt
 
+.PHONY: docs
+docs:
+	ci/build-docs.sh

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -11,14 +11,25 @@ local wezterm = require 'wezterm'
 -- This will hold the configuration.
 local config = wezterm.config_builder()
 
--- This is where you actually apply your config choices
+-- This is where you actually apply your config choices.
 
--- For example, changing the color scheme:
+-- For example, changing the initial geometry for new windows:
+config.initial_cols = 120
+config.initial_rows = 28
+
+-- or, changing the font size and color scheme.
+config.font_size = 10
 config.color_scheme = 'AdventureTime'
 
--- and finally, return the configuration to wezterm
+-- Finally, return the configuration to wezterm:
 return config
 ```
+
+_See [wezterm.config_builder](lua/wezterm/config_builder.md),
+[initial_cols](lua/config/initial_cols.md),
+[initial_rows](lua/config/initial_rows.md),
+[font_size](lua/config/font_size.md), and
+[color_scheme](lua/config/color_schemes.md) for details._
 
 ## Configuration Files
 

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -25,11 +25,13 @@ config.color_scheme = 'AdventureTime'
 return config
 ```
 
-_See [wezterm.config_builder](lua/wezterm/config_builder.md),
-[initial_cols](lua/config/initial_cols.md),
-[initial_rows](lua/config/initial_rows.md),
-[font_size](lua/config/font_size.md), and
-[color_scheme](lua/config/color_schemes.md) for details._
+For more details, see:
+
+- [wezterm.config_builder](lua/wezterm/config_builder.md)
+- [initial_cols](lua/config/initial_cols.md)
+- [initial_rows](lua/config/initial_rows.md)
+- [font_size](lua/config/font_size.md)
+- [color_scheme](lua/config/color_schemes.md)
 
 ## Configuration Files
 


### PR DESCRIPTION
No matter what search terms I tried, for the life of me I couldn't find the config setting for initial window geometry using the docs site's built-in search.

Really the config settings to set the initial window geometry are quite straightforward, they're just not surfaced in the docs (IMO) in a place where a new user would expect to see them.

What this PR does is put those config settings front and center, right in [the "Quick Start"](https://wezfurlong.org/wezterm/config/files.html#quick-start) section.

As an entertaining aside, I tried asking a chatbot LLM and it hallucinated some very-plausible-but-nonexistent wezterm config settings. So eventually I turned to the issue tracker, discovered #256 with a search, where others mentioned similiar problems finding these settings in the docs.