### PR TITLE
fix: add new build dependency for Fedora 41

### DIFF
--- a/get-deps
+++ b/get-deps
@@ -107,6 +107,13 @@ fedora_deps() {
   if test_flag; then
     $YUM install -y 'openssh-server'
   fi
+
+  # Fedora 41 and above split a part of openssl-devel into openssl-devel-engine.
+  # CentOS/RHEL 10 are doing the same thing.
+  if { [ "$VERSION_ID" -ge "41" ] && [ "$ID" == "fedora" ]; } \
+     || { [ "$VERSION_ID" -ge "10" ] && [ "$ID" != "fedora" ]; }; then
+    $YUM install -y 'openssl-devel-engine'
+  fi
 }
 
 suse_deps() {


### PR DESCRIPTION
Fix #6470. I did a bit of testing myself, and it makes the correct choice of dependencies depending on Fedora's version (40 vs 41) and CentOS/RHEL's version (9 vs 10). 