### PR TITLE
workspace-ify the deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -772,7 +772,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size 0.4.1",
 ]
 
 [[package]]
@@ -2822,7 +2821,7 @@ dependencies = [
  "proc-macro2",
  "regex",
  "syn 2.0.98",
- "terminal_size 0.2.6",
+ "terminal_size",
 ]
 
 [[package]]
@@ -4140,7 +4139,6 @@ dependencies = [
  "log",
  "nix 0.28.0",
  "serde",
- "serde_derive",
  "serial2",
  "shared_library",
  "shell-words",
@@ -5494,16 +5492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
-dependencies = [
- "rustix 0.38.44",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6746,7 +6734,7 @@ dependencies = [
  "anyhow",
  "assert_fs",
  "async_ossl",
- "base64 0.22.1",
+ "base64 0.21.7",
  "bitflags 1.3.2",
  "camino",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,244 @@ opt-level = 3
 #split-debuginfo = "unpacked"
 
 [workspace.dependencies]
-uuid = { version="1.13", features=["v4", "fast-rng"] }
+ahash = "0.8"
+anyhow = "1.0"
+async-executor = "1.11"
+async-io = "2.3"
+async-task = "4.7"
+async-trait = "0.1"
+async_ossl = { path = "async_ossl" }
+async-channel = "2.3"
+bytes = "1.0"
+guillotiere = "0.6"
+libloading = "0.8"
+line_drawing = "0.8"
+raw-window-handle = "0.6"
+resize = "0.5"
+backtrace = "0.3"
+clipboard-win = "2.2"
+glium = { version = "0.35", default-features = false }
+base64 = "0.21"
+camino = "1.0"
+base91 = { path = "base91" }
+battery = { path = "lua-api-crates/battery" }
+bintree = { path = "bintree" }
+bitflags = "1.3"
+bstr = "1.0"
+cairo-rs = {version="0.18", default-features=false}
+cassowary = "0.3"
+cc = {version="1.0", features = ["parallel"]}
+chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde"]}
+clap = {version="4.0", features=["derive"]}
+clap_complete = "4.4"
+clap_complete_fig = "4.0"
+cocoa = "0.25"
+codec = { path = "codec" }
+dns-lookup = "2.0"
+color-funcs = { path = "lua-api-crates/color-funcs" }
+colorgrad = "0.6"
+config = { path = "config" }
+core-foundation = "0.9"
+core-graphics = "0.23"
+cgl = "0.3"
+core-text = "20.0"
+criterion = "0.5"
+crossbeam = "0.8"
+csscolorparser = "0.6"
+deltae = "0.3"
+dirs-next = "2.0"
+dhat = "0.3"
+downcast-rs = "1.0"
+dwrote = "0.11"
+emojis = "0.6"
+encoding_rs = "0.8"
+enum-display-derive = "0.1"
+env-bootstrap = { path = "env-bootstrap" }
+frecency = { path = "frecency" }
+hdrhistogram = "7.1"
+http_req = "0.11"
+nucleo-matcher = "0.3"
+fastrand = "2.0"
+env_logger = "0.11"
+euclid = "0.22"
+fancy-regex = "0.11"
+gethostname = "0.5"
+libssh-rs = "0.3.5"
+socket2 = "0.5"
+ssh2 = "0.9.3"
+filedescriptor = { version="0.8.3", path = "filedescriptor" }
+filenamegen = "0.2.6"
+filesystem = { path = "lua-api-crates/filesystem" }
+finl_unicode = "1.2"
+fixed = "1.23"
+fixedbitset = "0.4"
+flume = "0.11"
+fnv = "1.0"
+fontconfig = { path = "deps/fontconfig" }
+freetype = { path = "deps/freetype" }
+futures = "0.3"
+getrandom = "0.3.1"
+git2 = { version = "0.18", default-features = false, features = ["https"] }
+governor = {version="0.5", default-features=false, features=["std"]}
+harfbuzz = { path = "deps/harfbuzz" }
+hex = "0.4"
+hostname = "0.4"
+human-sort = "0.2"
+humantime = "2.1"
+humansize = "2.1"
+image = "0.25"
+intrusive-collections = "0.9"
+k9 = "0.12.0"
+lazy_static = "1.4"
+leb128 = "0.2"
+lfucache = { path = "lfucache" }
+libc = "0.2"
+libflate = "2"
+log = "0.4"
+logging = { path = "lua-api-crates/logging" }
+lru = "0.12"
+luahelper = { path = "luahelper" }
+mac_address = "1.1.8"
+maplit = "1.0"
+memmap2 = "0.9"
+memmem = "0.1"
+metrics = "0.23"
+miniz_oxide = "0.7"
+mlua = "0.9"
+mux = { path = "mux" }
+mux-lua = { path = "lua-api-crates/mux" }
+names = { version = "0.12", default-features = false }
+nix = "0.28"
+notify = "5.0.0"
+ntapi = "0.4"
+num = "0.4"
+num-derive = "0.4"
+num-traits = "0.2"
+objc = "0.2"
+once_cell = "1.8"
+openssl = "0.10.57"
+ordered-float = "4.1"
+parking_lot = "0.12"
+percent-encoding = "2.3"
+pest = "2.1"
+pest_derive = "2.1"
+phf = "0.11"
+phf_codegen = "0.10"
+pkg-config = "0.3"
+plist = "1.3"
+plugin = { path = "lua-api-crates/plugin" }
+portable-pty = { path = "pty" }
+proc-macro2 = "1.0"
+procinfo = { path = "procinfo" }
+procinfo-funcs = { path = "lua-api-crates/procinfo-funcs" }
+promise = { path = "promise" }
+rcgen = "0.12"
+regex = "1"
+quote = "1.0.2"
+rangeset = { path = "rangeset" }
+ratelim= { path = "ratelim" }
+rayon = "1.7"
+reqwest = "0.12"
+rusqlite = "0.30"
+serde = {version="1.0", features = ["derive"]}
+serde-funcs = { path = "lua-api-crates/serde-funcs" }
+serde_json = "1.0"
+serde_with = {version="2.0", features = ["chrono_0_4"]}
+serde_yaml = "0.9"
+assert_fs = "1.0.4"
+predicates = "3.0"
+rstest = "0.21"
+passfd = "0.1.6"
+serial2 = "0.2"
+sha2 = "0.10"
+tiny-skia = "0.11"
+share-data = { path = "lua-api-crates/share-data" }
+shared_library = "0.1"
+shell-words = "1.1"
+whoami = "1.5"
+zbus = "4.2"
+futures-util = "0.3"
+futures-lite = "2.3"
+x11 = "2.21"
+xcb = "1.3"
+xkbcommon = "0.7.0"
+block2 = "0.6"
+mio = "0.8"
+objc2 = "0.6"
+objc2-user-notifications = "0.3"
+objc2-foundation = "0.3"
+xcb-imdkit = { version="0.3", git="https://github.com/wez/xcb-imdkit-rs.git", rev="358e226573461fe540efb920e2aad740e3c6fab1"}
+smithay-client-toolkit = {version = "0.19", default-features=false}
+wayland-backend = "0.3.5"
+wayland-protocols = "0.32"
+wayland-client = "0.31"
+wayland-egl = "0.32"
+zvariant = "4.0"
+unicode-width = "0.1"
+tabout = { path = "tabout" }
+shlex = "1.1"
+signal-hook = "0.3"
+siphasher = "0.3"
+smol = "2.0"
+spa = "0.3.1"
+spawn-funcs = { path = "lua-api-crates/spawn-funcs" }
+sqlite-cache = {git="https://github.com/losfair/sqlite-cache", rev="0961b50385ff189bb12742716331c05ed0bf7805" }
+ssh-funcs = { path = "lua-api-crates/ssh-funcs" }
+starship-battery = "0.8"
+strsim = "0.11"
+syn = "1.0"
+tar = "0.4"
+tempfile = "3.16"
+terminfo = "0.9"
+termios = "0.3"
+termwiz = { path = "termwiz" }
+gl_generator = "0.14"
+termwiz-funcs = { path = "lua-api-crates/termwiz-funcs" }
+textwrap = "0.16"
+thiserror = "1.0"
+time-funcs = { path = "lua-api-crates/time-funcs" }
+tokio = "1.19"
+toml = "0.8"
+ucd-trie = "0.1"
+umask = { path = "umask" }
+unicode-normalization = "0.1.21"
+unicode-segmentation = "1.8"
+url = "2"
+url-funcs = { path = "lua-api-crates/url-funcs" }
+utf8parse = "0.2"
+uuid = "1.13"
+varbincode = "0.1"
+vtparse = { version="0.6.2", path="vtparse" }
+walkdir = "2"
+bytemuck = { version="1.4", features=["derive"]}
+embed-resource = "1.7"
+wezterm-bidi = { version="0.2.3", path = "bidi" }
+wezterm-blob-leases = { version="0.1.1", path = "wezterm-blob-leases"}
+wezterm-client = { path = "wezterm-client" }
+wezterm-color-types = { version="0.3", path = "color-types" }
+wezterm-config-derive = { version="0.1", path="config/derive" }
+wezterm-dynamic = { version = "0.2.1", path = "wezterm-dynamic" }
+wezterm-dynamic-derive = { version="0.1.1", path="wezterm-dynamic/derive" }
+wezterm-font = { path = "wezterm-font" }
+wezterm-gui-subcommands = { path = "wezterm-gui-subcommands" }
+wezterm-input-types = { version="0.1", path = "wezterm-input-types" }
+wezterm-mux-server-impl = { path = "wezterm-mux-server-impl" }
+wezterm-open-url = { path = "wezterm-open-url" }
+wezterm-ssh = { path = "wezterm-ssh" }
+wezterm-term = { path = "term" }
+xml-rs = "0.8"
+uds_windows = "1.1"
+wezterm-toast-notification = { path = "wezterm-toast-notification" }
+wezterm-uds = { path = "wezterm-uds" }
+wezterm-version = { path = "wezterm-version" }
+wgpu = "24.0.1"
+window-funcs = { path = "lua-api-crates/window-funcs" }
+winapi = "0.3.9"
+window = {path="window"}
+windows = "0.33.0"
+benchmarking = "0.4"
+winreg = "0.10"
+zstd = "0.11"
 
 [patch.crates-io]
 # We use our own vendored cairo, which has minimal deps and should just

--- a/async_ossl/Cargo.toml
+++ b/async_ossl/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-io = "2.3"
+async-io.workspace = true
 
 [target.'cfg(not(any(windows, target_os="macos")))'.dependencies]
-openssl = "0.10"
+openssl.workspace = true
 
 [target.'cfg(any(windows, target_os="macos"))'.dependencies]
-openssl = { version = "0.10", features=["vendored"] }
+openssl = { workspace = true, features=["vendored"] }
 

--- a/bidi/Cargo.toml
+++ b/bidi/Cargo.toml
@@ -12,9 +12,9 @@ exclude = ["/data", "/tests"]
 [features]
 
 [dependencies]
-log = "0.4"
-wezterm-dynamic = { version = "0.2", path = "../wezterm-dynamic" }
+log.workspace = true
+wezterm-dynamic.workspace = true
 
 [dev-dependencies]
-k9 = "0.12.0"
-env_logger = "0.11"
+k9.workspace = true
+env_logger.workspace = true

--- a/bidi/generate/Cargo.toml
+++ b/bidi/generate/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
 

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -8,21 +8,21 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../config" }
-leb128 = "0.2"
-log = "0.4"
-metrics = "0.23"
-mux = { path = "../mux" }
-portable-pty = { path = "../pty", features = ["serde_support"]}
-rangeset = { path = "../rangeset" }
-serde = {version="1.0", features = ["rc", "derive"]}
-smol = "2.0"
-termwiz = { path = "../termwiz" }
-thiserror = "1.0"
-varbincode = "0.1"
-wezterm-term = { path = "../term", features=["use_serde"] }
-zstd = "0.11"
+anyhow.workspace = true
+config.workspace = true
+leb128.workspace = true
+log.workspace = true
+metrics.workspace = true
+mux.workspace = true
+portable-pty = { workspace = true, features = ["serde_support"]}
+rangeset.workspace = true
+serde = {workspace=true, features = ["rc", "derive"]}
+smol.workspace = true
+termwiz.workspace = true
+thiserror.workspace = true
+varbincode.workspace = true
+wezterm-term = { workspace=true, features=["use_serde"] }
+zstd.workspace = true
 
 [dev-dependencies]
-base91 = { path = "../base91" }
+base91.workspace = true

--- a/color-types/Cargo.toml
+++ b/color-types/Cargo.toml
@@ -11,8 +11,8 @@ license = "MIT"
 use_serde = ["serde"]
 
 [dependencies]
-csscolorparser = {version="0.6", features=["lab"]}
-deltae = "0.3"
-lazy_static = "1.4"
-serde = {version="1.0", features = ["derive"], optional=true}
-wezterm-dynamic = { path = "../wezterm-dynamic", version="0.2" }
+csscolorparser = {workspace=true, features=["lab"]}
+deltae.workspace = true
+lazy_static.workspace = true
+serde = {workspace=true, features = ["derive"], optional=true}
+wezterm-dynamic.workspace = true

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -8,45 +8,44 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dev-dependencies]
-env_logger = "0.11"
+env_logger.workspace = true
 
 [features]
 distro-defaults = []
 
 [dependencies]
-anyhow = "1.0"
-bitflags = "1.3"
-colorgrad = "0.6"
-dirs-next = "2.0"
-enum-display-derive = "0.1"
-hostname = "0.4"
-lazy_static = "1.4"
-libc = "0.2"
-log = "0.4"
-luahelper = { path = "../luahelper" }
-mlua = {version="0.9", features=["vendored", "lua54", "async", "send", "serialize"]}
-# file change notification
-notify = "5.0.0"
-once_cell = "1.8"
-ordered-float = { version = "4.1", features = ["serde"] }
-portable-pty = { path = "../pty", features = ["serde_support"]}
-promise = { path = "../promise" }
-serde = {version="1.0", features = ["rc", "derive"]}
-serde_json = "1.0"
-shlex = "1.1"
-smol = "2.0"
-termwiz = { path = "../termwiz", features=["use_serde"] }
-toml = "0.8"
-umask = { path = "../umask" }
-wezterm-config-derive = { version="0.1", path="derive" }
-wezterm-dynamic = { path = "../wezterm-dynamic" }
-wezterm-bidi = { path = "../bidi" }
-wezterm-input-types = { path = "../wezterm-input-types" }
-wezterm-ssh = { path = "../wezterm-ssh" }
-wezterm-term = { path = "../term", features=["use_serde"] }
+anyhow.workspace = true
+bitflags.workspace = true
+colorgrad.workspace = true
+dirs-next.workspace = true
+enum-display-derive.workspace = true
+hostname.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+luahelper.workspace = true
+mlua = {workspace=true, features=["vendored", "lua54", "async", "send", "serialize"]}
+notify.workspace = true
+once_cell.workspace = true
+ordered-float = { workspace=true, features = ["serde"] }
+portable-pty = { workspace=true, features = ["serde_support"]}
+promise.workspace = true
+serde = {workspace=true, features = ["rc", "derive"]}
+serde_json.workspace = true
+shlex.workspace = true
+smol.workspace = true
+termwiz = { workspace=true, features=["use_serde"] }
+toml.workspace = true
+umask.workspace = true
+wezterm-bidi.workspace = true
+wezterm-config-derive.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-input-types.workspace = true
+wezterm-ssh.workspace = true
+wezterm-term = { workspace = true, features=["use_serde"] }
 
 [target."cfg(unix)".dependencies]
-nix = {version="0.28", features=["resource"]}
+nix = {workspace=true, features=["resource"]}
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = ["winuser"]}
+winapi = { workspace=true, features = ["winuser"]}

--- a/config/derive/Cargo.toml
+++ b/config/derive/Cargo.toml
@@ -10,6 +10,6 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0.2"
-syn = "1.0"
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true

--- a/deps/cairo/Cargo.toml
+++ b/deps/cairo/Cargo.toml
@@ -32,4 +32,4 @@ use_glib = []
 libc = "0.2"
 
 [build-dependencies]
-cc = {version="1.0", features = ["parallel"]}
+cc.workspace = true

--- a/deps/fontconfig/Cargo.toml
+++ b/deps/fontconfig/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 publish = false
 
 [dependencies]
-libc = "~0.2"
+libc.workspace = true
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config.workspace = true

--- a/deps/freetype/Cargo.toml
+++ b/deps/freetype/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 publish = false
 
 [dependencies]
-fixed = "1.23"
+fixed.workspace = true
 
 [build-dependencies]
-cc = {version="1.0", features = ["parallel"]}
+cc.workspace = true

--- a/deps/harfbuzz/Cargo.toml
+++ b/deps/harfbuzz/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 publish = false
 
 [dependencies]
-freetype = { path = "../freetype" }
+freetype.workspace = true
 
 [build-dependencies]
-cc = {version="1.0", features = ["parallel"]}
+cc.workspace = true

--- a/env-bootstrap/Cargo.toml
+++ b/env-bootstrap/Cargo.toml
@@ -8,35 +8,35 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-backtrace = "0.3"
-chrono = {version="0.4", default-features=false, features=["unstable-locales"]}
-config = { path = "../config" }
-dirs-next = "2.0"
-lazy_static = "1.4"
-libc = "0.2"
-log = "0.4"
+backtrace.workspace = true
+battery.workspace = true
+chrono.workspace = true
+color-funcs.workspace = true
+config.workspace = true
+dirs-next.workspace = true
 env_logger = "0.10" # Note: we rely on filter::Builder which is gone in 0.11
-termwiz = { path = "../termwiz" }
-battery = { path = "../lua-api-crates/battery" }
-color-funcs = { path = "../lua-api-crates/color-funcs" }
-termwiz-funcs = { path = "../lua-api-crates/termwiz-funcs" }
-logging = { path = "../lua-api-crates/logging" }
-mux-lua = { path = "../lua-api-crates/mux" }
-procinfo-funcs = { path = "../lua-api-crates/procinfo-funcs" }
-filesystem = { path = "../lua-api-crates/filesystem" }
-serde-funcs = { path = "../lua-api-crates/serde-funcs" }
-plugin = { path = "../lua-api-crates/plugin" }
-share-data = { path = "../lua-api-crates/share-data" }
-ssh-funcs = { path = "../lua-api-crates/ssh-funcs" }
-spawn-funcs = { path = "../lua-api-crates/spawn-funcs" }
-time-funcs = { path = "../lua-api-crates/time-funcs" }
-url-funcs = { path = "../lua-api-crates/url-funcs" }
-wezterm-version = { path = "../wezterm-version" }
+filesystem.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+logging.workspace = true
+mux-lua.workspace = true
+plugin.workspace = true
+procinfo-funcs.workspace = true
+serde-funcs.workspace = true
+share-data.workspace = true
+spawn-funcs.workspace = true
+ssh-funcs.workspace = true
+termwiz-funcs.workspace = true
+termwiz.workspace = true
+time-funcs.workspace = true
+url-funcs.workspace = true
+wezterm-version.workspace = true
 
 [target."cfg(windows)".dependencies]
-winapi = "0.3"
+winapi.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.25"
-objc = "0.2"
+cocoa.workspace = true
+objc.workspace = true
 

--- a/filedescriptor/Cargo.toml
+++ b/filedescriptor/Cargo.toml
@@ -11,11 +11,11 @@ readme = "README.md"
 keywords = ["socketpair", "pipe", "poll", "filedescriptor"]
 
 [dependencies]
-thiserror = "1.0"
-libc = "0.2"
+thiserror.workspace = true
+libc.workspace = true
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = [
+winapi = { workspace=true, features = [
     "winuser",
     "handleapi",
     "fileapi",

--- a/frecency/Cargo.toml
+++ b/frecency/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-chrono = {version="0.4", default-features=false}
-serde = {version="1.0", features = ["derive"]}
-serde_with = {version="2.0", features = ["chrono_0_4"]}
+chrono.workspace = true
+serde = {workspace=true, features = ["derive"]}
+serde_with.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true

--- a/lfucache/Cargo.toml
+++ b/lfucache/Cargo.toml
@@ -7,11 +7,11 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ahash = "0.8"
-config = { path = "../config" }
-fnv = "1.0"
-intrusive-collections = "0.9"
-metrics = "0.23"
+ahash.workspace = true
+config.workspace = true
+fnv.workspace = true
+intrusive-collections.workspace = true
+metrics.workspace = true
 
 [dev-dependencies]
-k9 = "0.12"
+k9.workspace = true

--- a/lua-api-crates/battery/Cargo.toml
+++ b/lua-api-crates/battery/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-starship-battery = "0.8"
-config = { path = "../../config" }
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-luahelper = { path = "../../luahelper" }
+anyhow.workspace = true
+config.workspace = true
+luahelper.workspace = true
+starship-battery.workspace = true
+wezterm-dynamic.workspace = true

--- a/lua-api-crates/color-funcs/Cargo.toml
+++ b/lua-api-crates/color-funcs/Cargo.toml
@@ -7,18 +7,18 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-csscolorparser = {version="0.6", features=["lab"]}
-deltae = "0.3"
-image = "0.25"
-lazy_static = "1.4"
-log = "0.4"
-lru = "0.12"
-luahelper = { path = "../../luahelper" }
-plist = "1.3"
-serde = {version="1.0", features=["derive"]}
-serde_json = "1.0"
-serde_yaml = "0.9"
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-wezterm-term = { path = "../../term", features=["use_serde"] }
+anyhow.workspace = true
+config.workspace = true
+csscolorparser = {workspace=true, features=["lab"]}
+deltae.workspace = true
+image.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+lru.workspace = true
+luahelper.workspace = true
+plist.workspace = true
+serde = {workspace=true, features=["derive"]}
+serde_json.workspace = true
+serde_yaml.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-term = { workspace=true, features=["use_serde"] }

--- a/lua-api-crates/filesystem/Cargo.toml
+++ b/lua-api-crates/filesystem/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-filenamegen = "0.2.6"
-anyhow = "1.0"
-config = { path = "../../config" }
-luahelper = { path = "../../luahelper" }
-smol = "2.0"
+anyhow.workspace = true
+config.workspace = true
+filenamegen.workspace = true
+luahelper.workspace = true
+smol.workspace = true

--- a/lua-api-crates/logging/Cargo.toml
+++ b/lua-api-crates/logging/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-log = "0.4"
-luahelper = { path = "../../luahelper" }
+anyhow.workspace = true
+config.workspace = true
+log.workspace = true
+luahelper.workspace = true

--- a/lua-api-crates/mux/Cargo.toml
+++ b/lua-api-crates/mux/Cargo.toml
@@ -7,17 +7,17 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-wezterm-term = { path = "../../term" }
-libc = "0.2"
-log = "0.4"
-luahelper = { path = "../../luahelper" }
-parking_lot = "0.12"
-portable-pty = { path = "../../pty" }
-smol = "2.0"
-termwiz = { path = "../../termwiz" }
-termwiz-funcs = { path = "../termwiz-funcs" }
-mux = { path = "../../mux" }
-url-funcs = { path = "../url-funcs" }
+anyhow.workspace = true
+config.workspace = true
+libc.workspace = true
+log.workspace = true
+luahelper.workspace = true
+mux.workspace = true
+parking_lot.workspace = true
+portable-pty.workspace = true
+smol.workspace = true
+termwiz-funcs.workspace = true
+termwiz.workspace = true
+url-funcs.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-term.workspace = true

--- a/lua-api-crates/plugin/Cargo.toml
+++ b/lua-api-crates/plugin/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-git2 = { version = "0.18", default-features = false, features = ["https"] }
-log = "0.4"
-luahelper = { path = "../../luahelper" }
-tempfile = "3.3"
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
+anyhow.workspace = true
+config.workspace = true
+git2.workspace = true
+log.workspace = true
+luahelper.workspace = true
+tempfile.workspace = true
+wezterm-dynamic.workspace = true

--- a/lua-api-crates/procinfo-funcs/Cargo.toml
+++ b/lua-api-crates/procinfo-funcs/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-libc = "0.2"
-luahelper = { path = "../../luahelper" }
-procinfo = { path = "../../procinfo" }
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
+anyhow.workspace = true
+config.workspace = true
+libc.workspace = true
+luahelper.workspace = true
+procinfo.workspace = true
+wezterm-dynamic.workspace = true

--- a/lua-api-crates/serde-funcs/Cargo.toml
+++ b/lua-api-crates/serde-funcs/Cargo.toml
@@ -7,10 +7,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-luahelper = { path = "../../luahelper" }
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-serde_json = "1.0.82"
-serde_yaml = "0.9.31"
-toml = "0.8.9"
+anyhow.workspace = true
+config.workspace = true
+luahelper.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+toml.workspace = true
+wezterm-dynamic.workspace = true

--- a/lua-api-crates/share-data/Cargo.toml
+++ b/lua-api-crates/share-data/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-lazy_static = "1.4"
-luahelper = { path = "../../luahelper" }
-ordered-float = "4.1"
+anyhow.workspace = true
+config.workspace = true
+lazy_static.workspace = true
+luahelper.workspace = true
+ordered-float.workspace = true
+wezterm-dynamic.workspace = true

--- a/lua-api-crates/spawn-funcs/Cargo.toml
+++ b/lua-api-crates/spawn-funcs/Cargo.toml
@@ -7,14 +7,14 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-log = "0.4"
-luahelper = { path = "../../luahelper" }
-smol = "2.0"
-bstr = "1.0"
-wezterm-open-url = { path = "../../wezterm-open-url" }
+anyhow.workspace = true
+bstr.workspace = true
+config.workspace = true
+log.workspace = true
+luahelper.workspace = true
+smol.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-open-url.workspace = true
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = ["winuser"]}
+winapi = { workspace=true, features = ["winuser"]}

--- a/lua-api-crates/ssh-funcs/Cargo.toml
+++ b/lua-api-crates/ssh-funcs/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-luahelper = { path = "../../luahelper" }
-wezterm-ssh = { path = "../../wezterm-ssh" }
+anyhow.workspace = true
+config.workspace = true
+luahelper.workspace = true
+wezterm-ssh.workspace = true

--- a/lua-api-crates/termwiz-funcs/Cargo.toml
+++ b/lua-api-crates/termwiz-funcs/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-finl_unicode = "1.2"
-terminfo = "0.9"
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-wezterm-input-types = { path = "../../wezterm-input-types" }
-luahelper = { path = "../../luahelper" }
-termwiz = { path = "../../termwiz", features=["use_serde"] }
-lazy_static = "1.4"
+anyhow.workspace = true
+config.workspace = true
+finl_unicode.workspace = true
+lazy_static.workspace = true
+luahelper.workspace = true
+terminfo.workspace = true
+termwiz = { workspace=true, features=["use_serde"] }
+wezterm-dynamic.workspace = true
+wezterm-input-types.workspace = true

--- a/lua-api-crates/time-funcs/Cargo.toml
+++ b/lua-api-crates/time-funcs/Cargo.toml
@@ -7,12 +7,12 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-chrono = {version="0.4", default-features=false, features=["unstable-locales"]}
-config = { path = "../../config" }
-luahelper = { path = "../../luahelper" }
-lazy_static = "1.4"
-promise = { path = "../../promise" }
-smol = "2.0"
-spa = "0.3.1"
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
+anyhow.workspace = true
+chrono.workspace = true
+config.workspace = true
+lazy_static.workspace = true
+luahelper.workspace = true
+promise.workspace = true
+smol.workspace = true
+spa.workspace = true
+wezterm-dynamic.workspace = true

--- a/lua-api-crates/url-funcs/Cargo.toml
+++ b/lua-api-crates/url-funcs/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-luahelper = { path = "../../luahelper" }
-percent-encoding = "2.3"
-url = "2"
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
+anyhow.workspace = true
+config.workspace = true
+luahelper.workspace = true
+percent-encoding.workspace = true
+url.workspace = true
+wezterm-dynamic.workspace = true

--- a/lua-api-crates/window-funcs/Cargo.toml
+++ b/lua-api-crates/window-funcs/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-config = { path = "../../config" }
-luahelper = { path = "../../luahelper" }
-wezterm-dynamic = { path = "../../wezterm-dynamic" }
-window = {path="../../window"}
+anyhow.workspace = true
+config.workspace = true
+luahelper.workspace = true
+wezterm-dynamic.workspace = true
+window.workspace = true

--- a/luahelper/Cargo.toml
+++ b/luahelper/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bstr = "1.0"
-log = "0.4"
-mlua = "0.9"
-wezterm-dynamic = { path = "../wezterm-dynamic" }
+bstr.workspace = true
+log.workspace = true
+mlua.workspace = true
+wezterm-dynamic.workspace = true

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -8,50 +8,50 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-base64 = "0.21"
-bintree = { path = "../bintree" }
-bitflags = "1.3"
-chrono = { version = "0.4", default-features=false, features = ["serde"] }
-config = { path = "../config" }
-crossbeam = "0.8"
-downcast-rs = "1.0"
-fancy-regex = "0.11"
-filedescriptor = { version="0.8", path = "../filedescriptor" }
-finl_unicode = "1.2"
-hostname = "0.4"
-lazy_static = "1.4"
-libc = "0.2"
-log = "0.4"
-luahelper = { path = "../luahelper" }
-metrics = "0.23"
-mlua = "0.9"
-names = { version = "0.12", default-features = false }
-nix = {version="0.28", features=["term"]}
-parking_lot = "0.12"
-percent-encoding = "2"
-portable-pty = { path = "../pty", features = ["serde_support"]}
-procinfo = { path = "../procinfo" }
-promise = { path = "../promise" }
-rangeset = { path = "../rangeset" }
-serde = {version="1.0", features = ["rc", "derive"]}
-serial2 = "0.2"
-shell-words = "1.1"
-smol = "2.0"
-terminfo = "0.9"
-termwiz = { path = "../termwiz" }
-termwiz-funcs = { path = "../lua-api-crates/termwiz-funcs" }
-textwrap = "0.16"
-thiserror = "1.0"
-url = "2"
-wezterm-ssh = { path = "../wezterm-ssh" }
-wezterm-dynamic = { path = "../wezterm-dynamic" }
-wezterm-term = { path = "../term", features=["use_serde"] }
+anyhow.workspace = true
+async-trait.workspace = true
+base64.workspace = true
+bintree.workspace = true
+bitflags.workspace = true
+chrono.workspace = true
+config.workspace = true
+crossbeam.workspace = true
+downcast-rs.workspace = true
+fancy-regex.workspace = true
+filedescriptor.workspace = true
+finl_unicode.workspace = true
+hostname.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+luahelper.workspace = true
+metrics.workspace = true
+mlua.workspace = true
+names.workspace = true
+nix = {workspace=true, features=["term"]}
+parking_lot.workspace = true
+percent-encoding.workspace = true
+portable-pty = { workspace=true, features = ["serde_support"]}
+procinfo.workspace = true
+promise.workspace = true
+rangeset.workspace = true
+serde = {workspace=true, features = ["rc", "derive"]}
+serial2.workspace = true
+shell-words.workspace = true
+smol.workspace = true
+terminfo.workspace = true
+termwiz-funcs.workspace = true
+termwiz.workspace = true
+textwrap.workspace = true
+thiserror.workspace = true
+url.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-ssh.workspace = true
+wezterm-term = { workspace=true, features=["use_serde"] }
 
 [target."cfg(windows)".dependencies]
-ntapi = "0.4"
-winapi = { version = "0.3", features = [
+ntapi.workspace = true
+winapi = { workspace=true, features = [
     "handleapi",
     "memoryapi",
     "psapi",
@@ -60,4 +60,4 @@ winapi = { version = "0.3", features = [
 ]}
 
 [dev-dependencies]
-k9 = "0.12"
+k9.workspace = true

--- a/procinfo/Cargo.toml
+++ b/procinfo/Cargo.toml
@@ -10,14 +10,14 @@ default = ["lua"]
 lua = ["dep:luahelper", "dep:wezterm-dynamic"]
 
 [dependencies]
-libc = "0.2"
-log = "0.4"
-luahelper = { path = "../luahelper", optional = true }
-wezterm-dynamic = { path = "../wezterm-dynamic", optional = true }
+libc.workspace = true
+log.workspace = true
+luahelper = { workspace=true, optional = true }
+wezterm-dynamic = { workspace=true, optional = true }
 
 [target."cfg(windows)".dependencies]
-ntapi = "0.4"
-winapi = { version = "0.3", features = [
+ntapi.workspace = true
+winapi = { workspace=true, features = [
     "handleapi",
     "memoryapi",
     "psapi",

--- a/promise/Cargo.toml
+++ b/promise/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-async-task = "4.7"
-async-executor = "1.11"
-async-io = "2.3"
-anyhow = "1.0"
-thiserror = "1.0"
-lazy_static = "1.4"
-flume = "0.11"
+anyhow.workspace = true
+async-executor.workspace = true
+async-io.workspace = true
+async-task.workspace = true
+flume.workspace = true
+lazy_static.workspace = true
+thiserror.workspace =true

--- a/pty/Cargo.toml
+++ b/pty/Cargo.toml
@@ -9,26 +9,25 @@ license = "MIT"
 documentation = "https://docs.rs/portable-pty"
 
 [dependencies]
-anyhow = "1.0"
-downcast-rs = "1.0"
-filedescriptor = { version="0.8.3", path = "../filedescriptor" }
-log = "0.4"
-libc = "0.2"
-nix = {version="0.28", features=["term", "fs"]}
-shell-words = "1.1"
-serde_derive = {version="1.0", optional=true}
-serde = {version="1.0", optional=true}
-serial2 = "0.2"
+anyhow.workspace = true
+downcast-rs.workspace = true
+filedescriptor.workspace = true
+libc.workspace = true
+log.workspace = true
+nix = {workspace=true, features=["term", "fs"]}
+serde = {workspace=true, optional=true, features=["derive"]}
+serial2.workspace = true
+shell-words.workspace = true
 
 [features]
 default = []
-serde_support = ["serde", "serde_derive"]
+serde_support = ["serde"]
 
 [target."cfg(windows)".dependencies]
-bitflags = "1.3"
-lazy_static = "1.4"
-shared_library = "0.1"
-winapi = { version = "0.3", features = [
+bitflags.workspace = true
+lazy_static.workspace = true
+shared_library.workspace = true
+winapi = { workspace=true, features = [
     "winuser",
     "consoleapi",
     "handleapi",
@@ -36,8 +35,8 @@ winapi = { version = "0.3", features = [
     "namedpipeapi",
     "synchapi",
 ]}
-winreg = "0.10"
+winreg.workspace = true
 
 [dev-dependencies]
-smol = "2.0"
-futures = "0.3"
+futures.workspace = true
+smol.workspace = true

--- a/pty/src/cmdbuilder.rs
+++ b/pty/src/cmdbuilder.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use anyhow::Context;
 #[cfg(feature = "serde_support")]
-use serde_derive::*;
+use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 #[cfg(windows)]

--- a/pty/src/lib.rs
+++ b/pty/src/lib.rs
@@ -42,7 +42,7 @@ use downcast_rs::{impl_downcast, Downcast};
 #[cfg(unix)]
 use libc;
 #[cfg(feature = "serde_support")]
-use serde_derive::*;
+use serde::{Deserialize, Serialize};
 use std::io::Result as IoResult;
 #[cfg(windows)]
 use std::os::windows::prelude::{AsRawHandle, RawHandle};

--- a/rangeset/Cargo.toml
+++ b/rangeset/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-num = "0.4"
+num.workspace = true
 
 [dev-dependencies]
-criterion = "0.5"
+criterion.workspace = true
 
 [[bench]]
 name = "rangeset"

--- a/ratelim/Cargo.toml
+++ b/ratelim/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-governor = {version="0.5", default-features=false, features=["std"]}
-config = { path = "../config" }
+config.workspace = true
+governor.workspace = true

--- a/strip-ansi-escapes/Cargo.toml
+++ b/strip-ansi-escapes/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = {version="4.0", features=["derive"]}
-termwiz = { path = "../termwiz" }
+clap.workspace = true
+termwiz.workspace = true

--- a/sync-color-schemes/Cargo.toml
+++ b/sync-color-schemes/Cargo.toml
@@ -7,22 +7,22 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-color-funcs = { path = "../lua-api-crates/color-funcs" }
-config = { path = "../config" }
-env_logger = "0.11"
-futures = "0.3"
-lazy_static = "1.4"
-libflate = "2"
-log = "0.4"
-reqwest = "0.12"
-rusqlite = {version="0.30", features=["bundled", "blob"]}
-serde = {version="1.0", features=["derive"]}
-serde_json = "1.0"
-serde_yaml = "0.9"
-sqlite-cache = {git="https://github.com/losfair/sqlite-cache", rev="0961b50385ff189bb12742716331c05ed0bf7805" }
-tar = "0.4"
-tempfile = "3.3"
-tokio = { version = "1.19", features = ["rt-multi-thread", "sync", "macros"] }
-toml = "0.8"
-wezterm-dynamic = { path = "../wezterm-dynamic" }
+anyhow.workspace = true
+color-funcs.workspace = true
+config.workspace = true
+env_logger.workspace = true
+futures.workspace = true
+lazy_static.workspace = true
+libflate.workspace = true
+log.workspace = true
+reqwest.workspace = true
+rusqlite = {workspace=true, features=["bundled", "blob"]}
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+sqlite-cache.workspace = true
+tar.workspace = true
+tempfile.workspace = true
+tokio = { workspace=true, features = ["rt-multi-thread", "sync", "macros"] }
+toml.workspace = true
+wezterm-dynamic.workspace = true

--- a/tabout/Cargo.toml
+++ b/tabout/Cargo.toml
@@ -9,4 +9,4 @@ license = "MIT"
 documentation = "https://docs.rs/tabout"
 
 [dependencies]
-termwiz = { path = "../termwiz", version="0.23"}
+termwiz.workspace = true

--- a/term/Cargo.toml
+++ b/term/Cargo.toml
@@ -14,32 +14,31 @@ readme = "README.md"
 use_serde = ["termwiz/use_serde"]
 
 [dependencies]
-anyhow = "1.0"
-bitflags = "1.3"
-csscolorparser = "0.6"
-downcast-rs = "1.0"
-humansize = "2.1"
-miniz_oxide = "0.7"
-finl_unicode = "1.2"
-hex = "0.4"
-image = "0.25"
-lazy_static = "1.4"
-log = "0.4"
-lru = "0.12"
-num-traits = "0.2"
-ordered-float = "4.1"
-serde = {version="1.0", features = ["rc"]}
-terminfo = "0.9"
-unicode-normalization = "0.1.21"
-url = "2"
-wezterm-bidi = { path = "../bidi" }
-wezterm-dynamic = { path = "../wezterm-dynamic" }
+anyhow.workspace = true
+bitflags.workspace = true
+csscolorparser.workspace = true
+downcast-rs.workspace = true
+finl_unicode.workspace = true
+hex.workspace = true
+humansize.workspace = true
+image.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+lru.workspace = true
+miniz_oxide.workspace = true
+num-traits.workspace = true
+ordered-float.workspace = true
+serde = {workspace=true, features = ["rc"]}
+terminfo.workspace = true
+unicode-normalization.workspace = true
+url.workspace = true
+wezterm-bidi.workspace = true
+wezterm-dynamic.workspace = true
 
 [dev-dependencies]
-env_logger = "0.11"
-k9 = "0.12.0"
+env_logger.workspace = true
+k9.workspace = true
 
 [dependencies.termwiz]
-version = "0.23"
-path = "../termwiz"
+workspace = true
 features = ["use_image"]

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -11,41 +11,40 @@ keywords = ["terminal", "readline", "console", "curses"]
 readme = "README.md"
 
 [dependencies]
-# backtrace = "0.3"
-base64 = "0.21"
+anyhow.workspace = true
+base64.workspace = true
 bitflags = "2.0"
-cassowary = {version="0.3", optional=true}
-anyhow = "1.0"
-fancy-regex = "0.11"
-filedescriptor = { version="0.8", path = "../filedescriptor" }
-finl_unicode = "1.2"
-fixedbitset = "0.4"
-fnv = {version="1.0", optional=true}
-hex = "0.4"
-image = {version="0.25", optional=true}
-lazy_static = "1.4"
-libc = "0.2"
-log = "0.4"
-memmem = "0.1"
-num-derive = "0.4"
-num-traits = "0.2"
-ordered-float = "4.1"
-pest = "2.1"
-pest_derive = "2.1"
-phf = "0.11"
-serde = {version="1.0", features = ["rc", "derive"], optional=true}
-siphasher = "0.3"
-sha2 = "0.10"
-terminfo = "0.9"
-thiserror = "1.0"
-unicode-segmentation = "1.8"
-ucd-trie = "0.1"
-vtparse = { version="0.6.2", path="../vtparse" }
-wezterm-bidi = { path = "../bidi", version="0.2.1" }
-wezterm-blob-leases = { path = "../wezterm-blob-leases", version="0.1" }
-wezterm-color-types = { path = "../color-types", version="0.3" }
-wezterm-input-types = { path = "../wezterm-input-types", version="0.1", default-features=false }
-wezterm-dynamic = { path = "../wezterm-dynamic", version="0.2.1" }
+cassowary = {workspace=true, optional=true}
+fancy-regex.workspace = true
+filedescriptor.workspace = true
+finl_unicode.workspace = true
+fixedbitset.workspace = true
+fnv = {workspace=true, optional=true}
+hex.workspace = true
+image = {workspace=true, optional=true}
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+memmem.workspace = true
+num-derive.workspace = true
+num-traits.workspace = true
+ordered-float.workspace = true
+pest.workspace = true
+pest_derive.workspace = true
+phf.workspace = true
+serde = {workspace=true, features = ["rc", "derive"], optional=true}
+sha2.workspace = true
+siphasher.workspace = true
+terminfo.workspace = true
+thiserror.workspace = true
+ucd-trie.workspace = true
+unicode-segmentation.workspace = true
+vtparse.workspace = true
+wezterm-bidi.workspace = true
+wezterm-blob-leases.workspace = true
+wezterm-color-types.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-input-types.workspace = true
 
 [features]
 widgets = ["cassowary", "fnv"]
@@ -54,16 +53,16 @@ use_image = ["image"]
 docs = ["widgets", "use_serde"]
 
 [dev-dependencies]
-criterion = "0.5"
-varbincode = "0.1"
-k9 = "0.12"
-env_logger = "0.11"
+criterion.workspace = true
+env_logger.workspace = true
+k9.workspace = true
+varbincode.workspace = true
 
 
 [target."cfg(unix)".dependencies]
-signal-hook = "0.3"
-termios = "0.3"
-nix = {version="0.28", features=["mman", "fs"]}
+signal-hook.workspace = true
+termios.workspace = true
+nix = {workspace=true, features=["mman", "fs"]}
 
 [target."cfg(windows)".dependencies.winapi]
 features = [
@@ -79,7 +78,7 @@ features = [
     "winnt",
     "impl-default"
 ]
-version = "0.3.9"
+workspace = true
 
 [package.metadata.docs.rs]
 features = ["docs"]

--- a/termwiz/codegen/Cargo.toml
+++ b/termwiz/codegen/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-human-sort = "0.2"
-phf_codegen = "0.10"
-reqwest = {version="0.12", features=["blocking"]}
-serde = {version="1.0", features=["derive"]}
-serde_json = "1.0"
-ucd-trie = "0.1"
+human-sort.workspace = true
+phf_codegen.workspace = true
+reqwest = {workspace=true, features=["blocking"]}
+serde = {workspace=true, features=["derive"]}
+serde_json.workspace = true
+ucd-trie.workspace = true
 

--- a/umask/Cargo.toml
+++ b/umask/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4"
-libc = "0.2"
+lazy_static.workspace = true
+libc.workspace = true

--- a/vtparse/Cargo.toml
+++ b/vtparse/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["terminal", "escape", "ansi", "sequence", "parser"]
 readme = "README.md"
 
 [dependencies]
-utf8parse = "0.2"
+utf8parse.workspace = true
 
 [dev-dependencies]
-k9 = "0.12"
+k9.workspace = true

--- a/wezterm-blob-leases/Cargo.toml
+++ b/wezterm-blob-leases/Cargo.toml
@@ -9,13 +9,13 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-getrandom = "0.3.1"
-mac_address = "1.1.8"
-serde = {version="1.0", features=["derive"], optional=true}
-sha2 = "0.10"
-tempfile = {version="3.16", optional=true}
-thiserror = "1.0"
-uuid = {version="1.13", features=["v1", "rng"]}
+getrandom.workspace = true
+mac_address.workspace = true
+serde = {workspace=true, features=["derive"], optional=true}
+sha2.workspace = true
+tempfile = {workspace=true, optional=true}
+thiserror.workspace = true
+uuid = {workspace=true, features=["v1", "rng"]}
 
 [features]
 default = []

--- a/wezterm-client/Cargo.toml
+++ b/wezterm-client/Cargo.toml
@@ -8,38 +8,38 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-async-trait = "0.1"
-async_ossl = { path = "../async_ossl" }
-async-io = "2.3"
-codec = { path = "../codec" }
-config = { path = "../config" }
-filedescriptor = { version="0.8", path = "../filedescriptor" }
-futures = "0.3"
-lazy_static = "1.4"
-log = "0.4"
-libc = "0.2"
-lru = "0.12"
-metrics = "0.23"
-mux = { path = "../mux" }
-openssl = "0.10.57"
-parking_lot = "0.12"
-portable-pty = { path = "../pty", features = ["serde_support"]}
-promise = { path = "../promise" }
-rangeset = { path = "../rangeset" }
-ratelim= { path = "../ratelim" }
-smol = "2.0"
-termwiz = { path = "../termwiz" }
-textwrap = "0.16"
-thiserror = "1.0"
-umask = { path = "../umask" }
-url = "2"
-wezterm-dynamic = { path = "../wezterm-dynamic" }
-wezterm-ssh = { path = "../wezterm-ssh" }
-wezterm-term = { path = "../term", features=["use_serde"] }
-wezterm-uds = { path = "../wezterm-uds" }
+anyhow.workspace = true
+async-io.workspace = true
+async-trait.workspace = true
+async_ossl.workspace = true
+codec.workspace = true
+config.workspace = true
+filedescriptor.workspace = true
+futures.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+lru.workspace = true
+metrics.workspace = true
+mux.workspace = true
+openssl.workspace = true
+parking_lot.workspace = true
+portable-pty = { workspace=true, features = ["serde_support"]}
+promise.workspace = true
+rangeset.workspace = true
+ratelim.workspace = true
+smol.workspace = true
+termwiz.workspace = true
+textwrap.workspace = true
+thiserror.workspace = true
+umask.workspace = true
+url.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-ssh.workspace = true
+wezterm-term = { workspace=true, features=["use_serde"] }
+wezterm-uds.workspace = true
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = [
+winapi = { workspace=true, features = [
     "winuser",
 ]}

--- a/wezterm-dynamic/Cargo.toml
+++ b/wezterm-dynamic/Cargo.toml
@@ -7,11 +7,11 @@ description = "config serialization for wezterm via dynamic json-like data value
 license = "MIT"
 
 [dependencies]
-wezterm-dynamic-derive = { version="0.1.1", path="derive" }
-ordered-float = "4.1"
-thiserror = "1.0"
-strsim = "0.11"
-log = "0.4"
+log.workspace = true
+ordered-float.workspace = true
+strsim.workspace = true
+thiserror.workspace = true
+wezterm-dynamic-derive.workspace = true
 
 [dev-dependencies]
-maplit = "1.0"
+maplit.workspace = true

--- a/wezterm-dynamic/derive/Cargo.toml
+++ b/wezterm-dynamic/derive/Cargo.toml
@@ -10,6 +10,6 @@ license = "MIT"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0.2"
-syn = {version="1.0", features=["extra-traits"]}
+proc-macro2.workspace = true
+quote.workspace = true
+syn = {workspace=true, features=["extra-traits"]}

--- a/wezterm-font/Cargo.toml
+++ b/wezterm-font/Cargo.toml
@@ -14,45 +14,45 @@ vendor-noto-emoji = []
 vendor-nerd-font-symbols = []
 
 [dependencies]
-anyhow = "1.0"
-cairo-rs = {version="0.18", default-features=false}
-config = { path = "../config" }
-encoding_rs = "0.8"
-enum-display-derive = "0.1"
-euclid = "0.22"
-finl_unicode = "1.2"
-freetype = { path = "../deps/freetype" }
-harfbuzz = { path = "../deps/harfbuzz" }
-image = "0.25"
-lazy_static = "1.4"
-lfucache = { path = "../lfucache" }
-log = "0.4"
-memmap2 = "0.9"
-metrics = "0.23"
-ordered-float = "4.1"
-rangeset = { path = "../rangeset" }
-termwiz = { path = "../termwiz" }
-thiserror = "1.0"
-walkdir = "2"
-wezterm-color-types = { path = "../color-types" }
-wezterm-input-types = { path = "../wezterm-input-types" }
-wezterm-term = { path = "../term", features=["use_serde"] }
-wezterm-toast-notification = { path = "../wezterm-toast-notification" }
-wezterm-bidi = { path = "../bidi" }
+anyhow.workspace = true
+cairo-rs.workspace = true
+config.workspace = true
+encoding_rs.workspace = true
+enum-display-derive.workspace = true
+euclid.workspace = true
+finl_unicode.workspace = true
+freetype.workspace = true
+harfbuzz.workspace = true
+image.workspace = true
+lazy_static.workspace = true
+lfucache.workspace = true
+log.workspace = true
+memmap2.workspace = true
+metrics.workspace = true
+ordered-float.workspace = true
+rangeset.workspace = true
+termwiz.workspace = true
+thiserror.workspace = true
+walkdir.workspace = true
+wezterm-bidi.workspace = true
+wezterm-color-types.workspace = true
+wezterm-input-types.workspace = true
+wezterm-term = { workspace=true, features=["use_serde"] }
+wezterm-toast-notification.workspace = true
 
 [target.'cfg(any(target_os = "android", all(unix, not(target_os = "macos"))))'.dependencies]
-fontconfig = { path = "../deps/fontconfig" }
+fontconfig.workspace = true
 
 [target."cfg(windows)".dependencies]
-dwrote = "0.11"
-winapi = "0.3"
+dwrote.workspace = true
+winapi.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.25"
-core-foundation = "0.9"
-core-text = "20.0"
-objc = "0.2"
+cocoa.workspace = true
+core-foundation.workspace = true
+core-text.workspace = true
+objc.workspace = true
 
 [dev-dependencies]
-k9 = "0.12.0"
-env_logger = "0.11"
+env_logger.workspace = true
+k9.workspace = true

--- a/wezterm-gui-subcommands/Cargo.toml
+++ b/wezterm-gui-subcommands/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = {version="4.0", features=["derive"]}
-config = { path = "../config" }
-anyhow = "1.0"
+anyhow.workspace = true
+clap.workspace = true
+config.workspace = true

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -27,91 +27,91 @@ dhat-heap = ["dhat"]    # if you are doing heap profiling
 dhat-ad-hoc = ["dhat"]  # if you are doing ad hoc profiling
 
 [build-dependencies]
-anyhow = "1.0"
+anyhow.workspace = true
 
 [target.'cfg(windows)'.build-dependencies]
-embed-resource = "1.7"
-cc = "1.0"
+cc.workspace = true
+embed-resource.workspace = true
 
 [dependencies]
-anyhow = "1.0"
-bitflags = "1.3"
-bytemuck = { version="1.4", features=["derive"]}
-chrono = {version="0.4", default-features=false}
-clap = {version="4.0", features=["derive"]}
-codec = { path = "../codec" }
-colorgrad = "0.6"
-config = { path = "../config" }
-downcast-rs = "1.0"
-dhat = {version="0.3", optional=true}
-dirs-next = "2.0"
-emojis = "0.6"
-env-bootstrap = { path = "../env-bootstrap" }
-euclid = "0.22"
-fastrand = "2.0"
-filedescriptor = { version="0.8", path = "../filedescriptor" }
-finl_unicode = "1.2"
-frecency = { path = "../frecency" }
-futures = "0.3"
-nucleo-matcher = "0.3"
-hdrhistogram = "7.1"
-http_req = "0.11"
-image = "0.25"
-lazy_static = "1.4"
-libc = "0.2"
-lfucache = { path = "../lfucache" }
-log = "0.4"
-luahelper = { path = "../luahelper" }
-metrics = "0.23"
-mlua = {version="0.9", features=["send", "serialize"]}
-mux = { path = "../mux" }
-mux-lua = { path = "../lua-api-crates/mux" }
-once_cell = "1.8"
-ordered-float = "4.1"
-parking_lot = "0.12"
-portable-pty = { path = "../pty", features = ["serde_support"]}
-promise = { path = "../promise" }
-rangeset = { path = "../rangeset" }
-ratelim= { path = "../ratelim" }
-rayon = "1.7"
-regex = "1"
-serde = {version="1.0", features = ["rc", "derive"]}
-serde_json = "1.0"
-shlex = "1.1"
-smol = "2.0"
-tabout = { path = "../tabout" }
-tempfile = "3.4"
-terminfo = "0.9"
-termwiz = { path = "../termwiz" }
-termwiz-funcs = { path = "../lua-api-crates/termwiz-funcs" }
-textwrap = "0.16"
-thiserror = "1.0"
-tiny-skia = "0.11"
-umask = { path = "../umask" }
-unicode-normalization = "0.1"
-unicode-segmentation = "1.8"
-unicode-width = "0.1"
-url = "2"
-url-funcs = { path = "../lua-api-crates/url-funcs" }
-walkdir = "2"
-wezterm-bidi = { path = "../bidi" }
-wezterm-blob-leases = { path = "../wezterm-blob-leases", version="0.1", features=["simple_tempdir"] }
-wezterm-client = { path = "../wezterm-client" }
-wezterm-dynamic = { path = "../wezterm-dynamic" }
-wezterm-font = { path = "../wezterm-font" }
-wezterm-gui-subcommands = { path = "../wezterm-gui-subcommands" }
-wezterm-mux-server-impl = { path = "../wezterm-mux-server-impl" }
-wezterm-open-url = { path = "../wezterm-open-url" }
-wezterm-ssh = { path = "../wezterm-ssh" }
-wezterm-term = { path = "../term", features=["use_serde"] }
-wezterm-toast-notification = { path = "../wezterm-toast-notification" }
-wgpu = "24.0.1"
-window = { path = "../window" }
-window-funcs = { path = "../lua-api-crates/window-funcs" }
+anyhow.workspace = true
+bitflags.workspace = true
+bytemuck.workspace = true
+chrono.workspace = true
+clap.workspace = true
+codec.workspace = true
+colorgrad.workspace = true
+config.workspace = true
+dhat = {workspace=true, optional=true}
+dirs-next.workspace = true
+downcast-rs.workspace = true
+emojis.workspace = true
+env-bootstrap.workspace = true
+euclid.workspace = true
+fastrand.workspace = true
+filedescriptor.workspace = true
+finl_unicode.workspace = true
+frecency.workspace = true
+futures.workspace = true
+hdrhistogram.workspace = true
+http_req.workspace = true
+image.workspace = true
+lazy_static.workspace = true
+lfucache.workspace = true
+libc.workspace = true
+log.workspace = true
+luahelper.workspace = true
+metrics.workspace = true
+mlua = {workspace=true, features=["send", "serialize"]}
+mux-lua.workspace = true
+mux.workspace = true
+nucleo-matcher.workspace = true
+once_cell.workspace = true
+ordered-float.workspace = true
+parking_lot.workspace = true
+portable-pty = { workspace=true, features = ["serde_support"]}
+promise.workspace = true
+rangeset.workspace = true
+ratelim.workspace = true
+rayon.workspace = true
+regex.workspace = true
+serde = {workspace=true, features = ["rc", "derive"]}
+serde_json.workspace = true
+shlex.workspace = true
+smol.workspace = true
+tabout.workspace = true
+tempfile.workspace = true
+terminfo.workspace = true
+termwiz-funcs.workspace = true
+termwiz.workspace = true
+textwrap.workspace = true
+thiserror.workspace = true
+tiny-skia.workspace = true
+umask.workspace = true
+unicode-normalization.workspace = true
+unicode-segmentation.workspace = true
+unicode-width.workspace = true
+url-funcs.workspace = true
+url.workspace = true
+walkdir.workspace = true
+wezterm-bidi.workspace = true
+wezterm-blob-leases = { workspace=true, features=["simple_tempdir"] }
+wezterm-client.workspace = true
+wezterm-dynamic.workspace = true
+wezterm-font.workspace = true
+wezterm-gui-subcommands.workspace = true
+wezterm-mux-server-impl.workspace = true
+wezterm-open-url.workspace = true
+wezterm-ssh.workspace = true
+wezterm-term.workspace = true
+wezterm-toast-notification.workspace = true
+wgpu.workspace = true
+window-funcs.workspace = true
+window.workspace = true
 
 [target."cfg(windows)".dependencies]
-shared_library = "0.1"
-winapi = { version = "0.3", features = [
+shared_library.workspace = true
+winapi = { workspace=true, features = [
     "winuser",
     "consoleapi",
     "handleapi",
@@ -120,11 +120,11 @@ winapi = { version = "0.3", features = [
     "synchapi",
     "winsock2",
 ]}
-windows = { version="0.33.0", features = [
+windows = { workspace=true, features = [
     "Win32_UI_Shell",
 ]}
 
 [dev-dependencies]
-k9 = "0.12.0"
-env_logger = "0.11"
-benchmarking = "0.4"
+benchmarking.workspace = true
+env_logger.workspace = true
+k9.workspace = true

--- a/wezterm-input-types/Cargo.toml
+++ b/wezterm-input-types/Cargo.toml
@@ -10,11 +10,11 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitflags = "1.3"
-euclid = "0.22"
-lazy_static = "1.4"
-serde = {version="1.0", features = ["rc", "derive"], optional=true}
-wezterm-dynamic = {path="../wezterm-dynamic", version="0.2"}
+bitflags.workspace = true
+euclid.workspace = true
+lazy_static.workspace = true
+serde = {workspace=true, features = ["rc", "derive"], optional=true}
+wezterm-dynamic.workspace = true
 
 [features]
 default = ["serde"]

--- a/wezterm-mux-server-impl/Cargo.toml
+++ b/wezterm-mux-server-impl/Cargo.toml
@@ -8,28 +8,28 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-async_ossl = { path = "../async_ossl" }
-async-io = "2.3"
-codec = { path = "../codec" }
-config = { path = "../config" }
-dns-lookup = "2.0"
-futures = "0.3"
-hostname = "0.4"
-lazy_static = "1.4"
-libc = "0.2"
-log = "0.4"
-mux = { path = "../mux" }
-portable-pty = { path = "../pty", features = ["serde_support"]}
-promise = { path = "../promise" }
-rangeset = { path = "../rangeset" }
-rcgen = "0.12"
-smol = "2.0"
-url = "2"
-wezterm-client = { path = "../wezterm-client" }
-wezterm-term = { path = "../term", features=["use_serde"] }
-wezterm-uds = { path = "../wezterm-uds" }
-termwiz = { path = "../termwiz", features=["use_serde"] }
+anyhow.workspace = true
+async-io.workspace = true
+async_ossl.workspace = true
+codec.workspace = true
+config.workspace = true
+dns-lookup.workspace = true
+futures.workspace = true
+hostname.workspace = true
+lazy_static.workspace = true
+libc.workspace = true
+log.workspace = true
+mux.workspace = true
+portable-pty = { workspace=true, features = ["serde_support"]}
+promise.workspace = true
+rangeset.workspace = true
+rcgen.workspace = true
+smol.workspace = true
+termwiz = { workspace=true, features=["use_serde"] }
+url.workspace = true
+wezterm-client.workspace = true
+wezterm-term = { workspace=true, features=["use_serde"] }
+wezterm-uds.workspace = true
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = [ "winuser" ]}
+winapi = { workspace=true, features = [ "winuser" ]}

--- a/wezterm-mux-server/Cargo.toml
+++ b/wezterm-mux-server/Cargo.toml
@@ -9,27 +9,27 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-async_ossl = { path = "../async_ossl" }
-clap = {version="4.0", features=["derive"]}
-config = { path = "../config" }
-env-bootstrap = { path = "../env-bootstrap" }
-libc = "0.2"
-log = "0.4"
-mux = { path = "../mux" }
-mlua = "0.9"
-openssl = "0.10"
-portable-pty = { path = "../pty", features = ["serde_support"]}
-promise = { path = "../promise" }
-umask = { path = "../umask" }
-wezterm-blob-leases = { path = "../wezterm-blob-leases", version="0.1", features=["simple_tempdir"] }
-wezterm-mux-server-impl = { path = "../wezterm-mux-server-impl" }
-wezterm-gui-subcommands = { path = "../wezterm-gui-subcommands" }
-wezterm-term = { path = "../term" }
+anyhow.workspace = true
+async_ossl.workspace = true
+clap.workspace = true
+config.workspace = true
+env-bootstrap.workspace = true
+libc.workspace = true
+log.workspace = true
+mux.workspace = true
+mlua.workspace = true
+openssl.workspace = true
+portable-pty = { workspace=true, features = ["serde_support"]}
+promise.workspace = true
+umask.workspace = true
+wezterm-blob-leases = {workspace=true, features=["simple_tempdir"]}
+wezterm-mux-server-impl.workspace = true
+wezterm-gui-subcommands.workspace = true
+wezterm-term.workspace = true
 
 [target."cfg(windows)".dependencies]
-winapi = { version = "0.3", features = [ "winuser" ]}
+winapi = { workspace=true, features = [ "winuser" ]}
 
 [target.'cfg(windows)'.build-dependencies]
-embed-resource = "1.7"
-cc = "1.0"
+embed-resource.workspace = true
+cc.workspace = true

--- a/wezterm-open-url/Cargo.toml
+++ b/wezterm-open-url/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-winapi = {version="0.3", features=["shellapi"]}
+winapi = {workspace=true, features=["shellapi"]}

--- a/wezterm-ssh/Cargo.toml
+++ b/wezterm-ssh/Cargo.toml
@@ -17,40 +17,40 @@ vendored-openssl-ssh2 = ["ssh2/vendored-openssl"]
 vendored-openssl-libssh-rs = ["libssh-rs/vendored-openssl"]
 
 [dependencies]
-anyhow = "1.0"
-base64 = "0.22"
-bitflags = "1.3"
-camino = "1.0"
-dirs-next = "2.0"
-filedescriptor = { version="0.8", path = "../filedescriptor" }
-filenamegen = "0.2.6"
-gethostname = "0.5"
-libc = "0.2"
-log = "0.4"
-portable-pty = { version="0.9", path = "../pty" }
-regex = "1"
-smol = "2.0"
-ssh2 = {version="0.9.3", features=["openssl-on-win32"], optional = true}
-libssh-rs = {version="0.3.5", features=["vendored"], optional = true}
+anyhow.workspace = true
+base64.workspace = true
+bitflags.workspace = true
+camino.workspace = true
+dirs-next.workspace = true
+filedescriptor.workspace = true
+filenamegen.workspace = true
+gethostname.workspace = true
+libc.workspace = true
+libssh-rs = {workspace=true, features=["vendored"], optional = true}
 #libssh-rs = {path="../../libssh-rs/libssh-rs", features=["vendored"], optional = true}
-thiserror = "1.0"
-socket2 = "0.5"
-wezterm-uds = { path = "../wezterm-uds" }
+log.workspace = true
+portable-pty.workspace = true
+regex.workspace = true
+smol.workspace = true
+socket2.workspace = true
+ssh2 = {workspace=true, features=["openssl-on-win32"], optional = true}
+thiserror.workspace = true
+wezterm-uds.workspace = true
 
 # Not used directly, but is used to centralize the openssl vendor feature selection
-async_ossl = { path = "../async_ossl" }
+async_ossl.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-passfd = "0.1.6"
+passfd.workspace = true
 
 [dev-dependencies]
-assert_fs = "1.0.4"
-clap = {version="4.0", features=["derive"]}
-k9 = "0.12.0"
-once_cell = "1.8"
-predicates = "3.0"
-env_logger = "0.11"
-rstest = "0.21"
-shell-words = "1.1"
-termwiz = { version = "0.23", path = "../termwiz" }
-whoami = "1.5"
+assert_fs.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+k9.workspace = true
+once_cell.workspace = true
+predicates.workspace = true
+rstest.workspace = true
+shell-words.workspace = true
+termwiz.workspace = true
+whoami.workspace = true

--- a/wezterm-toast-notification/Cargo.toml
+++ b/wezterm-toast-notification/Cargo.toml
@@ -9,28 +9,28 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wezterm-open-url = { path = "../wezterm-open-url" }
-log = "0.4"
+log.workspace = true
+wezterm-open-url.workspace = true
 
 [target.'cfg(all(not(windows), not(target_os="macos")))'.dependencies]
-serde = {version="1.0", features = ["derive"]}
-zbus = "4.2"
-zvariant = "4.0"
-async-io = "2.3"
-futures-util = "0.3"
+async-io.workspace = true
+futures-util.workspace = true
+serde = {workspace=true, features = ["derive"]}
+zbus.workspace = true
+zvariant.workspace = true
 
 [target.'cfg(target_os="macos")'.dependencies]
-block2 = "0.6"
-objc2 = "0.6"
-objc2-user-notifications = "0.3"
-objc2-foundation = "0.3"
-uuid.workspace = true
+block2.workspace = true
+objc2.workspace = true
+objc2-user-notifications.workspace = true
+objc2-foundation.workspace = true
+uuid = { workspace=true, features=["v4", "fast-rng"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version="0.33.0", features = [
+windows = { workspace=true, features = [
     "Data_Xml_Dom",
     "Foundation",
     "UI_Notifications",
     "Win32_Foundation",
 ]}
-xml-rs = "0.8"
+xml-rs.workspace = true

--- a/wezterm-uds/Cargo.toml
+++ b/wezterm-uds/Cargo.toml
@@ -8,5 +8,5 @@ license = "MIT"
 documentation = "https://docs.rs/wezterm-uds"
 
 [dependencies]
-async-io = "2.3"
-uds_windows = "1.1"
+async-io.workspace = true
+uds_windows.workspace = true

--- a/wezterm-version/Cargo.toml
+++ b/wezterm-version/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-git2 = { version = "0.18", default-features = false }
+git2 = { workspace=true, default-features = false }
 
 [dependencies]

--- a/wezterm/Cargo.toml
+++ b/wezterm/Cargo.toml
@@ -8,40 +8,40 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0"
-chrono = {version="0.4", default-features=false}
-clap = {version="4.0", features=["derive", "wrap_help"]}
-clap_complete = "4.4"
-clap_complete_fig = "4.0"
-codec = { path = "../codec" }
-config = { path = "../config" }
-env-bootstrap = { path = "../env-bootstrap" }
-filedescriptor = { version="0.8", path = "../filedescriptor" }
-hostname = "0.4"
-humantime = "2.1"
-image = "0.25"
-libc = "0.2"
-log = "0.4"
-mux = { path = "../mux" }
-portable-pty = { path = "../pty" }
-promise = { path = "../promise" }
-serde = {version="1.0", features = ["derive"]}
-serde_json = "1.0"
-shell-words = "1.1"
-smol = "2.0"
-tabout = { path = "../tabout" }
-tempfile = "3.3"
-termwiz = { path = "../termwiz" }
-termwiz-funcs = { path = "../lua-api-crates/termwiz-funcs" }
-textwrap = "0.16"
-umask = { path = "../umask" }
-url = "2"
-wezterm-client = { path = "../wezterm-client" }
-wezterm-gui-subcommands = { path = "../wezterm-gui-subcommands" }
-wezterm-term = { path = "../term" }
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+clap_complete.workspace = true
+clap_complete_fig.workspace = true
+codec.workspace = true
+config.workspace = true
+env-bootstrap.workspace = true
+filedescriptor.workspace = true
+hostname.workspace = true
+humantime.workspace = true
+image.workspace = true
+libc.workspace = true
+log.workspace = true
+mux.workspace = true
+portable-pty.workspace = true
+promise.workspace  =true
+serde.workspace = true
+serde_json.workspace = true
+shell-words.workspace = true
+smol.workspace = true
+tabout.workspace = true
+tempfile.workspace = true
+termwiz-funcs.workspace = true
+termwiz.workspace = true
+textwrap.workspace  =true
+umask.workspace = true
+url.workspace = true
+wezterm-client.workspace = true
+wezterm-gui-subcommands.workspace = true
+wezterm-term.workspace = true
 
 [target."cfg(unix)".dependencies]
-termios = "0.3"
+termios.workspace = true
 
 [target."cfg(windows)".dependencies.winapi]
 features = [
@@ -54,8 +54,8 @@ features = [
     "fileapi",
     "synchapi",
 ]
-version = "0.3"
+workspace = true
 
 [target.'cfg(windows)'.build-dependencies]
-embed-resource = "1.7"
-cc = "1.0"
+cc.workspace = true
+embed-resource.workspace = true

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -9,48 +9,48 @@ license = "MIT"
 build = "build.rs"
 
 [dev-dependencies]
-k9 = "0.12.0"
+k9.workspace = true
 
 [build-dependencies]
-gl_generator = "0.14"
+gl_generator.workspace = true
 
 [features]
 wayland = ["wayland-client", "smithay-client-toolkit", "wayland-egl", "wayland-protocols", "wayland-backend"]
 
 [dependencies]
-async-channel = "2.3"
-async-io = "2.3"
-async-task = "4.7"
-async-trait = "0.1"
-anyhow = "1.0"
-bytes = "1.0"
-config = { path = "../config" }
-downcast-rs = "1.0"
-thiserror = "1.0"
-bitflags = "1.3"
-euclid = "0.22"
-guillotiere = "0.6"
-lazy_static = "1.4"
-libloading = "0.8"
-line_drawing = "0.8"
-log = "0.4"
-metrics = "0.23"
-promise = { path = "../promise" }
-raw-window-handle = "0.6"
-resize = "0.5"
-serde = {version="1.0", features = ["rc", "derive"]}
-tiny-skia = "0.11"
-glium = { version = "0.35", default-features = false }
-url = "2"
-wezterm-bidi = { path = "../bidi" }
-wezterm-color-types = { path = "../color-types" }
-wezterm-font = { path = "../wezterm-font" }
-wezterm-input-types = { path = "../wezterm-input-types" }
+async-channel.workspace = true
+async-io.workspace = true
+async-task.workspace = true
+async-trait.workspace = true
+anyhow.workspace = true
+bytes.workspace = true
+config.workspace = true
+downcast-rs.workspace = true
+thiserror.workspace = true
+bitflags.workspace = true
+euclid.workspace = true
+guillotiere.workspace = true
+lazy_static.workspace = true
+libloading.workspace = true
+line_drawing.workspace = true
+log.workspace = true
+metrics.workspace = true
+promise.workspace = true
+raw-window-handle.workspace = true
+resize.workspace = true
+serde = {workspace=true, features = ["rc", "derive"]}
+tiny-skia.workspace = true
+glium.workspace = true
+url.workspace = true
+wezterm-bidi.workspace = true
+wezterm-color-types.workspace = true
+wezterm-font.workspace = true
+wezterm-input-types.workspace = true
 
 [target."cfg(windows)".dependencies]
-clipboard-win = "2.2"
-shared_library = "0.1"
-winapi = { version = "0.3", features = [
+clipboard-win.workspace = true
+shared_library.workspace = true
+winapi = { workspace=true, features = [
     "dwmapi",
     "handleapi",
     "imm",
@@ -61,37 +61,37 @@ winapi = { version = "0.3", features = [
     "winerror",
     "winuser",
 ]}
-windows = { version="0.33.0", features = [
+windows = { workspace=true, features = [
     "UI_ViewManagement",
     "Win32_Devices_Display",
 ]}
-winreg = "0.10"
+winreg.workspace = true
 
 [target.'cfg(all(unix, not(target_os = "macos")))'.dependencies]
-dirs-next = "2.0"
-filedescriptor = { version="0.8", path = "../filedescriptor" }
-futures-util = "0.3"
-futures-lite = "2.3"
-x11 = {version ="2.21", features = ["xlib_xcb", "xlib"]}
-xcb = {version="1.3", features=["render", "randr", "dri2", "xkb", "xlib_xcb", "present", "as-raw-xcb-connection"]}
-xkbcommon = { version = "0.7.0", features = ["x11", "wayland"] }
-mio = {version="0.8", features=["os-ext"]}
-libc = "0.2"
-xcb-imdkit = { version="0.3", git="https://github.com/wez/xcb-imdkit-rs.git", rev="358e226573461fe540efb920e2aad740e3c6fab1"}
-zbus = "4.2"
-zvariant = "4.0"
+dirs-next.workspace = true
+filedescriptor.workspace = true
+futures-lite.workspace = true
+futures-util.workspace = true
+libc.workspace = true
+mio = {workspace=true, features=["os-ext"]}
+x11 = {workspace=true, features = ["xlib_xcb", "xlib"]}
+xcb = {workspace=true, features=["render", "randr", "dri2", "xkb", "xlib_xcb", "present", "as-raw-xcb-connection"]}
+xcb-imdkit.workspace = true
+xkbcommon = { workspace=true, features = ["x11", "wayland"] }
+zbus.workspace = true
+zvariant.workspace = true
 
-smithay-client-toolkit = {version = "0.19", default-features=false, optional=true}
-wayland-backend = {version="0.3.5", features=["client_system", "rwh_06"], optional=true}
-wayland-protocols = {version="0.32", optional=true}
-wayland-client = {version="0.31", optional=true}
-wayland-egl = {version="0.32", optional=true}
+smithay-client-toolkit = {workspace=true, default-features=false, optional=true}
+wayland-backend = {workspace=true, features=["client_system", "rwh_06"], optional=true}
+wayland-protocols = {workspace=true, optional=true}
+wayland-client = {workspace=true, optional=true}
+wayland-egl = {workspace=true, optional=true}
 
 [target.'cfg(target_os="macos")'.dependencies]
-cocoa = "0.25"
-objc = "0.2"
-core-foundation = "0.9"
-core-graphics = "0.23"
-cgl = "0.3"
-plist = "1.3"
-shlex = "1.1"
+cgl.workspace = true
+cocoa.workspace = true
+core-foundation.workspace = true
+core-graphics.workspace = true
+objc.workspace = true
+plist.workspace = true
+shlex.workspace = true


### PR DESCRIPTION
There have been a couple of attempts at this in the past, which had some usability warts in what I recall as an earlier, less useful set of features overall.

Whether that was collective misunderstanding at the time, or things have gotten better since then, now is a good time to adopt the workspace dep syntax, because wezterm has many crates to keep on top of, and automation like dependabot can't see a lot of them.

This will help to manage the versions of deps in wezterm centrally.

Let's try this out in CI: the Cargo.lock changes here are minimal (eliminated a second version of base64 from one crate, terminal_size from another, and removed an explicit dep on serde_derive) so hopefully this sails through on !linux.