### PR TITLE
feat: reorder tabs via left mouse drag

### DIFF
--- a/docs/config/lua/keyassignment/MoveTabRelative.md
+++ b/docs/config/lua/keyassignment/MoveTabRelative.md
@@ -4,6 +4,8 @@ Move the current tab relative to its peers.  The argument specifies an
 offset. eg: `-1` moves the tab to the left of the current tab, while `1` moves
 the tab to the right.
 
+It is also possible to reorder tabs via left mouse drag on the tab bar entry.
+
 ```lua
 local act = wezterm.action
 


### PR DESCRIPTION
Relates to #549

Be able to reorder tabs within a window via left mouse drag. Doesn't have animation dragging (like on Konsole), so it looks snappy for now.

[Screencast_20241230_204103.webm](https://github.com/user-attachments/assets/c612f8b6-f03d-4e2a-95fa-f2ca6b5ca39f)
