### PR TITLE
Adapt get-deps for NetBSD, and add NetBSD installation instructions.

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -5,7 +5,7 @@ hide:
 
 ## Available Features
 
-* Runs on Linux, macOS, Windows 10 and FreeBSD
+* Runs on Linux, macOS, Windows 10, FreeBSD and NetBSD
 * [Multiplex terminal panes, tabs and windows on local and remote hosts, with native mouse and scrollback](multiplexing.md)
 * <a href="https://github.com/tonsky/FiraCode#fira-code-monospaced-font-with-programming-ligatures">Ligatures</a>, Color Emoji and font fallback, with true color and [dynamic color schemes](config/appearance.md).
 * [Hyperlinks](hyperlinks.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ hide:
 
 ## Features
 
-* Runs on Linux, macOS, Windows 10 and FreeBSD
+* Runs on Linux, macOS, Windows 10, FreeBSD and NetBSD
 * [Multiplex terminal panes, tabs and windows on local and remote hosts, with native mouse and scrollback](multiplexing.md)
 * <a href="https://github.com/tonsky/FiraCode#fira-code-monospaced-font-with-programming-ligatures">Ligatures</a>, Color Emoji and font fallback, with true color and [dynamic color schemes](config/appearance.md).
 * [Hyperlinks](hyperlinks.md)

--- a/docs/install/netbsd.md
+++ b/docs/install/netbsd.md
@@ -1,0 +1,14 @@
+## Installing on NetBSD
+
+WezTerm is available [from pkgsrc](https://pkgsrc.se/x11/wezterm).
+
+The most common NetBSD architectures have pre-built binaries which you can install via:
+
+```bash
+$ pkgin install wezterm
+```
+
+The version available in ports is not directly managed by the release
+automation of the WezTerm project and may lag behind the latest release.  If
+you need to run a newer version, then the [build from source](source.md)
+instructions also apply to NetBSD.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,5 +10,6 @@ source, you may also build it for yourself.
  - [macOS](install/macos.md)
  - [Linux](install/linux.md)
  - [FreeBSD](install/freebsd.md)
+ - [NetBSD](install/netbsd.md)
  - [Build from source](install/source.md)
 

--- a/get-deps
+++ b/get-deps
@@ -209,7 +209,7 @@ arch_deps() {
   fi
 }
 
-bsd_deps() {
+freebsd_deps() {
   PKG="$SUDO pkg"
   $PKG install -y \
     'cmake' \
@@ -238,6 +238,23 @@ bsd_deps() {
     'xcb-util-wm' \
     'z' \
     'zip'
+}
+
+netbsd_deps() {
+  PKG="$SUDO pkgin"
+  $PKG -y install \
+    'bash' \
+    'fontconfig' \
+    'git-base' \
+    'hicolor-icon-theme' \
+    'libX11' \
+    'libxkbcommon' \
+    'pkgconf' \
+    'rust' \
+    'wayland' \
+    'xcb-util' \
+    'xcb-util-image' \
+    'xorgproto'
 }
 
 gentoo_deps() {
@@ -322,11 +339,14 @@ fallback_method() {
       echo "skipping darwin*/msys"
     ;;
     freebsd*)
-      bsd_deps
+      freebsd_deps
     ;;
     ''|linux-gnu)
       # catch and known OSTYPE
       echo "\$OSTYPE is '$OSTYPE'"
+    ;;
+    netbsd*)
+      netbsd_deps
     ;;
     *)
       NOTFOUND=1
@@ -338,6 +358,8 @@ fallback_method() {
 
 if test -e /etc/os-release; then
   . /etc/os-release
+else
+  ID=$(uname -s | tr '[:upper:]' '[:lower:]')
 fi
 
 set -e
@@ -356,7 +378,10 @@ case $ID in
     debian_deps
   ;;
   freebsd) # available since 13.0
-    bsd_deps
+    freebsd_deps
+  ;;
+  netbsd*)
+    netbsd_deps
   ;;
   arch|artix)
     arch_deps


### PR DESCRIPTION
There is one remaining (minor) issue: NetBSD's sort doesn't support `--version-sort`, so when running `get-deps` when that runs `ci/check-rust-version.sh`, you'll get:
```
sort: unknown option -- -
usage: sort [-bdfHilmnrSsu] [-k kstart[,kend]] [-o output] [-R char] [-T dir]
             [-t char] [file ...]
   or: sort -C|-c [-bdfilnru] [-k kstart[,kend]] [-o output] [-R char]
             [-t char] [file]
Installed rustc version '1.82.0' is less than required '1.71.0'

Check if your OS provides newer version of Rust, if not
use rustup to manage installed versions of Rust
https://www.rust-lang.org/en-US/install.html

See https://wezterm.org/install/source.html for complete
installation instructions for wezterm
```

The link to the package (in the installation instructions for NetBSD) will start working in a couple hours.

I packaged git head as of 20250213-133349-ee0c04e7, since the last release was too old.