### PR TITLE
glyph: Fix glyph '┽', was rendering as '┥'

### DIFF
--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -1776,7 +1776,7 @@ impl BlockKey {
                 },
                 Poly {
                     path: &[
-                        PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::Frac(1, 2)),
+                        PolyCommand::MoveTo(BlockCoord::One, BlockCoord::Frac(1, 2)),
                         PolyCommand::LineTo(BlockCoord::Frac(1, 2), BlockCoord::Frac(1, 2)),
                         PolyCommand::LineTo(BlockCoord::Frac(1, 2), BlockCoord::Zero),
                         PolyCommand::LineTo(BlockCoord::Frac(1, 2), BlockCoord::One),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/be3ff0fb-0dc7-4795-8941-a2085804eed9)