### PR TITLE
Improve dragging and double-clicking for maximize on the tab bar

### DIFF
--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -472,9 +472,9 @@ impl super::TermWindow {
                         .window_state
                         .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
                     if let Some(ref window) = self.window {
-                        if self.config.window_decorations
-                            == WindowDecorations::INTEGRATED_BUTTONS | WindowDecorations::RESIZE
-                        {
+                        if self.config.window_decorations.contains(
+                            WindowDecorations::INTEGRATED_BUTTONS | WindowDecorations::RESIZE,
+                        ) {
                             if self.last_mouse_click.as_ref().map(|c| c.streak) == Some(2) {
                                 if maximized {
                                     window.restore();

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -159,6 +159,21 @@ impl super::TermWindow {
 
             WMEK::Move => {
                 if let Some(start) = self.window_drag_position.as_ref() {
+                    // Restore the window size when dragging in the maximized state
+                    let maximized = self
+                        .window_state
+                        .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
+                    if maximized {
+                        if let Some(window) = self.window.as_ref() {
+                            window.restore();
+                        }
+                        // self.window_drag_position.coords needs to be recalculated
+                        // after restoring the window, so we clear it here and skip
+                        // the rest of the Move event handling
+                        self.window_drag_position = None;
+                        return;
+                    }
+
                     // Dragging the window
                     // Compute the distance since the initial event
                     let delta_x = start.screen_coords.x - event.screen_coords.x;
@@ -471,21 +486,22 @@ impl super::TermWindow {
                     let maximized = self
                         .window_state
                         .intersects(WindowState::MAXIMIZED | WindowState::FULL_SCREEN);
+                    let resizable_by_tab_bar = self.config.window_decorations.contains(
+                        WindowDecorations::INTEGRATED_BUTTONS | WindowDecorations::RESIZE,
+                    );
                     if let Some(ref window) = self.window {
-                        if self.config.window_decorations.contains(
-                            WindowDecorations::INTEGRATED_BUTTONS | WindowDecorations::RESIZE,
-                        ) {
-                            if self.last_mouse_click.as_ref().map(|c| c.streak) == Some(2) {
-                                if maximized {
-                                    window.restore();
-                                } else {
-                                    window.maximize();
-                                }
+                        if resizable_by_tab_bar
+                            && self.last_mouse_click.as_ref().map(|c| c.streak) == Some(2)
+                        {
+                            if maximized {
+                                window.restore();
+                            } else {
+                                window.maximize();
                             }
                         }
                     }
                     // Potentially starting a drag by the tab bar
-                    if !maximized {
+                    if !maximized || resizable_by_tab_bar {
                         self.window_drag_position.replace(event.clone());
                     }
                     context.request_drag_move();


### PR DESCRIPTION
- Fix the bug where double-clicking on the tab bar would not maximize the window if extra `window_decorations` flag other than `INTEGRATED_BUTTONS | RESIZE` were set (e.g. `INTEGRATED_BUTTONS | RESIZE | MACOS_FORCE_ENABLE_SHADOW`)
- Allow dragging on the tab bar to restore a maximized window, consistent with OS behavior in handling dragging windows

https://github.com/user-attachments/assets/615b5581-4c61-4541-8ab0-5f8ac05e7a10