### PR TITLE
Copy terminfo into MacOS app resources

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -35,7 +35,7 @@ case $OSTYPE in
     mkdir -p $zipdir/WezTerm.app/Contents/Resources
     cp -r assets/shell-integration/* $zipdir/WezTerm.app/Contents/Resources
     cp -r assets/shell-completion $zipdir/WezTerm.app/Contents/Resources
-    tic -xe wezterm -o $zipdir/WezTerm.app/Contents/Resources/terminfo termwiz/data/wezterm.info
+    tic -xe wezterm -o $zipdir/WezTerm.app/Contents/Resources/terminfo termwiz/data/wezterm.terminfo
 
     for bin in wezterm wezterm-mux-server wezterm-gui strip-ansi-escapes ; do
       # If the user ran a simple `cargo build --release`, then we want to allow

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -35,6 +35,7 @@ case $OSTYPE in
     mkdir -p $zipdir/WezTerm.app/Contents/Resources
     cp -r assets/shell-integration/* $zipdir/WezTerm.app/Contents/Resources
     cp -r assets/shell-completion $zipdir/WezTerm.app/Contents/Resources
+    tic -xe wezterm -o $zipdir/WezTerm.app/Contents/Resources/terminfo termwiz/data/wezterm.info
 
     for bin in wezterm wezterm-mux-server wezterm-gui strip-ansi-escapes ; do
       # If the user ran a simple `cargo build --release`, then we want to allow


### PR DESCRIPTION
Currently the terminfo file has to be downloaded from the repo and installed manually. It'd be nice to include it in the app so that a package manager like Homebrew could install it in the right place when Wezterm is installed, which is something that Alacritty does.

I've chosen to include the compiled version so that package manager don't have to invoke `tic` and can just copy files around.

This will result in the following being added to the Resources folder:
```
WezTerm.app/Contents/Resources/terminfo/77/wezterm
```

Once this is in I'll send [a patch](https://github.com/Homebrew/homebrew-cask/compare/master...ddeville:homebrew-cask:wezterm-terminfo) to update the [Homebrew formula](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/w/wezterm.rb) and have it actually install the terminfo.