### PR TITLE
Add configuration option for InputSelector label background and foreground color

### DIFF
--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -170,6 +170,9 @@ pub struct Palette {
     pub quick_select_label_bg: Option<ColorSpec>,
     pub quick_select_match_fg: Option<ColorSpec>,
     pub quick_select_match_bg: Option<ColorSpec>,
+
+    pub input_selector_label_fg: Option<ColorSpec>,
+    pub input_selector_label_bg: Option<ColorSpec>,
 }
 impl_lua_conversion_dynamic!(Palette);
 
@@ -219,6 +222,8 @@ impl Palette {
             quick_select_label_bg: overlay!(quick_select_label_bg),
             quick_select_match_fg: overlay!(quick_select_match_fg),
             quick_select_match_bg: overlay!(quick_select_match_bg),
+            input_selector_label_fg: overlay!(input_selector_label_fg),
+            input_selector_label_bg: overlay!(input_selector_label_bg),
         }
     }
 }

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -130,6 +130,9 @@ config.colors = {
   quick_select_label_fg = { Color = '#ffffff' },
   quick_select_match_bg = { AnsiColor = 'Navy' },
   quick_select_match_fg = { Color = '#ffffff' },
+
+  input_selector_label_bg = { AnsiColor = 'Black' },
+  input_selector_label_fg = { Color = '#ffffff' },
 }
 
 return config

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -131,7 +131,7 @@ config.colors = {
   quick_select_match_bg = { AnsiColor = 'Navy' },
   quick_select_match_fg = { Color = '#ffffff' },
 
-  input_selector_label_bg = { AnsiColor = 'Black' },
+  input_selector_label_bg = { AnsiColor = 'Black' }, -- {{since('nightly', inline=True)}}
   input_selector_label_fg = { Color = '#ffffff' },
 }
 

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -132,7 +132,7 @@ config.colors = {
   quick_select_match_fg = { Color = '#ffffff' },
 
   input_selector_label_bg = { AnsiColor = 'Black' }, -- {{since('nightly', inline=True)}}
-  input_selector_label_fg = { Color = '#ffffff' },
+  input_selector_label_fg = { Color = '#ffffff' }, -- {{since('nightly', inline=True)}}
 }
 
 return config

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -1,5 +1,6 @@
 use super::quickselect;
 use crate::scripting::guiwin::GuiWin;
+use config::configuration;
 use config::keyassignment::{InputSelector, InputSelectorEntry, KeyAssignment};
 use mux::termwiztermtab::TermWizTerminal;
 use mux_lua::MuxPane;
@@ -119,6 +120,11 @@ impl SelectorState {
         let max_label_len = labels.iter().map(|s| s.len()).max().unwrap_or(0);
         let mut labels_iter = labels.into_iter();
 
+        let config = configuration();
+        let colors = &config.resolved_palette;
+        let input_selector_label_fg = colors.input_selector_label_fg;
+        let input_selector_label_bg = colors.input_selector_label_bg;
+
         for (row_num, (entry_idx, entry)) in self
             .filtered_entries
             .iter()
@@ -142,7 +148,23 @@ impl SelectorState {
             // and we are not filtering
             if !self.filtering {
                 if let Some(label) = labels_iter.next() {
+                    if let Some(input_selector_label_bg) = input_selector_label_bg {
+                        changes.push(
+                            AttributeChange::Background(input_selector_label_bg.into()).into(),
+                        );
+                    }
+                    if let Some(input_selector_label_fg) = input_selector_label_fg {
+                        changes.push(
+                            AttributeChange::Foreground(input_selector_label_fg.into()).into(),
+                        );
+                    }
                     changes.push(Change::Text(format!(" {label:>max_label_len$}. ")));
+                    if input_selector_label_bg.is_some() {
+                        changes.push(AttributeChange::Background(ColorAttribute::Default).into());
+                    }
+                    if input_selector_label_fg.is_some() {
+                        changes.push(AttributeChange::Foreground(ColorAttribute::Default).into());
+                    }
                 } else {
                     changes.push(Change::Text(" ".repeat(max_label_len + 3)));
                 }


### PR DESCRIPTION
Add below configuration option in config.colors:
- `input_selector_label_bg`
- `input_selector_label_fg`

If above mentioned options are not set in the configuration file then:
- `input_selector_label_bg` defaults to default background color
- `input_selector_label_fg` defaults to default foreground color