### PR TITLE
docs: Try fix mkdocs rendering of nested lists

### DIFF
--- a/docs/config/lua/keyassignment/ActivateKeyTable.md
+++ b/docs/config/lua/keyassignment/ActivateKeyTable.md
@@ -10,7 +10,9 @@ The following parameters are possible:
 
 * `name` - the name of the table to activate.  The name must match up to an entry in the `key_tables` configuration.
 * `timeout_milliseconds` - an optional duration expressed in milliseconds. If specified, then the activation will automatically expire and pop itself from the key table stack once that duration elapses.  If omitted, this activation will not expire due to time.
+
   * {{since('20220807-113146-c2fee766', inline=True)}}: the timer is reset each time you press a key that matches this key table activation, allowing for repeated key presses
+
 * `one_shot` - an optional boolean that controls whether the activation will pop itself after a single additional key press.  The default if left unspecified is `one_shot=true`. When set to `false`, pressing a key will not automatically pop the activation and you will need to use either a timeout or an explicit key assignment that triggers [PopKeyTable](PopKeyTable.md) to cancel the activation.
 * `replace_current` - an optional boolean. Defaults to `false` if unspecified. If set to `true` then behave as though [PopKeyTable](PopKeyTable.md) was triggered before pushing this new activation on the stack.  This is most useful for key assignments in a table that was activated using `one_shot=false`.
 * `until_unknown` - an optional boolean. Defaults to `false` if unspecified. If set to `true` then a key press that doesn't match any entries in the named key table will implicitly pop this entry from the stack. This can be used together with `timeout_milliseconds`. {{since('20220807-113146-c2fee766', inline=True)}}

--- a/docs/config/lua/wezterm/font.md
+++ b/docs/config/lua/wezterm/font.md
@@ -30,7 +30,10 @@ When specifying a font using its family name, the second *attributes* parameter
 is an optional table that can be used to specify style attributes; the
 following keys are allowed:
 
-* `weight` - specifies the weight of the font.  The default value is `"Regular"`, and possible values are:
+* `weight` - specifies the weight of the font.
+
+  The default value is `"Regular"`, and possible values are:
+
   * `"Thin"`
   * `"ExtraLight"`
   * `"Light"`
@@ -46,7 +49,11 @@ following keys are allowed:
 
   `weight` has been supported since version 20210502-130208-bff6815d, In earlier versions you
   could use `bold=true` to get a bold font variant.
-* `stretch` - specifies the font stretch to select.  The default value is `"Normal"`, and possible values are:
+
+* `stretch` - specifies the font stretch to select.
+
+  The default value is `"Normal"`, and possible values are:
+
   * `"UltraCondensed"`
   * `"ExtraCondensed"`
   * `"Condensed"`
@@ -58,7 +65,11 @@ following keys are allowed:
   * `"UltraExpanded"`.
 
   `stretch` has been supported since version 20210502-130208-bff6815d.
-* `style` - specifies the font style to select.  The default is `"Normal"`, and possible values are:
+
+* `style` - specifies the font style to select.
+
+  The default is `"Normal"`, and possible values are:
+
   * `"Normal"`
   * `"Italic"`
   * `"Oblique"`


### PR DESCRIPTION
Nested lists rendering with mkdocs is basically completely broken at the moment.

This happens in these pages:
- https://wezterm.org/config/lua/wezterm/font.html
- https://wezterm.org/config/lua/keyassignment/ActivateKeyTable.html
  (bulletpoint under `timeout_milliseconds` should be indented)

I remember from last time I used mkdocs (~2years ago) that we had to add spaces around (nested) lists to 'unbreak' the nested list rendering.

But at the same time https://github.com/squidfunk/mkdocs-material/issues/6509 seems to mention we need to have 4 indent spaces instead of 2.

I can't run the script to build the docs at the moment to verify this 😬.
Maybe someone else can check this out 👀