### PR TITLE
fix: window version stack overflow when run "tmux -CC"

### DIFF
--- a/mux/src/tmux_pty.rs
+++ b/mux/src/tmux_pty.rs
@@ -84,7 +84,7 @@ impl Child for TmuxChild {
     }
 
     fn process_id(&self) -> Option<u32> {
-        Some(0)
+        None
     }
 
     #[cfg(windows)]


### PR DESCRIPTION
refs: #6671

before this change, The default process id is 0.
"with_root_pid" function call the recursion function "build_proc". Since all processes are child processes of 0, cause the recursion function called too many time and hence stack overflow.

Actually, when we use tmux control mode, we don't care the child process information, so just give "None" for process id.