### PR TITLE
feat(macOS): add support to disable rounded corners on macOS

### DIFF
--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1975,7 +1975,8 @@ bitflags! {
         // so that we effective have Option<bool>
         const MACOS_FORCE_DISABLE_SHADOW = 4;
         const MACOS_FORCE_ENABLE_SHADOW = 4|8;
-        const INTEGRATED_BUTTONS = 16;
+        const MACOS_FORCE_SQUARE_CORNERS = 16;
+        const INTEGRATED_BUTTONS = 32;
     }
 }
 
@@ -1995,6 +1996,8 @@ impl Into<String> for &WindowDecorations {
             s.push("MACOS_FORCE_ENABLE_SHADOW");
         } else if self.contains(WindowDecorations::MACOS_FORCE_DISABLE_SHADOW) {
             s.push("MACOS_FORCE_DISABLE_SHADOW");
+        } else if self.contains(WindowDecorations::MACOS_FORCE_SQUARE_CORNERS) {
+            s.push("MACOS_FORCE_SQUARE_CORNERS");
         }
         if s.is_empty() {
             "NONE".to_string()
@@ -2020,6 +2023,8 @@ impl TryFrom<String> for WindowDecorations {
                 flags |= Self::MACOS_FORCE_DISABLE_SHADOW;
             } else if ele == "MACOS_FORCE_ENABLE_SHADOW" {
                 flags |= Self::MACOS_FORCE_ENABLE_SHADOW;
+            } else if ele == "MACOS_FORCE_SQUARE_CORNERS" {
+                flags |= Self::MACOS_FORCE_SQUARE_CORNERS;
             } else if ele == "INTEGRATED_BUTTONS" {
                 flags |= Self::INTEGRATED_BUTTONS;
             } else {

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1975,8 +1975,8 @@ bitflags! {
         // so that we effective have Option<bool>
         const MACOS_FORCE_DISABLE_SHADOW = 4;
         const MACOS_FORCE_ENABLE_SHADOW = 4|8;
-        const MACOS_FORCE_SQUARE_CORNERS = 16;
-        const INTEGRATED_BUTTONS = 32;
+        const INTEGRATED_BUTTONS = 16;
+        const MACOS_FORCE_SQUARE_CORNERS = 32;
     }
 }
 

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1375,6 +1375,11 @@ fn decoration_to_mask(
             | NSWindowStyleMask::NSClosableWindowMask
             | NSWindowStyleMask::NSMiniaturizableWindowMask
             | NSWindowStyleMask::NSResizableWindowMask
+    } else if decorations == WindowDecorations::MACOS_FORCE_SQUARE_CORNERS | WindowDecorations::RESIZE {
+        NSWindowStyleMask::NSClosableWindowMask
+            | NSWindowStyleMask::NSMiniaturizableWindowMask
+            | NSWindowStyleMask::NSResizableWindowMask
+            | NSWindowStyleMask::NSFullSizeContentViewWindowMask
     } else if decorations == WindowDecorations::RESIZE
         || decorations == WindowDecorations::INTEGRATED_BUTTONS
         || decorations == WindowDecorations::INTEGRATED_BUTTONS | WindowDecorations::RESIZE
@@ -1393,6 +1398,10 @@ fn decoration_to_mask(
         NSWindowStyleMask::NSTitledWindowMask
             | NSWindowStyleMask::NSClosableWindowMask
             | NSWindowStyleMask::NSMiniaturizableWindowMask
+    } else if decorations == WindowDecorations::MACOS_FORCE_SQUARE_CORNERS {
+        NSWindowStyleMask::NSClosableWindowMask
+            | NSWindowStyleMask::NSMiniaturizableWindowMask
+            | NSWindowStyleMask::NSFullSizeContentViewWindowMask
     } else {
         NSWindowStyleMask::NSTitledWindowMask
             | NSWindowStyleMask::NSClosableWindowMask


### PR DESCRIPTION
This PR adds support to disable rounded corners on macOS with a new window decoration option `MACOS_FORCE_SQUARE_CORNERS`.
```lua
config.window_decorations = 'MACOS_FORCE_SQUARE_CORNERS'
```
Before:
<img width="755" alt="image" src="https://github.com/user-attachments/assets/956ca6d2-8b6b-4b58-a4e9-ccf5b3666b1b" />

After:
<img width="755" alt="image" src="https://github.com/user-attachments/assets/dfa34032-d543-440e-8468-16e3f4bdcd0f" />

It is recommended to use `RESIZE` with this option since it does not make the window resizable by itself.


It does not work with `TITLE` and `INTEGRATED_BUTTONS`.

resolves #2182