### PR TITLE
Make rustflags in cargo config an array

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,4 @@ ar = "x86_64-w64-mingw32-gcc-ar"
 # and openssl-src does that based on the crt-static feature being
 # enabled for the target, so let's turn that on here.
 [target.x86_64-pc-windows-msvc]
-rustflags = "-C target-feature=+crt-static"
+rustflags = ["-C target-feature=+crt-static"]


### PR DESCRIPTION
If you have top-level cargo settings that set rustflags in some parent directory you can't build wezterm from source because a string and an array can't be merged. This fixes that, and better matches the [reference](https://doc.rust-lang.org/cargo/reference/config.html) where rustflags is an array.