### PR TITLE
shift check bit when comparing to pattern

### DIFF
--- a/wezterm-gui/src/customglyph.rs
+++ b/wezterm-gui/src/customglyph.rs
@@ -5072,7 +5072,7 @@ impl GlyphCache {
                 for row in 0..3 {
                     for col in 0..2 {
                         let bit = 2 * row + col;
-                        if pattern & bit != 0 {
+                        if pattern & (1u8 << bit) != 0 {
                             fill_rect(
                                 &mut buffer,
                                 col as f32 * x_half..(col + 1) as f32 * x_half,


### PR DESCRIPTION
There seems to have been a regression when rendering sextant characters when `custom_block_glyphs=true` in the new "dynamic" rendering of bit/marched glyphs like sextant/octants.

Octants has the proper bit shifting when comparing, however this did not seem to get utilized for sextants.


Left is regressed, right is fixed
![Screenshot_2025-02-19-22-17-25_1920x1080](https://github.com/user-attachments/assets/1a0ea043-dc2e-4caf-8016-b0dd3d8ceb63)
