### PR TITLE
fix mouse button streak requiring pixel precision

### DIFF
--- a/term/src/input.rs
+++ b/term/src/input.rs
@@ -80,7 +80,8 @@ impl LastMouseClick {
     pub fn add(&self, button: MouseButton, position: ClickPosition) -> Self {
         let now = Instant::now();
         let streak = if button == self.button
-            && position == self.position
+            && position.column == self.position.column
+            && position.row == self.position.row
             && now.duration_since(self.time) <= Duration::from_millis(CLICK_INTERVAL)
         {
             self.streak + 1


### PR DESCRIPTION
The fix made for #1805 introduced a problem where the multiple clicks must be done in the same pixel because the add of pixel offset in ClickPosition.

Multiple clicks in same character but with a little pixel displacement should be taken as multiple clicks as was before #1805.

This pull updates term/src/input.rs function LastMouseClick.add to check streak only if position.column and position.row matches, instead of checking full position with pixel offsets, fixing #6475.