### PR TITLE
macOS: drag-n-drop folder into the app icon

### DIFF
--- a/assets/macos/WezTerm.app/Contents/Info.plist
+++ b/assets/macos/WezTerm.app/Contents/Info.plist
@@ -99,6 +99,16 @@
 				<string>public.unix-executable</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.directory</string>
+				<string>com.apple.bundle</string>
+				<string>com.apple.resolvable</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>

--- a/window/src/connection.rs
+++ b/window/src/connection.rs
@@ -23,6 +23,7 @@ pub fn shutdown() {
 pub enum ApplicationEvent {
     /// The system wants to open a command in the terminal
     OpenCommandScript(String),
+    OpenDirectory(String),
     PerformKeyAssignment(KeyAssignment),
 }
 

--- a/window/src/os/macos/app.rs
+++ b/window/src/os/macos/app.rs
@@ -121,9 +121,14 @@ extern "C" fn application_open_file(
     let launched: BOOL = unsafe { *this.get_ivar("launched") };
     if launched == YES {
         let file_name = unsafe { nsstring_to_str(file_name) }.to_string();
+        let path = std::path::Path::new(&file_name);
         if let Some(conn) = Connection::get() {
             log::debug!("application_open_file {file_name}");
-            conn.dispatch_app_event(ApplicationEvent::OpenCommandScript(file_name));
+            if path.is_dir() {
+                conn.dispatch_app_event(ApplicationEvent::OpenDirectory(file_name));
+            } else {
+                conn.dispatch_app_event(ApplicationEvent::OpenCommandScript(file_name));
+            }
         }
     }
 }

--- a/window/src/os/macos/app.rs
+++ b/window/src/os/macos/app.rs
@@ -118,7 +118,7 @@ extern "C" fn application_open_file(
     _sel: Sel,
     _app: *mut Object,
     file_name: *mut Object,
-) {
+) -> BOOL {
     let file_name = unsafe { nsstring_to_str(file_name) }.to_string();
     let path = std::path::Path::new(&file_name);
     if let Some(conn) = Connection::get() {
@@ -128,7 +128,9 @@ extern "C" fn application_open_file(
         } else {
             conn.dispatch_app_event(ApplicationEvent::OpenCommandScript(file_name));
         }
+        return YES;
     }
+    NO
 }
 
 extern "C" fn application_dock_menu(
@@ -165,7 +167,7 @@ fn get_class() -> &'static Class {
             );
             cls.add_method(
                 sel!(application:openFile:),
-                application_open_file as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object),
+                application_open_file as extern "C" fn(&mut Object, Sel, *mut Object, *mut Object) -> BOOL,
             );
             cls.add_method(
                 sel!(applicationDockMenu:),


### PR DESCRIPTION
This implements #3975: macOS: drag-n-drop folder into the app icon

This requires in the _Info.plist_ to expand the  _CFBundleDocumentTypes_ array (copied the parts of the definition from _Terminal.app/Contents/Info.plist_). With this in place, the _application:openFile:_ gets called. I copied the existing OpenCommandScript code and adapted it.

This enables to open folders by drag-n-drop into the app icon, most commonly when in the Dock. But it also allows other applications to open wezterm at a certain directory.

Example Script:
```bash
# opens that directory in WezTerm (Path)
open -a ~/Downloads/WezTerm-macos-20240203-110809-5046fc22/WezTerm.app ~/Downloads/WezTerm-macos-20240203-110809-5046fc22

# opens that directory in WezTerm (Bundle ID)
open -b com.github.wez.wezterm ~/Downloads/WezTerm-macos-20240203-110809-5046fc22
```

Example Objective-C:
```objc
NSWorkspace *workspace = NSWorkspace.sharedWorkspace;
NSURL *appURL = [workspace URLForApplicationWithBundleIdentifier:@"com.github.wez.wezterm"];
if (appURL) {
	NSWorkspaceOpenConfiguration *configuration = [NSWorkspaceOpenConfiguration configuration];
	[workspace openURLs:@[url] withApplicationAtURL:appURL configuration:configuration completionHandler:^(NSRunningApplication *application, NSError *error) {
		if (error) {
			completionHandler(NO, error);
		} else {
			completionHandler(YES, nil);
		}
	}];
}
```

Todo:
* When WezTerm is launched with a directory to open, only open one window with the directory as cwd. Currently the default window opens and a window with the directory as cwd. I don't have a rust dev env, so I can't debug this.