### PR TITLE
Reset attributes before emitting CRLF in the Launcher Menu

### DIFF
--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -410,6 +410,7 @@ impl LauncherState {
             if entry_idx == self.active_idx {
                 changes.push(AttributeChange::Reverse(false).into());
             }
+            changes.push(Change::AllAttributes(CellAttributes::default()));
             changes.push(Change::Text("\r\n".to_string()));
         }
 

--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -405,11 +405,12 @@ impl LauncherState {
                 line.resize(max_width, termwiz::surface::SEQ_ZERO);
             }
             changes.append(&mut line.changes(&attr));
-            changes.push(Change::Text(" \r\n".to_string()));
+            changes.push(Change::Text(" ".to_string()));
 
             if entry_idx == self.active_idx {
                 changes.push(AttributeChange::Reverse(false).into());
             }
+            changes.push(Change::Text("\r\n".to_string()));
         }
 
         if self.filtering || !self.filter_term.is_empty() {


### PR DESCRIPTION
Below changes are made:
- Emit CRLF after attributes have been reversed
- Reset Attributes before emitting CRLF in order to handle cases where formatted string is passed against `label` field in `SpawnCommand` object entries in `config.launch_menu`