### PR TITLE
fix: display whitespace before reset of attributes in InputSelector

### DIFF
--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -155,11 +155,11 @@ impl SelectorState {
                 line.resize(max_width, termwiz::surface::SEQ_ZERO);
             }
             changes.append(&mut line.changes(&attr));
+            changes.push(Change::Text(" \r\n".to_string()));
             if entry_idx == self.active_idx {
                 changes.push(AttributeChange::Reverse(false).into());
             }
             changes.push(Change::AllAttributes(CellAttributes::default()));
-            changes.push(Change::Text(" \r\n".to_string()));
         }
 
         if self.filtering || !self.filter_term.is_empty() {

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -155,11 +155,12 @@ impl SelectorState {
                 line.resize(max_width, termwiz::surface::SEQ_ZERO);
             }
             changes.append(&mut line.changes(&attr));
-            changes.push(Change::Text(" \r\n".to_string()));
+            changes.push(Change::Text(" ".to_string()));
             if entry_idx == self.active_idx {
                 changes.push(AttributeChange::Reverse(false).into());
             }
             changes.push(Change::AllAttributes(CellAttributes::default()));
+            changes.push(Change::Text("\r\n".to_string()));
         }
 
         if self.filtering || !self.filter_term.is_empty() {


### PR DESCRIPTION
Display white space before reset of background and setting attributes to default in `InputSelector`. This is in order for whitespace after the option to be highlighted in the same background color as the currently selected option.
The above mentioned points are currently reflected in `ShowLauncherArgs` but not in `InputSelector`.