### PR TITLE
Add description and fuzzy_description arguments to ShowLauncherArgs

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -17,6 +17,8 @@ use wezterm_term::SemanticType;
 pub struct LauncherActionArgs {
     pub flags: LauncherFlags,
     pub title: Option<String>,
+    pub help_text: Option<String>,
+    pub fuzzy_help_text: Option<String>,
 }
 
 bitflags::bitflags! {

--- a/docs/config/lua/keyassignment/ShowLauncherArgs.md
+++ b/docs/config/lua/keyassignment/ShowLauncherArgs.md
@@ -10,6 +10,14 @@ The arguments are a lua table with the following keys:
 * `flags` - required; the set of flags that specifies what to show in the launcher
 * `title` - optional; the title to show in the tab while the launcher is active
 
+{{since('nightly')}}
+
+These additional keys are also available
+* `help_text` - a string to display when in the default mode. Defaults to:
+  `"Select an item and press Enter=launch  Esc=cancel  /=filter"`
+* `fuzzy_help_text` - a string to display when in fuzzy finding mode. Defaults to:
+  `"Fuzzy matching: "`
+
 The possible flags are listed below. You must explicitly list each item that you
 want to include in the launcher. If you only specify `"FUZZY"` then you will see
 an empty launcher:

--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -57,6 +57,8 @@ pub struct LauncherArgs {
     title: String,
     active_workspace: String,
     workspaces: Vec<String>,
+    help_text: String,
+    fuzzy_help_text: String,
 }
 
 impl LauncherArgs {
@@ -67,6 +69,8 @@ impl LauncherArgs {
         mux_window_id: WindowId,
         pane_id: PaneId,
         domain_id_of_current_tab: DomainId,
+        help_text: &str,
+        fuzzy_help_text: &str,
     ) -> Self {
         let mux = Mux::get();
 
@@ -155,6 +159,8 @@ impl LauncherArgs {
             title: title.to_string(),
             workspaces,
             active_workspace,
+            help_text: help_text.to_string(),
+            fuzzy_help_text: fuzzy_help_text.to_string(),
         }
     }
 }
@@ -172,6 +178,8 @@ struct LauncherState {
     window: ::window::Window,
     filtering: bool,
     flags: LauncherFlags,
+    help_text: String,
+    fuzzy_help_text: String,
 }
 
 impl LauncherState {
@@ -361,11 +369,7 @@ impl LauncherState {
             },
             Change::Text(format!(
                 "{}\r\n",
-                truncate_right(
-                    "Select an item and press Enter=launch  \
-                     Esc=cancel  /=filter",
-                    max_width
-                )
+                truncate_right(&self.help_text, max_width)
             )),
             Change::AllAttributes(CellAttributes::default()),
         ];
@@ -416,7 +420,7 @@ impl LauncherState {
                 },
                 Change::ClearToEndOfLine(ColorAttribute::Default),
                 Change::Text(truncate_right(
-                    &format!("Fuzzy matching: {}", self.filter_term),
+                    &format!("{}{}", &self.fuzzy_help_text, self.filter_term),
                     max_width,
                 )),
             ]);
@@ -608,6 +612,8 @@ pub fn launcher(
         window,
         filtering: args.flags.contains(LauncherFlags::FUZZY),
         flags: args.flags,
+        help_text: args.help_text.clone(),
+        fuzzy_help_text: args.fuzzy_help_text.clone(),
     };
 
     term.set_raw_mode()?;

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2340,7 +2340,7 @@ impl TermWindow {
             help_text: None,
             fuzzy_help_text: None,
         };
-        self.show_launcher_impl(&args, active_tab_idx);
+        self.show_launcher_impl(args, active_tab_idx);
     }
 
     fn show_launcher(&mut self) {
@@ -2355,10 +2355,10 @@ impl TermWindow {
             help_text: None,
             fuzzy_help_text: None,
         };
-        self.show_launcher_impl(&args, 0);
+        self.show_launcher_impl(args, 0);
     }
 
-    fn show_launcher_impl(&mut self, args: &LauncherActionArgs, initial_choice_idx: usize) {
+    fn show_launcher_impl(&mut self, args: LauncherActionArgs, initial_choice_idx: usize) {
         let mux_window_id = self.mux_window_id;
         let window = self.window.as_ref().unwrap().clone();
 
@@ -2379,16 +2379,15 @@ impl TermWindow {
             .domain_id();
         let pane_id = pane.pane_id();
         let tab_id = tab.tab_id();
-        let title = args.title.clone().unwrap();
+        let title = args.title.unwrap();
         let flags = args.flags;
-        let help_text = args.help_text.clone().unwrap_or(
+        let help_text = args.help_text.unwrap_or(
             "Select an item and press Enter=launch  \
                                                             Esc=cancel  /=filter"
                 .to_string(),
         );
         let fuzzy_help_text = args
             .fuzzy_help_text
-            .clone()
             .unwrap_or("Fuzzy matching: ".to_string());
 
         promise::spawn::spawn(async move {
@@ -2741,7 +2740,7 @@ impl TermWindow {
                     help_text: args.help_text.clone(),
                     fuzzy_help_text: args.fuzzy_help_text.clone(),
                 };
-                self.show_launcher_impl(&args, 0);
+                self.show_launcher_impl(args, 0);
             }
             HideApplication => {
                 let con = Connection::get().expect("call on gui thread");


### PR DESCRIPTION
Add `description`, `fuzzy_description` optional arguments in `ShowLauncherArgs`.
Similar to `description`, `fuzzy_description` arguments present in `InputSelector`.
If `description` argument is not provided, default value of `"Select an item and press Enter=launch Esc=cancel  /=filter"` is displayed
If `fuzzy_description` argument is not provided, default value of `"Fuzzy matching: "` is displayed