### PR TITLE
docs: replace %HOME% with %USERPROFILE% for Windows

### DIFF
--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -27,7 +27,7 @@ configuration file using the logic shown below.
 
 !!! tip
     The recommendation is to place your configuration file at `$HOME/.wezterm.lua`
-    (`%HOME%/.wezterm.lua` on Windows) to get started.
+    (`%USERPROFILE%/.wezterm.lua` on Windows) to get started.
 
 More complex configurations that need to span multiple files can be placed in
 `$XDG_CONFIG_HOME/wezterm/wezterm.lua` (for X11/Wayland) or


### PR DESCRIPTION
`%HOME%` is not a thing on Windows, `%USERPROFILE%` is.
![image](https://github.com/user-attachments/assets/45bf671b-7329-4a7c-a7b9-70af2f53761c)


Apologies, I messed up the commit name a bit by doing so:
![image](https://github.com/user-attachments/assets/44498f8c-1a59-4076-9138-60bb2e348e48)
