### PR TITLE
Add alphabet to launcher args

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -414,6 +414,9 @@ pub struct Config {
     pub disable_default_key_bindings: bool,
     pub leader: Option<LeaderKey>,
 
+    #[dynamic(default = "default_num_alphabet")]
+    pub launcher_alphabet: String,
+
     #[dynamic(default)]
     pub disable_default_quick_select_patterns: bool,
     #[dynamic(default)]
@@ -1802,6 +1805,10 @@ fn default_status_update_interval() -> u64 {
 
 fn default_alternate_buffer_wheel_scroll_speed() -> u8 {
     3
+}
+
+fn default_num_alphabet() -> String {
+    "1234567890abcdefghilmnopqrstuvwxyz".to_string()
 }
 
 fn default_alphabet() -> String {

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1808,6 +1808,7 @@ fn default_alternate_buffer_wheel_scroll_speed() -> u8 {
 }
 
 fn default_num_alphabet() -> String {
+    // Note: vi motion keys are intentionally excluded from this alphabet
     "1234567890abcdefghilmnopqrstuvwxyz".to_string()
 }
 

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -19,6 +19,7 @@ pub struct LauncherActionArgs {
     pub title: Option<String>,
     pub help_text: Option<String>,
     pub fuzzy_help_text: Option<String>,
+    pub alphabet: Option<String>,
 }
 
 bitflags::bitflags! {

--- a/docs/config/lua/config/launcher_alphabet.md
+++ b/docs/config/lua/config/launcher_alphabet.md
@@ -1,0 +1,13 @@
+---
+tags:
+  - launcher
+---
+# `launcher_alphabet`
+
+{{since('nightly')}}
+
+Specify a string of unique characters. The characters in the string are used
+to calculate one or two click shortcuts that can be used to quickly choose from
+the Launcher when in the default mode. Defaults to:
+`"1234567890abcdefghilmnopqrstuvwxyz"`. (Without j/k so they can be used for movement
+up and down.)

--- a/docs/config/lua/config/launcher_alphabet.md
+++ b/docs/config/lua/config/launcher_alphabet.md
@@ -7,7 +7,7 @@ tags:
 {{since('nightly')}}
 
 Specify a string of unique characters. The characters in the string are used
-to calculate one or two click shortcuts that can be used to quickly choose from
+to calculate one or two key press shortcuts that can be used to quickly choose from
 the Launcher when in the default mode. Defaults to:
 `"1234567890abcdefghilmnopqrstuvwxyz"`. (Without j/k so they can be used for movement
 up and down.)

--- a/docs/config/lua/keyassignment/ShowLauncherArgs.md
+++ b/docs/config/lua/keyassignment/ShowLauncherArgs.md
@@ -15,9 +15,8 @@ The arguments are a lua table with the following keys:
   `"Fuzzy matching: "` {{since('nightly', inline=True)}}
 * `alphabet` - a string of unique characters. The characters in the string are used
   to calculate one or two click shortcuts that can be used to quickly choose from
-  the InputSelector when in the default mode. Defaults to:
-  `"1234567890abcdefghilmnopqrstuvwxyz"`. (Without j/k so they can be used for movement
-  up and down.) {{since('nightly', inline=True)}}
+  the Launcher when in the default mode. Defaults to the same value as
+  [launcher_alphabet](../config/launcher_alphabet.md) {{since('nightly', inline=True)}}
 
 The possible flags are listed below. You must explicitly list each item that you
 want to include in the launcher. If you only specify `"FUZZY"` then you will see

--- a/docs/config/lua/keyassignment/ShowLauncherArgs.md
+++ b/docs/config/lua/keyassignment/ShowLauncherArgs.md
@@ -13,6 +13,11 @@ The arguments are a lua table with the following keys:
   `"Select an item and press Enter=launch  Esc=cancel  /=filter"` {{since('nightly', inline=True)}}
 * `fuzzy_help_text` - a string to display when in fuzzy finding mode. Defaults to:
   `"Fuzzy matching: "` {{since('nightly', inline=True)}}
+* `alphabet` - a string of unique characters. The characters in the string are used
+  to calculate one or two click shortcuts that can be used to quickly choose from
+  the InputSelector when in the default mode. Defaults to:
+  `"1234567890abcdefghilmnopqrstuvwxyz"`. (Without j/k so they can be used for movement
+  up and down.) {{since('nightly', inline=True)}}
 
 The possible flags are listed below. You must explicitly list each item that you
 want to include in the launcher. If you only specify `"FUZZY"` then you will see

--- a/docs/config/lua/keyassignment/ShowLauncherArgs.md
+++ b/docs/config/lua/keyassignment/ShowLauncherArgs.md
@@ -14,7 +14,7 @@ The arguments are a lua table with the following keys:
 * `fuzzy_help_text` - a string to display when in fuzzy finding mode. Defaults to:
   `"Fuzzy matching: "` {{since('nightly', inline=True)}}
 * `alphabet` - a string of unique characters. The characters in the string are used
-  to calculate one or two click shortcuts that can be used to quickly choose from
+  to calculate one or two key press shortcuts that can be used to quickly choose from
   the Launcher when in the default mode. Defaults to the same value as
   [launcher_alphabet](../config/launcher_alphabet.md) {{since('nightly', inline=True)}}
 

--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -5,6 +5,7 @@
 //! be rendered as a popup/context menu if the system supports it; at the
 //! time of writing our window layer doesn't provide an API for context
 //! menus.
+use super::quickselect;
 use crate::commands::derive_command_from_key_assignment;
 use crate::inputmap::InputMap;
 use crate::overlay::selector::{matcher_pattern, matcher_score};
@@ -59,6 +60,7 @@ pub struct LauncherArgs {
     workspaces: Vec<String>,
     help_text: String,
     fuzzy_help_text: String,
+    alphabet: String,
 }
 
 impl LauncherArgs {
@@ -71,6 +73,7 @@ impl LauncherArgs {
         domain_id_of_current_tab: DomainId,
         help_text: &str,
         fuzzy_help_text: &str,
+        alphabet: &str,
     ) -> Self {
         let mux = Mux::get();
 
@@ -161,6 +164,7 @@ impl LauncherArgs {
             active_workspace,
             help_text: help_text.to_string(),
             fuzzy_help_text: fuzzy_help_text.to_string(),
+            alphabet: alphabet.to_string(),
         }
     }
 }
@@ -180,6 +184,9 @@ struct LauncherState {
     flags: LauncherFlags,
     help_text: String,
     fuzzy_help_text: String,
+    labels: Vec<String>,
+    alphabet: String,
+    selection: String,
 }
 
 impl LauncherState {
@@ -360,6 +367,14 @@ impl LauncherState {
     fn render(&mut self, term: &mut TermWizTerminal) -> termwiz::Result<()> {
         let size = term.get_screen_size()?;
         let max_width = size.cols.saturating_sub(6);
+        let max_items = size.rows.saturating_sub(ROW_OVERHEAD);
+        if max_items != self.max_items {
+            self.labels = quickselect::compute_labels_for_alphabet_with_preserved_case(
+                &self.alphabet,
+                self.filtered_entries.len().min(max_items + 1),
+            );
+            self.max_items = max_items;
+        }
 
         let mut changes = vec![
             Change::ClearScreen(ColorAttribute::Default),
@@ -374,7 +389,9 @@ impl LauncherState {
             Change::AllAttributes(CellAttributes::default()),
         ];
 
-        let max_items = self.max_items;
+        let labels = &self.labels;
+        let max_label_len = labels.iter().map(|s| s.len()).max().unwrap_or(0);
+        let mut labels_iter = labels.into_iter();
 
         for (row_num, (entry_idx, entry)) in self
             .filtered_entries
@@ -394,8 +411,15 @@ impl LauncherState {
                 attr.set_reverse(true);
             }
 
-            if row_num < 9 && !self.filtering {
-                changes.push(Change::Text(format!(" {}. ", row_num + 1)));
+            // from above we know that row_num <= max_items
+            // show labels as long as we have more labels left
+            // and we are not filtering
+            if !self.filtering {
+                if let Some(label) = labels_iter.next() {
+                    changes.push(Change::Text(format!(" {label:>max_label_len$}. ")));
+                } else {
+                    changes.push(Change::Text(" ".repeat(max_label_len + 3)));
+                }
             } else {
                 changes.push(Change::Text("    ".to_string()));
             }
@@ -464,22 +488,29 @@ impl LauncherState {
             match event {
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char(c),
-                    ..
-                }) if !self.filtering && c >= '1' && c <= '9' => {
-                    if self.launch(self.top_row + (c as u32 - '1' as u32) as usize) {
-                        break;
+                    modifiers: Modifiers::NONE,
+                }) if !self.filtering && self.alphabet.contains(c) => {
+                    self.selection.push(c);
+                    if let Some(pos) = self.labels.iter().position(|x| *x == self.selection) {
+                        // since the number of labels is always <= self.max_items
+                        // by construction, we have pos as usize <= self.max_items
+                        // for free
+                        self.active_idx = self.top_row + pos as usize;
+                        if self.launch(self.active_idx) {
+                            break;
+                        }
                     }
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('j'),
                     ..
-                }) if !self.filtering => {
+                }) if !self.filtering && !self.alphabet.contains("j") => {
                     self.move_down();
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('k'),
                     ..
-                }) if !self.filtering => {
+                }) if !self.filtering && !self.alphabet.contains("k") => {
                     self.move_up();
                 }
                 InputEvent::Key(KeyEvent {
@@ -504,12 +535,16 @@ impl LauncherState {
                     key: KeyCode::Backspace,
                     ..
                 }) => {
-                    if self.filter_term.pop().is_none()
-                        && !self.flags.contains(LauncherFlags::FUZZY)
-                    {
-                        self.filtering = false;
+                    if !self.filtering {
+                        self.selection.pop();
+                    } else {
+                        if self.filter_term.pop().is_none()
+                            && !self.flags.contains(LauncherFlags::FUZZY)
+                        {
+                            self.filtering = false;
+                        }
+                        self.update_filter();
                     }
-                    self.update_filter();
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('G') | KeyCode::Char('['),
@@ -583,9 +618,6 @@ impl LauncherState {
                         break;
                     }
                 }
-                InputEvent::Resized { rows, .. } => {
-                    self.max_items = rows.saturating_sub(ROW_OVERHEAD);
-                }
                 _ => {}
             }
             self.render(term)?;
@@ -601,11 +633,9 @@ pub fn launcher(
     window: ::window::Window,
     initial_choice_idx: usize,
 ) -> anyhow::Result<()> {
-    let size = term.get_screen_size()?;
-    let max_items = size.rows.saturating_sub(ROW_OVERHEAD);
     let mut state = LauncherState {
         active_idx: initial_choice_idx,
-        max_items,
+        max_items: 0,
         pane_id: args.pane_id,
         top_row: 0,
         entries: vec![],
@@ -616,6 +646,9 @@ pub fn launcher(
         flags: args.flags,
         help_text: args.help_text.clone(),
         fuzzy_help_text: args.fuzzy_help_text.clone(),
+        labels: vec![],
+        selection: String::new(),
+        alphabet: args.alphabet.clone(),
     };
 
     term.set_raw_mode()?;

--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -5,9 +5,9 @@
 //! be rendered as a popup/context menu if the system supports it; at the
 //! time of writing our window layer doesn't provide an API for context
 //! menus.
-use super::quickselect;
 use crate::commands::derive_command_from_key_assignment;
 use crate::inputmap::InputMap;
+use crate::overlay::quickselect;
 use crate::overlay::selector::{matcher_pattern, matcher_score};
 use crate::termwindow::TermWindowNotif;
 use config::configuration;

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -146,6 +146,8 @@ impl SelectorState {
                 } else {
                     changes.push(Change::Text(" ".repeat(max_label_len + 3)));
                 }
+            } else if !self.always_fuzzy {
+                changes.push(Change::Text(" ".repeat(max_label_len + 3)));
             } else {
                 changes.push(Change::Text("    ".to_string()));
             }

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -1,4 +1,4 @@
-use super::quickselect;
+use crate::overlay::quickselect;
 use crate::scripting::guiwin::GuiWin;
 use config::keyassignment::{InputSelector, InputSelectorEntry, KeyAssignment};
 use mux::termwiztermtab::TermWizTerminal;

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2396,9 +2396,8 @@ impl TermWindow {
             .fuzzy_help_text
             .unwrap_or("Fuzzy matching: ".to_string());
 
-        let alphabet = args
-            .alphabet
-            .unwrap_or("1234567890abcdefghilmnopqrstuvwxyz".to_string());
+        let config = &self.config;
+        let alphabet = args.alphabet.unwrap_or(config.launcher_alphabet.clone());
 
         promise::spawn::spawn(async move {
             let args = LauncherArgs::new(

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2343,6 +2343,7 @@ impl TermWindow {
             flags: LauncherFlags::TABS,
             help_text: None,
             fuzzy_help_text: None,
+            alphabet: None,
         };
         self.show_launcher_impl(args, active_tab_idx);
     }
@@ -2358,6 +2359,7 @@ impl TermWindow {
                 | LauncherFlags::COMMANDS,
             help_text: None,
             fuzzy_help_text: None,
+            alphabet: None,
         };
         self.show_launcher_impl(args, 0);
     }
@@ -2394,6 +2396,10 @@ impl TermWindow {
             .fuzzy_help_text
             .unwrap_or("Fuzzy matching: ".to_string());
 
+        let alphabet = args
+            .alphabet
+            .unwrap_or("1234567890abcdefghilmnopqrstuvwxyz".to_string());
+
         promise::spawn::spawn(async move {
             let args = LauncherArgs::new(
                 &title,
@@ -2403,6 +2409,7 @@ impl TermWindow {
                 domain_id_of_current_pane,
                 &help_text,
                 &fuzzy_help_text,
+                &alphabet,
             )
             .await;
 
@@ -2743,6 +2750,7 @@ impl TermWindow {
                     flags: args.flags,
                     help_text: args.help_text.clone(),
                     fuzzy_help_text: args.fuzzy_help_text.clone(),
+                    alphabet: args.alphabet.clone(),
                 };
                 self.show_launcher_impl(args, 0);
             }


### PR DESCRIPTION
This PR adds the below changes:
- Similar to `InputSelector`, the labels for the Launcher are generated based on the provided argument or the default value
- Add configuration option `launcher_alphabet` for Launcher alphabet.
  - This is in order to be able to configure the alphabet for actions corresponding to KeyAssignment enums `ShowLauncher`, `ShowTabNavigator`
  - If `launcher_alphabet` configuration option not set, the value defaults to `"1234567890abcdefghilmnopqrstuvwxyz"`
- Optional argument `alphabet` is added to `ShowLauncherArgs`
- The `alphabet` string value defaults to the same value as the configuration option `launcher_alphabet` 
- Push `(max_label_len+3)` whitespaces if always_fuzzy false in InputSelector
  - This is to handle edge case in `InputSelector` when `max_label_len` is 2 and the labels shift one place to the left when entering fuzzy mode and back one place to the right when exiting fuzzy mode
- Push `(max_label_len+3)` whitespaces if `FUZZY` not present in `args` argument of the Launcher. This is to handle the edge case in the Launcher mentioned in the previous point