### PR TITLE
Add font configuration option for ActivateCommandPalette, CharSelect, PaneSelect

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -142,6 +142,10 @@ pub struct Config {
     #[dynamic(default)]
     pub window_frame: WindowFrameConfig,
 
+    /// Font to use for CharSelect
+    #[dynamic(default)]
+    pub char_select_font: Option<TextStyle>,
+
     #[dynamic(default = "default_char_select_font_size")]
     pub char_select_font_size: f64,
 
@@ -150,6 +154,10 @@ pub struct Config {
 
     #[dynamic(default = "default_char_select_bg_color")]
     pub char_select_bg_color: RgbaColor,
+
+    /// Font to use for ActivateCommandPalette
+    #[dynamic(default)]
+    pub command_palette_font: Option<TextStyle>,
 
     #[dynamic(default = "default_command_palette_font_size")]
     pub command_palette_font_size: f64,
@@ -160,6 +168,10 @@ pub struct Config {
 
     #[dynamic(default = "default_command_palette_bg_color")]
     pub command_palette_bg_color: RgbaColor,
+
+    /// Font to use for PaneSelect
+    #[dynamic(default)]
+    pub pane_select_font: Option<TextStyle>,
 
     #[dynamic(default = "default_pane_select_font_size")]
     pub pane_select_font_size: f64,

--- a/docs/config/lua/config/char_select_font.md
+++ b/docs/config/lua/config/char_select_font.md
@@ -1,0 +1,19 @@
+---
+tags:
+  - appearance
+  - char_select
+  - font
+---
+# `char_select_font`
+
+{{since('nightly')}}
+
+Configures the font to use for character selection. The `char_select_font`
+setting can specify a set of fallbacks and other options, and is described
+in more detail in the [Fonts](../../fonts.md) section.
+
+If not specified, the font is same as the font in `window_frame.font`
+
+You will typically use [wezterm.font](../wezterm/font.md) or
+[wezterm.font_with_fallback](../wezterm/font_with_fallback.md) to specify the
+font.

--- a/docs/config/lua/config/char_select_font.md
+++ b/docs/config/lua/config/char_select_font.md
@@ -17,3 +17,9 @@ If not specified, the font is same as the font in `window_frame.font`
 You will typically use [wezterm.font](../wezterm/font.md) or
 [wezterm.font_with_fallback](../wezterm/font_with_fallback.md) to specify the
 font.
+
+To specify `char_select_font`:
+
+```lua
+config.char_select_font = wezterm.font 'Roboto'
+```

--- a/docs/config/lua/config/command_palette_font.md
+++ b/docs/config/lua/config/command_palette_font.md
@@ -1,0 +1,18 @@
+---
+tags:
+  - font
+  - command_palette
+---
+# `command_palette_font`
+
+{{since('nightly')}}
+
+Configures the font to use for command palette. The `command_palette_font`
+setting can specify a set of fallbacks and other options, and is described
+in more detail in the [Fonts](../../fonts.md) section.
+
+If not specified, the font is same as the font in `window_frame.font`
+
+You will typically use [wezterm.font](../wezterm/font.md) or
+[wezterm.font_with_fallback](../wezterm/font_with_fallback.md) to specify the
+font.

--- a/docs/config/lua/config/command_palette_font.md
+++ b/docs/config/lua/config/command_palette_font.md
@@ -16,3 +16,9 @@ If not specified, the font is same as the font in `window_frame.font`
 You will typically use [wezterm.font](../wezterm/font.md) or
 [wezterm.font_with_fallback](../wezterm/font_with_fallback.md) to specify the
 font.
+
+To specify `command_palette_font`:
+
+```lua
+config.command_palette_font = wezterm.font 'Roboto'
+```

--- a/docs/config/lua/config/pane_select_font.md
+++ b/docs/config/lua/config/pane_select_font.md
@@ -1,0 +1,19 @@
+---
+tags:
+  - appearance
+  - pane_select
+  - font
+---
+# `pane_select_font`
+
+{{since('nightly')}}
+
+Configures the font to use for pane selection mode. The `pane_select_font`
+setting can specify a set of fallbacks and other options, and is described
+in more detail in the [Fonts](../../fonts.md) section.
+
+If not specified, the font is same as the font in `window_frame.font`
+
+You will typically use [wezterm.font](../wezterm/font.md) or
+[wezterm.font_with_fallback](../wezterm/font_with_fallback.md) to specify the
+font.

--- a/docs/config/lua/config/pane_select_font.md
+++ b/docs/config/lua/config/pane_select_font.md
@@ -17,3 +17,9 @@ If not specified, the font is same as the font in `window_frame.font`
 You will typically use [wezterm.font](../wezterm/font.md) or
 [wezterm.font_with_fallback](../wezterm/font_with_fallback.md) to specify the
 font.
+
+To specify `pane_select_font`:
+
+```lua
+config.pane_select_font = wezterm.font 'Roboto'
+```

--- a/docs/config/lua/keyassignment/ActivateCommandPalette.md
+++ b/docs/config/lua/keyassignment/ActivateCommandPalette.md
@@ -41,6 +41,7 @@ action.
 
 See also:
 
+ * [command_palette_font](../config/command_palette_font.md)
  * [command_palette_font_size](../config/command_palette_font_size.md)
  * [command_palette_fg_color](../config/command_palette_fg_color.md)
  * [command_palette_bg_color](../config/command_palette_bg_color.md)

--- a/docs/config/lua/keyassignment/CharSelect.md
+++ b/docs/config/lua/keyassignment/CharSelect.md
@@ -43,7 +43,7 @@ The default assignment is equivalent to this config:
 
 ```lua
 -- Control the size of the font.
--- Uses the same font as window_frame.font
+-- Uses the same font as window_frame.font if char_select_font option is not set
 -- char_select_font_size = 18.0,
 
 config.keys = {
@@ -73,6 +73,7 @@ The `CharSelect` action accepts a lua table with the following fields:
   `"SmileysAndEmotion"` otherwise.
 
 See also:
+* [char_select_font](../config/char_select_font.md)
 * [char_select_font_size](../config/char_select_font_size.md)
 * [char_select_fg_color](../config/char_select_fg_color.md)
 * [char_select_bg_color](../config/char_select_bg_color.md)

--- a/docs/config/lua/keyassignment/PaneSelect.md
+++ b/docs/config/lua/keyassignment/PaneSelect.md
@@ -41,7 +41,7 @@ local wezterm = require 'wezterm'
 local act = wezterm.action
 
 -- 36 is the default, but you can choose a different size.
--- Uses the same font as window_frame.font
+-- Uses the same font as window_frame.font if pane_select_font option is not set
 -- config.pane_select_font_size=36,
 
 config.keys = {

--- a/wezterm-font/src/lib.rs
+++ b/wezterm-font/src/lib.rs
@@ -452,6 +452,13 @@ impl FallbackResolveInfo {
     }
 }
 
+enum EntityFont {
+    Title,
+    CommandPalette,
+    CharSelect,
+    PaneSelect,
+}
+
 struct FontConfigInner {
     fonts: RefCell<HashMap<TextStyle, Rc<LoadedFont>>>,
     metrics: RefCell<Option<FontMetrics>>,
@@ -584,18 +591,33 @@ impl FontConfigInner {
         )
     }
 
-    fn make_title_font_impl(
+    fn make_entity_font_impl(
         &self,
         myself: &Rc<Self>,
         pref_size: Option<f64>,
         make_bold: bool,
+        entity_font: EntityFont,
     ) -> anyhow::Result<Rc<LoadedFont>> {
         let config = self.config.borrow();
         let (sys_font, sys_size) = self.compute_title_font(&config, make_bold);
 
         let font_size = pref_size.unwrap_or(sys_size);
 
-        let text_style = config.window_frame.font.as_ref().unwrap_or(&sys_font);
+        let text_style = match entity_font {
+            EntityFont::Title => config.window_frame.font.as_ref().unwrap_or(&sys_font),
+            EntityFont::CommandPalette => config
+                .command_palette_font
+                .as_ref()
+                .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
+            EntityFont::CharSelect => config
+                .char_select_font
+                .as_ref()
+                .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
+            EntityFont::PaneSelect => config
+                .pane_select_font
+                .as_ref()
+                .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
+        };
 
         let dpi = *self.dpi.borrow() as u32;
         let pixel_size = (font_size * dpi as f64 / 72.0) as u16;
@@ -639,7 +661,12 @@ impl FontConfigInner {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded = self.make_title_font_impl(myself, config.window_frame.font_size, true)?;
+        let loaded = self.make_entity_font_impl(
+            myself,
+            config.window_frame.font_size,
+            true,
+            EntityFont::Title,
+        )?;
 
         title_font.replace(Rc::clone(&loaded));
 
@@ -655,8 +682,12 @@ impl FontConfigInner {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded =
-            self.make_title_font_impl(myself, Some(config.command_palette_font_size), false)?;
+        let loaded = self.make_entity_font_impl(
+            myself,
+            Some(config.command_palette_font_size),
+            false,
+            EntityFont::CommandPalette,
+        )?;
 
         command_palette_font.replace(Rc::clone(&loaded));
 
@@ -672,7 +703,12 @@ impl FontConfigInner {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded = self.make_title_font_impl(myself, Some(config.char_select_font_size), true)?;
+        let loaded = self.make_entity_font_impl(
+            myself,
+            Some(config.char_select_font_size),
+            true,
+            EntityFont::CharSelect,
+        )?;
 
         char_select_font.replace(Rc::clone(&loaded));
 
@@ -688,7 +724,12 @@ impl FontConfigInner {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded = self.make_title_font_impl(myself, Some(config.pane_select_font_size), true)?;
+        let loaded = self.make_entity_font_impl(
+            myself,
+            Some(config.pane_select_font_size),
+            true,
+            EntityFont::PaneSelect,
+        )?;
 
         pane_select_font.replace(Rc::clone(&loaded));
 

--- a/wezterm-font/src/lib.rs
+++ b/wezterm-font/src/lib.rs
@@ -452,7 +452,7 @@ impl FallbackResolveInfo {
     }
 }
 
-enum EntityFont {
+enum Entity {
     Title,
     CommandPalette,
     CharSelect,
@@ -596,24 +596,24 @@ impl FontConfigInner {
         myself: &Rc<Self>,
         pref_size: Option<f64>,
         make_bold: bool,
-        entity_font: EntityFont,
+        entity: Entity,
     ) -> anyhow::Result<Rc<LoadedFont>> {
         let config = self.config.borrow();
         let (sys_font, sys_size) = self.compute_title_font(&config, make_bold);
 
         let font_size = pref_size.unwrap_or(sys_size);
 
-        let text_style = match entity_font {
-            EntityFont::Title => config.window_frame.font.as_ref().unwrap_or(&sys_font),
-            EntityFont::CommandPalette => config
+        let text_style = match entity {
+            Entity::Title => config.window_frame.font.as_ref().unwrap_or(&sys_font),
+            Entity::CommandPalette => config
                 .command_palette_font
                 .as_ref()
                 .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
-            EntityFont::CharSelect => config
+            Entity::CharSelect => config
                 .char_select_font
                 .as_ref()
                 .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
-            EntityFont::PaneSelect => config
+            Entity::PaneSelect => config
                 .pane_select_font
                 .as_ref()
                 .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
@@ -661,12 +661,8 @@ impl FontConfigInner {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded = self.make_entity_font_impl(
-            myself,
-            config.window_frame.font_size,
-            true,
-            EntityFont::Title,
-        )?;
+        let loaded =
+            self.make_entity_font_impl(myself, config.window_frame.font_size, true, Entity::Title)?;
 
         title_font.replace(Rc::clone(&loaded));
 
@@ -686,7 +682,7 @@ impl FontConfigInner {
             myself,
             Some(config.command_palette_font_size),
             false,
-            EntityFont::CommandPalette,
+            Entity::CommandPalette,
         )?;
 
         command_palette_font.replace(Rc::clone(&loaded));
@@ -707,7 +703,7 @@ impl FontConfigInner {
             myself,
             Some(config.char_select_font_size),
             true,
-            EntityFont::CharSelect,
+            Entity::CharSelect,
         )?;
 
         char_select_font.replace(Rc::clone(&loaded));
@@ -728,7 +724,7 @@ impl FontConfigInner {
             myself,
             Some(config.pane_select_font_size),
             true,
-            EntityFont::PaneSelect,
+            Entity::PaneSelect,
         )?;
 
         pane_select_font.replace(Rc::clone(&loaded));

--- a/wezterm-font/src/lib.rs
+++ b/wezterm-font/src/lib.rs
@@ -452,6 +452,7 @@ impl FallbackResolveInfo {
     }
 }
 
+#[derive(PartialEq, Eq)]
 enum Entity {
     Title,
     CommandPalette,
@@ -595,10 +596,10 @@ impl FontConfigInner {
         &self,
         myself: &Rc<Self>,
         pref_size: Option<f64>,
-        make_bold: bool,
         entity: Entity,
     ) -> anyhow::Result<Rc<LoadedFont>> {
         let config = self.config.borrow();
+        let make_bold = entity != Entity::CommandPalette;
         let (sys_font, sys_size) = self.compute_title_font(&config, make_bold);
 
         let font_size = pref_size.unwrap_or(sys_size);
@@ -662,7 +663,7 @@ impl FontConfigInner {
         }
 
         let loaded =
-            self.make_entity_font_impl(myself, config.window_frame.font_size, true, Entity::Title)?;
+            self.make_entity_font_impl(myself, config.window_frame.font_size, Entity::Title)?;
 
         title_font.replace(Rc::clone(&loaded));
 
@@ -681,7 +682,6 @@ impl FontConfigInner {
         let loaded = self.make_entity_font_impl(
             myself,
             Some(config.command_palette_font_size),
-            false,
             Entity::CommandPalette,
         )?;
 
@@ -702,7 +702,6 @@ impl FontConfigInner {
         let loaded = self.make_entity_font_impl(
             myself,
             Some(config.char_select_font_size),
-            true,
             Entity::CharSelect,
         )?;
 
@@ -723,7 +722,6 @@ impl FontConfigInner {
         let loaded = self.make_entity_font_impl(
             myself,
             Some(config.pane_select_font_size),
-            true,
             Entity::PaneSelect,
         )?;
 

--- a/wezterm-font/src/lib.rs
+++ b/wezterm-font/src/lib.rs
@@ -595,30 +595,30 @@ impl FontConfigInner {
     fn make_entity_font_impl(
         &self,
         myself: &Rc<Self>,
-        pref_size: Option<f64>,
         entity: Entity,
     ) -> anyhow::Result<Rc<LoadedFont>> {
         let config = self.config.borrow();
         let make_bold = entity != Entity::CommandPalette;
         let (sys_font, sys_size) = self.compute_title_font(&config, make_bold);
 
-        let font_size = pref_size.unwrap_or(sys_size);
-
-        let text_style = match entity {
-            Entity::Title => config.window_frame.font.as_ref().unwrap_or(&sys_font),
-            Entity::CommandPalette => config
-                .command_palette_font
-                .as_ref()
-                .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
-            Entity::CharSelect => config
-                .char_select_font
-                .as_ref()
-                .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
-            Entity::PaneSelect => config
-                .pane_select_font
-                .as_ref()
-                .unwrap_or_else(|| config.window_frame.font.as_ref().unwrap_or(&sys_font)),
+        let (font_size, text_style) = match entity {
+            Entity::Title => (config.window_frame.font_size.unwrap_or(sys_size), None),
+            Entity::CommandPalette => (
+                config.command_palette_font_size,
+                config.command_palette_font.as_ref(),
+            ),
+            Entity::CharSelect => (
+                config.char_select_font_size,
+                config.char_select_font.as_ref(),
+            ),
+            Entity::PaneSelect => (
+                config.pane_select_font_size,
+                config.pane_select_font.as_ref(),
+            ),
         };
+
+        let text_style =
+            text_style.unwrap_or(config.window_frame.font.as_ref().unwrap_or(&sys_font));
 
         let dpi = *self.dpi.borrow() as u32;
         let pixel_size = (font_size * dpi as f64 / 72.0) as u16;
@@ -654,16 +654,13 @@ impl FontConfigInner {
     }
 
     fn title_font(&self, myself: &Rc<Self>) -> anyhow::Result<Rc<LoadedFont>> {
-        let config = self.config.borrow();
-
         let mut title_font = self.title_font.borrow_mut();
 
         if let Some(entry) = title_font.as_ref() {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded =
-            self.make_entity_font_impl(myself, config.window_frame.font_size, Entity::Title)?;
+        let loaded = self.make_entity_font_impl(myself, Entity::Title)?;
 
         title_font.replace(Rc::clone(&loaded));
 
@@ -671,19 +668,13 @@ impl FontConfigInner {
     }
 
     fn command_palette_font(&self, myself: &Rc<Self>) -> anyhow::Result<Rc<LoadedFont>> {
-        let config = self.config.borrow();
-
         let mut command_palette_font = self.command_palette_font.borrow_mut();
 
         if let Some(entry) = command_palette_font.as_ref() {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded = self.make_entity_font_impl(
-            myself,
-            Some(config.command_palette_font_size),
-            Entity::CommandPalette,
-        )?;
+        let loaded = self.make_entity_font_impl(myself, Entity::CommandPalette)?;
 
         command_palette_font.replace(Rc::clone(&loaded));
 
@@ -691,19 +682,13 @@ impl FontConfigInner {
     }
 
     fn char_select_font(&self, myself: &Rc<Self>) -> anyhow::Result<Rc<LoadedFont>> {
-        let config = self.config.borrow();
-
         let mut char_select_font = self.char_select_font.borrow_mut();
 
         if let Some(entry) = char_select_font.as_ref() {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded = self.make_entity_font_impl(
-            myself,
-            Some(config.char_select_font_size),
-            Entity::CharSelect,
-        )?;
+        let loaded = self.make_entity_font_impl(myself, Entity::CharSelect)?;
 
         char_select_font.replace(Rc::clone(&loaded));
 
@@ -711,19 +696,13 @@ impl FontConfigInner {
     }
 
     fn pane_select_font(&self, myself: &Rc<Self>) -> anyhow::Result<Rc<LoadedFont>> {
-        let config = self.config.borrow();
-
         let mut pane_select_font = self.pane_select_font.borrow_mut();
 
         if let Some(entry) = pane_select_font.as_ref() {
             return Ok(Rc::clone(entry));
         }
 
-        let loaded = self.make_entity_font_impl(
-            myself,
-            Some(config.pane_select_font_size),
-            Entity::PaneSelect,
-        )?;
+        let loaded = self.make_entity_font_impl(myself, Entity::PaneSelect)?;
 
         pane_select_font.replace(Rc::clone(&loaded));
 


### PR DESCRIPTION
Add configuration option for font for the below entities:
- `ActivateCommandPalette`
- `CharSelect`
- `PaneSelect`

For the above entities, if the font is not set in configuration, it defaults to the font same font as `config.window_frame.font`