### PR TITLE
flake.nix: fix build on darwin

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -63,11 +63,11 @@
           with pkgs;
           [
             fontconfig
+            openssl
             zlib
           ]
           ++ lib.optionals stdenv.isLinux [
             libxkbcommon
-            openssl
             wayland
 
             xorg.libX11


### PR DESCRIPTION
The `openssl` dependency is also needed on Darwin.