### PR TITLE
feat: add cli flag to specify output file in `wezterm record`

### DIFF
--- a/docs/examples/cmd-synopsis-wezterm-record--help.txt
+++ b/docs/examples/cmd-synopsis-wezterm-record--help.txt
@@ -9,4 +9,6 @@ Arguments:
 Options:
       --cwd <CWD>  Start in the specified directory, instead of the default_cwd
                    defined by your wezterm configuration
+  -o <OUTFILE>     Save asciicast to the specified file, instead of using a
+                   random file name in the temp directory
   -h, --help       Print help


### PR DESCRIPTION
Adds a new cli flag `-o` to `wezterm record` to specify the file where the asciicast will be saved.

Resolves #6625 