### PR TITLE
fix: setting width and height to `Contain` is not preserving aspect ratio of tall images

### DIFF
--- a/wezterm-gui/src/termwindow/background.rs
+++ b/wezterm-gui/src/termwindow/background.rs
@@ -471,7 +471,7 @@ impl crate::TermWindow {
             }
         } else {
             // Height is the longest side
-            let target_width = pixel_height / aspect;
+            let target_width = pixel_height * aspect;
             if target_width > pixel_width {
                 (
                     pixel_width,

--- a/wezterm-gui/src/termwindow/background.rs
+++ b/wezterm-gui/src/termwindow/background.rs
@@ -438,11 +438,11 @@ impl crate::TermWindow {
 
         let pixel_width = self.dimensions.pixel_width as f32;
         let pixel_height = self.dimensions.pixel_height as f32;
-        let pixel_aspect = pixel_width / pixel_height;
-
         let tex_width = sprite.coords.width() as f32;
         let tex_height = sprite.coords.height() as f32;
-        let aspect = tex_width as f32 / tex_height as f32;
+
+        let scale_width = pixel_width / tex_width as f32;
+        let scale_height = pixel_height / tex_height as f32;
 
         let h_context = DimensionContext {
             dpi: self.dimensions.dpi as f32,
@@ -457,47 +457,26 @@ impl crate::TermWindow {
 
         // log::info!("tex {tex_width}x{tex_height} aspect={aspect}");
 
-        // Compute the largest aspect-preserved size that will fill the space
-        let (max_aspect_width, max_aspect_height) = if aspect >= 1.0 {
-            // Width is the longest side
-            let target_height = pixel_width / aspect;
-            if target_height > pixel_height {
-                (
-                    (pixel_width * pixel_height / target_height).floor(),
-                    pixel_height,
-                )
-            } else {
-                (pixel_width, target_height)
-            }
-        } else {
-            // Height is the longest side
-            let target_width = pixel_height * aspect;
-            if target_width > pixel_width {
-                (
-                    pixel_width,
-                    (pixel_height * pixel_width / target_width).floor(),
-                )
-            } else {
-                (target_width, pixel_height)
-            }
-        };
-
         // Compute the smallest aspect-preserved size that will fit the space
-        let (min_aspect_width, min_aspect_height) = if pixel_aspect > aspect {
-            (pixel_width, (pixel_width / aspect).floor())
-        } else {
-            ((pixel_height * aspect).floor(), pixel_height)
+        let (min_aspect_width, min_aspect_height) = {
+            let scale = scale_width.min(scale_height);
+            (tex_width * scale, tex_height * scale)
+        };
+        // Compute the largest aspect-preserved size that will fill the space
+        let (max_aspect_width, max_aspect_height) = {
+            let scale = scale_width.max(scale_height);
+            (tex_width * scale, tex_height * scale)
         };
 
         let width = match layer.def.width {
-            BackgroundSize::Contain => max_aspect_width as f32,
-            BackgroundSize::Cover => min_aspect_width as f32,
+            BackgroundSize::Contain => min_aspect_width as f32,
+            BackgroundSize::Cover => max_aspect_width as f32,
             BackgroundSize::Dimension(n) => n.evaluate_as_pixels(h_context),
         };
 
         let height = match layer.def.height {
-            BackgroundSize::Contain => max_aspect_height as f32,
-            BackgroundSize::Cover => min_aspect_height as f32,
+            BackgroundSize::Contain => min_aspect_height as f32,
+            BackgroundSize::Cover => max_aspect_height as f32,
             BackgroundSize::Dimension(n) => n.evaluate_as_pixels(v_context),
         };
 


### PR DESCRIPTION
fixes #3708, fixes #4407

---

The scaling for `"Contain"` uses the wrong direct proportion formula for tall images. This is due to the image's `aspect` being `width / height`. The original formula `scaled_width = scaled_height / aspect` expands to
```math
\frac{\text{scaled\_width}}{\text{scaled\_height}} = \frac{\text{height}}{\text{width}}
```
which inversely scaled the width of tall images. 

The formula is now based on two scaling factors based on the image's dimension relative to the window's. Now, only one computation is needed to cover for all scenarios of computing width instead of having to go through if else branches. Same goes for height.
```math
\text{scale\_width} = \frac{\text{window\_width}}{\text{image\_width}}
```
```math
\text{scale\_height} = \frac{\text{window\_height}}{\text{image\_height}}
```
These were derived from the principle of direct proportion `k=x/y` where `k` is a scaling factor, and `x` `y` are the widths of the image and window for example. The larger `k` is, the larger the window is relative to the image on the width side. Same goes for the height.

Contain needs the minimum scaling factor to ensure both dimensions fit within the window. Cover needs the maximum scaling factor to ensure the image's smaller dimension fits in the window, allowing the larger dimension to crop, as expected. Both of which are the behavior described in the docs.

## Example
config used
```lua
local wezterm = require("wezterm")
local config = wezterm.config_builder()

config.background = {
	{
		source = {
			Color = "#161616",
		},
		height = "100%",
		width = "100%",
	},
	{
		source = {
			File = os.getenv("HOME") .. "/pictures/wt_bg/center-uniform-0.1/drip yo.jpg",
		},
		width = --[[ VARIABLE ]],
		height =  --[[ VARIABLE ]],
		vertical_align = "Top",
		horizontal_align = "Center",
		repeat_x = "NoRepeat",
		repeat_y = "NoRepeat",
		opacity = 0.2,
	},
}
config.enable_tab_bar = false

return config
```
1. with both width and height set to `"Contain"`

| old | new |
|---|---|
| ![image](https://github.com/user-attachments/assets/e1231711-80e0-4a74-994c-e01d5b30dfce) | ![image](https://github.com/user-attachments/assets/1262f924-5bf8-4ed6-a5f0-3e4b8c874c13) |

2. both width and height set to `"Cover"` (no changes)

| old | new |
|---|---|
| ![image](https://github.com/user-attachments/assets/22aea00c-7ad9-45c4-b574-37b82bf5a720) | ![image](https://github.com/user-attachments/assets/15761fcc-0379-47cb-b2ff-d1f8f5cfc1eb) |

[art](https://x.com/AZMC15/status/1479631341222531072) by [@AZMC15](https://x.com/AZMC15)