### PR TITLE
ci: Fix Nix warning, magic cache is deprecated

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Cache build artifacts
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs
         uses: DeterminateSystems/flake-checker-action@main
         with:

--- a/.github/workflows/nix_continuous.yml
+++ b/.github/workflows/nix_continuous.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Cache build artifacts
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs
         uses: DeterminateSystems/flake-checker-action@main
         with:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
-      - name: Enable magic Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Cache build artifacts
+        uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake
         uses: DeterminateSystems/flake-checker-action@main
       - name: Update flake.lock


### PR DESCRIPTION
This warning:
![image](https://github.com/user-attachments/assets/98019087-a071-40b7-910b-e470e481a7a5)
