### PR TITLE
feat: enforce minimum contrast ratio for reverse video cursor

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -637,6 +637,8 @@ pub struct Config {
 
     #[dynamic(default)]
     pub force_reverse_video_cursor: bool,
+    #[dynamic(default = "default_reverse_video_cursor_min_contrast")]
+    pub reverse_video_cursor_min_contrast: f32,
 
     /// Specifies the default cursor style.  various escape sequences
     /// can override the default style in different situations (eg:
@@ -1902,6 +1904,10 @@ const fn default_one_cell() -> Dimension {
 
 const fn default_half_cell() -> Dimension {
     Dimension::Cells(0.5)
+}
+
+const fn default_reverse_video_cursor_min_contrast() -> f32 {
+    2.5
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug)]

--- a/docs/config/lua/config/reverse_video_cursor_min_contrast.md
+++ b/docs/config/lua/config/reverse_video_cursor_min_contrast.md
@@ -5,6 +5,8 @@ tags:
 ---
 # `reverse_video_cursor_min_contrast = 2.5`
 
+{{since('nightly')}}
+
 The minimum contrast ratio required to use the reverse video cursor.
 
 When the contrast ratio between the reverse video cursor foreground and

--- a/docs/config/lua/config/reverse_video_cursor_min_contrast.md
+++ b/docs/config/lua/config/reverse_video_cursor_min_contrast.md
@@ -1,0 +1,12 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `reverse_video_cursor_min_contrast = 2.5`
+
+The minimum contrast ratio required to use the reverse video cursor.
+
+When the contrast ratio between the reverse video cursor foreground and
+background is below this threshold then the default cursor foreground and
+background will be used instead.


### PR DESCRIPTION
This PR ensures the reverse video cursor meets a minimum contrast ratio, otherwise the default fg/bg is used instead.

The minimum contrast ratio of `2.5` was chosen from the kitty implementation linked in https://github.com/wez/wezterm/discussions/2861.

The `SrgbaTuple::contrast_ratio` implementation also appeared to be incorrect since it was comparing lightness instead of luminance.

This should resolve https://github.com/wez/wezterm/discussions/2861.

### Before
<img src="https://github.com/user-attachments/assets/ae51a0d6-f87b-40f4-8446-9ec42beb405c" width="400px" /> <img src="https://github.com/user-attachments/assets/927b5dbf-8bfb-49a5-bade-d2dc8c21b285" width="400px" />

### After
<img src="https://github.com/user-attachments/assets/7d9fe03c-36c4-4eda-aae9-918e45d10a0c" width="400px" /> <img src="https://github.com/user-attachments/assets/89fccf5c-dde1-4317-8fa6-e5f6ca97dfe3" width="400px" />
