### PR TITLE
Add config option to adjust window alignment

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -521,6 +521,9 @@ pub struct Config {
     #[dynamic(default)]
     pub window_padding: WindowPadding,
 
+    #[dynamic(default)]
+    pub window_content_alignment: WindowContentAlignment,
+
     /// Specifies the path to a background image attachment file.
     /// The file can be any image format that the rust `image`
     /// crate is able to identify and load.
@@ -1895,6 +1898,28 @@ impl Default for WindowPadding {
             bottom: default_half_cell(),
         }
     }
+}
+
+#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, Default)]
+pub struct WindowContentAlignment {
+    pub horizontal: HorizontalWindowContentAlignment,
+    pub vertical: VerticalWindowContentAlignment,
+}
+
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HorizontalWindowContentAlignment {
+    #[default]
+    Left,
+    Center,
+    Right,
+}
+
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VerticalWindowContentAlignment {
+    #[default]
+    Top,
+    Center,
+    Bottom,
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/config/lua/config/window_content_alignment.md
+++ b/docs/config/lua/config/window_content_alignment.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - appearance
+---
+# `window_content_alignment`
+
+Controls the alignment of the terminal cells inside the window.
+
+When window size is not a multiple of terminal cell size, terminal cells will be slightly smaller than the window, and leave a small gap between the two.
+You can use this option to control where the additional gap will be.
+
+The lua table has two fields and following possible values:
+
+* `horizontal`
+    * `"Left"` (the default)
+    * `"Center"`
+    * `"Right"`
+* `vertical`
+    * `"Top"` (the default)
+    * `"Center"`
+    * `"Bottom"`
+
+For example, to center the terminal cells:
+
+```lua
+config.window_content_alignment = {
+  horizontal = "Center",
+  vertical = "Center",
+}
+```


### PR DESCRIPTION
Hi @wez, first time here.

This PR add a config option `window_alignment`, it can be used like so:
```lua
config.window_alignment = {
  horizontal = "Center",
  vertical = "Center",
}
```
one small concern is that the new option works fine with window padding, scroll bar and tab bar, but I don't know if there is something that i didn't tested.

related issue: #1124