### PR TITLE
Compute background dimensions preserving aspect ratio.

### DIFF
--- a/wezterm-gui/src/termwindow/background.rs
+++ b/wezterm-gui/src/termwindow/background.rs
@@ -489,20 +489,22 @@ impl crate::TermWindow {
             ((pixel_height * aspect).floor(), pixel_height)
         };
         
-        let computed_background_height = match layer.def.height {
-            BackgroundSize::Cover => match layer.def.width {
-                BackgroundSize::Dimension(n) => (n.evaluate_as_pixels(h_context) / aspect) as f32,
-                _ => min_aspect_height,
-            }
-            _ => min_aspect_height,
+        // Compute image height preserving aspect ratio.
+        let computed_background_height = if let (
+            BackgroundSize::Cover, BackgroundSize::Dimension(width)
+        ) = (layer.def.height, layer.def.width) {
+            (width.evaluate_as_pixels(h_context) / aspect).floor()
+        } else {
+            min_aspect_height
         };
 
-        let computed_background_width = match layer.def.width {
-            BackgroundSize::Cover => match layer.def.height {
-                BackgroundSize::Dimension(n) => (n.evaluate_as_pixels(v_context) * aspect).floor(),
-                _ => min_aspect_width,
-            }
-            _ => min_aspect_width,
+        // Compute width preserving aspect ratio.
+        let computed_background_width = if let (
+            BackgroundSize::Cover, BackgroundSize::Dimension(height)
+        ) = (layer.def.width, layer.def.height) {
+            (height.evaluate_as_pixels(h_context) * aspect).floor()
+        } else {
+            min_aspect_width
         };
 
         let width = match layer.def.width {

--- a/wezterm-gui/src/termwindow/background.rs
+++ b/wezterm-gui/src/termwindow/background.rs
@@ -488,16 +488,32 @@ impl crate::TermWindow {
         } else {
             ((pixel_height * aspect).floor(), pixel_height)
         };
+        
+        let computed_background_height = match layer.def.height {
+            BackgroundSize::Cover => match layer.def.width {
+                BackgroundSize::Dimension(n) => (n.evaluate_as_pixels(h_context) / aspect) as f32,
+                _ => min_aspect_height,
+            }
+            _ => min_aspect_height,
+        };
+
+        let computed_background_width = match layer.def.width {
+            BackgroundSize::Cover => match layer.def.height {
+                BackgroundSize::Dimension(n) => (n.evaluate_as_pixels(v_context) * aspect).floor(),
+                _ => min_aspect_width,
+            }
+            _ => min_aspect_width,
+        };
 
         let width = match layer.def.width {
             BackgroundSize::Contain => max_aspect_width as f32,
-            BackgroundSize::Cover => min_aspect_width as f32,
+            BackgroundSize::Cover => computed_background_width as f32,
             BackgroundSize::Dimension(n) => n.evaluate_as_pixels(h_context),
         };
 
         let height = match layer.def.height {
             BackgroundSize::Contain => max_aspect_height as f32,
-            BackgroundSize::Cover => min_aspect_height as f32,
+            BackgroundSize::Cover => computed_background_height as f32,
             BackgroundSize::Dimension(n) => n.evaluate_as_pixels(v_context),
         };
 


### PR DESCRIPTION
## Compute background dimensions preserving original aspect ratio.

### The problem I'm trying to solve:
In my config I'm setting many different backgrounds, for all of them I'm typically setting custom `width` and `height`, so for each one of them I have to manually compute the right values based on aspect ratio. And since my images have different aspect ratios I'm find the process a bit tedious.

### Current Behavior
Currently, wezterm supports size="**Cover**" which, as the documentation states: "scales the image to the smallest possible size to fill the viewport". 

### What I'm doing in this changeset?
In this PR I'm adding additional behavior for the mentioned unit, so, If only one of the dimension attributes is set to `Cover` (example height=Cover, width=200), the value of the mentioned attribute will be computed based on the dimension assigned to the other one, and of course, preserving the aspect ratio.

BTW, even though I used to do C many (many) years ago, I'm not familiar with rust AT ALL (I'm just learning some bits today after reading your code), so bear with me if things are not good enough.

### Are there any other ways to approach this use-case?
Yeah, we could also introduce a new unit type?, example width="auto", but I was not sure so I decided to keep this simple,  (to me, the current approach in this PR makes sense and feels like easy to use).

## Examples:

### 1) Compute height based image width:
Here I'm setting an arbitrary width = 550px while I set height=Cover.
```
    background = {
        source = {
            File = wezterm.config_dir .. "/backgrounds/1.png",
        },
        vertical_align = "Bottom",
        horizontal_align = "Right",
        width = "550", 
	height = "Cover",
        repeat_x = "NoRepeat",
        repeat_y = "NoRepeat",
    },
```

#### Before:

<img width="1153" alt="image" src="https://github.com/user-attachments/assets/753391de-99fd-47d6-a177-a096b18369b5" />


#### After:
<img width="1324" alt="image" src="https://github.com/user-attachments/assets/26859293-8f3f-4d78-bfeb-b2a26d0a4792" />

### 2) Compute correct width based on user provided height:
```
    background = {
        source = {
            File = wezterm.config_dir .. "/backgrounds/1.png",
        },
        vertical_align = "Bottom",
        horizontal_align = "Right",
        width = "Cover", 
        height = "754.6",
	width = "Cover",
        repeat_x = "NoRepeat",
        repeat_y = "NoRepeat",
    },

```

#### Before:
<img width="1153" alt="image" src="https://github.com/user-attachments/assets/067cde49-974f-444b-9006-3c9034e33b6a" />


#### After:

<img width="994" alt="image" src="https://github.com/user-attachments/assets/135cf59b-95b3-4e4c-b37a-798c51d99bcc" />
