### PR TITLE
feat: allow explicitly setting the window appearance on macOS

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -19,6 +19,7 @@ use crate::ssh::{SshBackend, SshDomain};
 use crate::tls::{TlsDomainClient, TlsDomainServer};
 use crate::units::Dimension;
 use crate::unix::UnixDomain;
+use crate::window::MacOSWindowAppearance;
 use crate::wsl::WslDomain;
 use crate::{
     default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
@@ -543,6 +544,10 @@ pub struct Config {
     /// Only works on MacOS
     #[dynamic(default)]
     pub macos_window_background_blur: i64,
+
+    /// Explicitly sets the window appearance on macOS.
+    #[dynamic(default)]
+    pub macos_window_appearance: MacOSWindowAppearance,
 
     /// Only works on Windows
     #[dynamic(default)]

--- a/config/src/window.rs
+++ b/config/src/window.rs
@@ -7,3 +7,11 @@ pub enum WindowLevel {
     Normal = 0,
     AlwaysOnTop = 3,
 }
+
+#[derive(Debug, Default, Clone, ToDynamic, PartialEq, Eq, FromDynamic)]
+pub enum MacOSWindowAppearance {
+    #[default]
+    System,
+    Light,
+    Dark,
+}

--- a/docs/config/lua/config/macos_window_appearance.md
+++ b/docs/config/lua/config/macos_window_appearance.md
@@ -1,0 +1,14 @@
+---
+tags:
+  - appearance
+---
+# `macos_window_appearance = "System"`
+
+{{since('nightly')}}
+
+This option allows explicitly the appearance of the window on macOS.
+
+The following values are supported:
+- `"System"`: Follow the system appearance. This is the default.
+- `"Light"`: Use the light appearance.
+- `"Dark"`: Use the dark appearance.

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -16,7 +16,7 @@ use crate::{
 use anyhow::{anyhow, bail, ensure};
 use async_trait::async_trait;
 use cocoa::appkit::{
-    self, CGFloat, NSApplication, NSApplicationActivateIgnoringOtherApps,
+    self, CGFloat, NSAppearance, NSApplication, NSApplicationActivateIgnoringOtherApps,
     NSApplicationPresentationOptions, NSBackingStoreBuffered, NSEvent, NSEventModifierFlags,
     NSOpenGLContext, NSOpenGLPixelFormat, NSPasteboard, NSRunningApplication, NSScreen, NSView,
     NSViewHeightSizable, NSViewWidthSizable, NSWindow, NSWindowStyleMask,
@@ -26,7 +26,7 @@ use cocoa::foundation::{
     NSArray, NSAutoreleasePool, NSFastEnumeration, NSInteger, NSNotFound, NSPoint, NSRect, NSSize,
     NSUInteger,
 };
-use config::window::WindowLevel;
+use config::window::{MacOSWindowAppearance, WindowLevel};
 use config::ConfigHandle;
 use core_foundation::base::{CFTypeID, TCFType};
 use core_foundation::bundle::{CFBundleGetBundleWithIdentifier, CFBundleGetFunctionPointerForName};
@@ -602,6 +602,13 @@ impl Window {
             );
             window.setContentView_(*view);
             window.setDelegate_(*view);
+
+            let appearance = match config.macos_window_appearance {
+                MacOSWindowAppearance::System => nil,
+                MacOSWindowAppearance::Light => NSAppearance(*nsstring("NSAppearanceNameAqua")),
+                MacOSWindowAppearance::Dark => NSAppearance(*nsstring("NSAppearanceNameDarkAqua")),
+            };
+            NSWindow::setAppearance(*window, appearance);
 
             view.setWantsLayer(YES);
             let () = msg_send![


### PR DESCRIPTION
Adds a new option `macos_window_appearance` allowing users to specify the appearance (e.g., dark, light) of the window.

Close #5281 