### PR TITLE
Add Confirmation to Key assignment

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -517,6 +517,18 @@ fn default_fuzzy_description() -> String {
 }
 
 #[derive(Debug, Clone, PartialEq, FromDynamic, ToDynamic)]
+pub struct Confirmation {
+    pub action: Box<KeyAssignment>,
+    /// Text to show for confirmation
+    #[dynamic(default = "default_message")]
+    pub message: String,
+}
+
+fn default_message() -> String {
+    "🛑 Really continue?".to_string()
+}
+
+#[derive(Debug, Clone, PartialEq, FromDynamic, ToDynamic)]
 pub enum KeyAssignment {
     SpawnTab(SpawnTabDomain),
     SpawnWindow,
@@ -630,6 +642,7 @@ pub enum KeyAssignment {
     ActivateWindowRelativeNoWrap(isize),
     PromptInputLine(PromptInputLine),
     InputSelector(InputSelector),
+    Confirmation(Confirmation),
 }
 impl_lua_conversion_dynamic!(KeyAssignment);
 

--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -519,6 +519,8 @@ fn default_fuzzy_description() -> String {
 #[derive(Debug, Clone, PartialEq, FromDynamic, ToDynamic)]
 pub struct Confirmation {
     pub action: Box<KeyAssignment>,
+    #[dynamic(default)]
+    pub cancel: Option<Box<KeyAssignment>>,
     /// Text to show for confirmation
     #[dynamic(default = "default_message")]
     pub message: String,

--- a/docs/config/lua/keyassignment/Confirmation.md
+++ b/docs/config/lua/keyassignment/Confirmation.md
@@ -1,0 +1,43 @@
+# `Confirmation`
+
+{{since('nightly')}}
+
+Activates an overlay to display a confirmation menu
+
+When the user accepts a line, emits an event that allows you to act
+upon the input.
+
+`Confirmation` accepts the following fields:
+
+* `message` - the text to show for confirmation. You may embed
+  escape sequences and/or use [wezterm.format](../wezterm/format.md).
+  Defaults to: `"🛑 Really continue?"`.
+
+## Example of choosing a program with user confirmation
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+local config = wezterm.config_builder()
+
+config.keys = {
+  {
+    key = 'E',
+    mods = 'CTRL|SHIFT',
+    action = act.Confirmation {
+      message = "Do you want to run htop in a new window?",
+      action = wezterm.action_callback(function(window, pane)
+        window:perform_action(act.SpawnCommandInNewWindow { args = { 'htop' } }, pane)
+      end),
+    },
+  },
+}
+
+return config
+```
+
+
+
+
+See also [InputSelector](InputSelector.md).
+See also [PromptInputLine](PromptInputLine.md).

--- a/docs/config/lua/keyassignment/Confirmation.md
+++ b/docs/config/lua/keyassignment/Confirmation.md
@@ -40,13 +40,16 @@ config.keys = {
     key = 'E',
     mods = 'CTRL|SHIFT',
     action = act.Confirmation {
-      message = "Do you want to run htop in a new window?",
+      message = 'Do you want to run htop in a new window?',
       action = wezterm.action_callback(function(window, pane)
-        window:perform_action(act.SpawnCommandInNewWindow { args = { 'htop' } }, pane)
+        window:perform_action(
+          act.SpawnCommandInNewWindow { args = { 'htop' } },
+          pane
+        )
       end),
-      cancel = wezterm.action_callback(function(window,pane)
-        wezterm.log_error("user declined")
-      end)
+      cancel = wezterm.action_callback(function(window, pane)
+        wezterm.log_error 'user declined'
+      end),
     },
   },
 }

--- a/docs/config/lua/keyassignment/Confirmation.md
+++ b/docs/config/lua/keyassignment/Confirmation.md
@@ -18,7 +18,7 @@ upon the input.
   objects from the current pane and window. This callback is called when the
   user selects `Yes`.
 * `cancel` - event callback registered via `wezterm.action_callback`.  The
-  callback's function signature is `(window, pane, id, label)` where `window` and
+  callback's function signature is `(window, pane)` where `window` and
   `pane` are the [Window](../window/index.md) and [Pane](../pane/index.md).
   This is an optional argument. If present, this callback is called when the
   user selects `No` or closes the confirmation menu.

--- a/docs/config/lua/keyassignment/Confirmation.md
+++ b/docs/config/lua/keyassignment/Confirmation.md
@@ -13,7 +13,7 @@ upon the input.
   escape sequences and/or use [wezterm.format](../wezterm/format.md).
   Defaults to: `"🛑 Really continue?"`.
 * `action` - event callback registered via `wezterm.action_callback`.  The
-  callback's function signature is `(window, pane, id, label)` where `window` and
+  callback's function signature is `(window, pane)` where `window` and
   `pane` are the [Window](../window/index.md) and [Pane](../pane/index.md)
   objects from the current pane and window. This callback is called when the
   user selects `Yes`.

--- a/docs/config/lua/keyassignment/Confirmation.md
+++ b/docs/config/lua/keyassignment/Confirmation.md
@@ -12,6 +12,16 @@ upon the input.
 * `message` - the text to show for confirmation. You may embed
   escape sequences and/or use [wezterm.format](../wezterm/format.md).
   Defaults to: `"🛑 Really continue?"`.
+* `action` - event callback registered via `wezterm.action_callback`.  The
+  callback's function signature is `(window, pane, id, label)` where `window` and
+  `pane` are the [Window](../window/index.md) and [Pane](../pane/index.md)
+  objects from the current pane and window. This callback is called when the
+  user selects `Yes`.
+* `cancel` - event callback registered via `wezterm.action_callback`.  The
+  callback's function signature is `(window, pane, id, label)` where `window` and
+  `pane` are the [Window](../window/index.md) and [Pane](../pane/index.md).
+  This is an optional argument. If present, this callback is called when the
+  user selects `No` or closes the confirmation menu.
 
 ## Example of choosing a program with user confirmation
 
@@ -29,6 +39,9 @@ config.keys = {
       action = wezterm.action_callback(function(window, pane)
         window:perform_action(act.SpawnCommandInNewWindow { args = { 'htop' } }, pane)
       end),
+      cancel = wezterm.action_callback(function(window,pane)
+        wezterm.log_error("user declined")
+      end)
     },
   },
 }

--- a/docs/config/lua/keyassignment/Confirmation.md
+++ b/docs/config/lua/keyassignment/Confirmation.md
@@ -52,5 +52,6 @@ return config
 
 
 
-See also [InputSelector](InputSelector.md).
-See also [PromptInputLine](PromptInputLine.md).
+See also:
+   * [InputSelector](InputSelector.md).
+   * [PromptInputLine](PromptInputLine.md).

--- a/docs/config/lua/keyassignment/Confirmation.md
+++ b/docs/config/lua/keyassignment/Confirmation.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - prompt
+---
+
 # `Confirmation`
 
 {{since('nightly')}}

--- a/docs/config/lua/keyassignment/InputSelector.md
+++ b/docs/config/lua/keyassignment/InputSelector.md
@@ -232,4 +232,5 @@ return config
 
 
 See also [PromptInputLine](PromptInputLine.md).
+See also [Confirmation](Confirmation.md).
 

--- a/docs/config/lua/keyassignment/InputSelector.md
+++ b/docs/config/lua/keyassignment/InputSelector.md
@@ -231,6 +231,7 @@ return config
 
 
 
-See also [PromptInputLine](PromptInputLine.md).
-See also [Confirmation](Confirmation.md).
+See also:
+   * [PromptInputLine](PromptInputLine.md).
+   * [Confirmation](Confirmation.md).
 

--- a/docs/config/lua/keyassignment/InputSelector.md
+++ b/docs/config/lua/keyassignment/InputSelector.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - prompt
+---
+
 # `InputSelector`
 
 {{since('20230408-112425-69ae8472')}}

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -96,3 +96,4 @@ return config
 ```
 
 See also [InputSelector](InputSelector.md).
+See also [Confirmation](Confirmation.md).

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -1,3 +1,8 @@
+---
+tags:
+  - prompt
+---
+
 # `PromptInputLine`
 
 {{since('20230408-112425-69ae8472')}}

--- a/docs/config/lua/keyassignment/PromptInputLine.md
+++ b/docs/config/lua/keyassignment/PromptInputLine.md
@@ -95,5 +95,6 @@ config.keys = {
 return config
 ```
 
-See also [InputSelector](InputSelector.md).
-See also [Confirmation](Confirmation.md).
+See also:
+   * [InputSelector](InputSelector.md).
+   * [Confirmation](Confirmation.md).

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -812,6 +812,14 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &[],
             icon: None,
         },
+        Confirmation(_) => CommandDef {
+            brief: "Prompt the user for confirmation".into(),
+            doc: "Activates the confirmation overlay and wait for input".into(),
+            keys: vec![],
+            args: &[ArgType::ActiveWindow],
+            menubar: &[],
+            icon: None,
+        },
         PromptInputLine(_) => CommandDef {
             brief: "Prompt the user for a line of text".into(),
             doc: "Activates the prompt overlay and wait for input".into(),

--- a/wezterm-gui/src/overlay/confirm.rs
+++ b/wezterm-gui/src/overlay/confirm.rs
@@ -1,0 +1,216 @@
+use crate::scripting::guiwin::GuiWin;
+use config::keyassignment::{Confirmation, KeyAssignment};
+use mux::termwiztermtab::TermWizTerminal;
+use mux_lua::MuxPane;
+use std::rc::Rc;
+use termwiz::cell::AttributeChange;
+use termwiz::color::ColorAttribute;
+use termwiz::input::{InputEvent, KeyCode, KeyEvent, MouseButtons, MouseEvent};
+use termwiz::surface::{Change, CursorVisibility, Position};
+use termwiz::terminal::Terminal;
+
+pub fn run_confirmation(message: &str, term: &mut TermWizTerminal) -> anyhow::Result<bool> {
+    run_confirmation_impl(message, term)
+}
+
+fn run_confirmation_impl(message: &str, term: &mut TermWizTerminal) -> anyhow::Result<bool> {
+    term.set_raw_mode()?;
+
+    let size = term.get_screen_size()?;
+
+    /*
+    use crate::termwindow::ICON_DATA;
+    use image::GenericImageView;
+    use std::sync::Arc;
+    use termwiz::surface::change::ImageData;
+    use termwiz::surface::TextureCoordinate;
+
+        let image_data = Arc::new(ImageData::with_raw_data(ICON_DATA.to_vec()));
+        let decoded_image = image::load_from_memory(ICON_DATA)?;
+        let logo_width_cells = 3usize;
+        let logo_width = logo_width_cells * size.xpixel;
+        let logo_scale = logo_width as f32 / decoded_image.width() as f32;
+        let logo_height = decoded_image.height() as f32 * logo_scale;
+        let logo_height_cells = (logo_height / size.ypixel as f32).ceil() as usize;
+        */
+
+    // Render 80% wide, centered
+    let text_width = size.cols * 80 / 100;
+    let x_pos = size.cols * 10 / 100;
+
+    // Fit text to the width
+    let wrapped = textwrap::fill(message, text_width);
+
+    let message_rows = wrapped.split("\n").count();
+    // Now we want to vertically center the prompt in the view.
+    // After the prompt there will be a blank line and then the "buttons",
+    // so we add two to the number of rows.
+    let top_row = (size.rows - (message_rows + 2)) / 2;
+
+    let button_row = top_row + message_rows + 1;
+    let mut active = ActiveButton::None;
+
+    let yes_x = x_pos;
+    let yes_w = 7;
+
+    let no_x =  yes_x + yes_w + 8 /* spacer */;
+    let no_w = 6;
+
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    enum ActiveButton {
+        None,
+        Yes,
+        No,
+    }
+
+    let render = |term: &mut TermWizTerminal, active: ActiveButton| -> termwiz::Result<()> {
+        let mut changes = vec![
+            Change::ClearScreen(ColorAttribute::Default),
+            Change::CursorVisibility(CursorVisibility::Hidden),
+            /*
+            Change::Image(termwiz::surface::change::Image {
+                width: logo_width_cells,
+                height: logo_height_cells,
+                top_left: TextureCoordinate::new_f32(0., 0.),
+                bottom_right: TextureCoordinate::new_f32(1., 1.),
+                image: Arc::clone(&image_data),
+            }),
+            */
+        ];
+
+        for (y, row) in wrapped.split("\n").enumerate() {
+            let row = row.trim_end();
+            changes.push(Change::CursorPosition {
+                x: Position::Absolute(x_pos),
+                y: Position::Absolute(top_row + y),
+            });
+            changes.push(Change::Text(row.to_string()));
+        }
+
+        changes.push(Change::CursorPosition {
+            x: Position::Absolute(x_pos),
+            y: Position::Absolute(button_row),
+        });
+
+        if active == ActiveButton::Yes {
+            changes.push(AttributeChange::Reverse(true).into());
+        }
+        changes.push(" [Y]es ".into());
+        if active == ActiveButton::Yes {
+            changes.push(AttributeChange::Reverse(false).into());
+        }
+
+        changes.push("        ".into());
+
+        if active == ActiveButton::No {
+            changes.push(AttributeChange::Reverse(true).into());
+        }
+        changes.push(" [N]o ".into());
+        if active == ActiveButton::No {
+            changes.push(AttributeChange::Reverse(false).into());
+        }
+
+        term.render(&changes)?;
+        term.flush()
+    };
+
+    render(term, active)?;
+
+    while let Ok(Some(event)) = term.poll_input(None) {
+        match event {
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Char('y' | 'Y'),
+                ..
+            }) => {
+                return Ok(true);
+            }
+            InputEvent::Key(KeyEvent {
+                key: KeyCode::Char('n' | 'N'),
+                ..
+            })
+            | InputEvent::Key(KeyEvent {
+                key: KeyCode::Escape,
+                ..
+            }) => {
+                return Ok(false);
+            }
+            InputEvent::Mouse(MouseEvent {
+                x,
+                y,
+                mouse_buttons,
+                ..
+            }) => {
+                let x = x as usize;
+                let y = y as usize;
+                if y == button_row && x >= yes_x && x < yes_x + yes_w {
+                    active = ActiveButton::Yes;
+                    if mouse_buttons == MouseButtons::LEFT {
+                        return Ok(true);
+                    }
+                } else if y == button_row && x >= no_x && x < no_x + no_w {
+                    active = ActiveButton::No;
+                    if mouse_buttons == MouseButtons::LEFT {
+                        return Ok(false);
+                    }
+                } else {
+                    active = ActiveButton::None;
+                }
+
+                if mouse_buttons != MouseButtons::NONE {
+                    // Treat any other mouse button as cancel
+                    return Ok(false);
+                }
+            }
+            _ => {}
+        }
+
+        render(term, active)?;
+    }
+
+    Ok(false)
+}
+
+pub fn show_confirmation_overlay(
+    mut term: TermWizTerminal,
+    args: Confirmation,
+    window: GuiWin,
+    pane: MuxPane,
+) -> anyhow::Result<()> {
+    let name = match *args.action {
+        KeyAssignment::EmitEvent(id) => id,
+        _ => anyhow::bail!("Confirmation requires action to be defined by wezterm.action_callback"),
+    };
+
+    if let Ok(true) = run_confirmation_impl(&args.message, &mut term) {
+        promise::spawn::spawn_into_main_thread(async move {
+            trampoline(name, window, pane);
+            anyhow::Result::<()>::Ok(())
+        })
+        .detach();
+    }
+    Ok(())
+}
+
+fn trampoline(name: String, window: GuiWin, pane: MuxPane) {
+    promise::spawn::spawn(async move {
+        config::with_lua_config_on_main_thread(move |lua| do_event(lua, name, window, pane)).await
+    })
+    .detach();
+}
+
+async fn do_event(
+    lua: Option<Rc<mlua::Lua>>,
+    name: String,
+    window: GuiWin,
+    pane: MuxPane,
+) -> anyhow::Result<()> {
+    if let Some(lua) = lua {
+        let args = lua.pack_multi((window, pane))?;
+
+        if let Err(err) = config::lua::emit_event(&lua, (name.clone(), args)).await {
+            log::error!("while processing {} event: {:#}", name, err);
+        }
+    }
+
+    Ok(())
+}

--- a/wezterm-gui/src/overlay/confirm.rs
+++ b/wezterm-gui/src/overlay/confirm.rs
@@ -18,22 +18,6 @@ fn run_confirmation_impl(message: &str, term: &mut TermWizTerminal) -> anyhow::R
 
     let size = term.get_screen_size()?;
 
-    /*
-    use crate::termwindow::ICON_DATA;
-    use image::GenericImageView;
-    use std::sync::Arc;
-    use termwiz::surface::change::ImageData;
-    use termwiz::surface::TextureCoordinate;
-
-        let image_data = Arc::new(ImageData::with_raw_data(ICON_DATA.to_vec()));
-        let decoded_image = image::load_from_memory(ICON_DATA)?;
-        let logo_width_cells = 3usize;
-        let logo_width = logo_width_cells * size.xpixel;
-        let logo_scale = logo_width as f32 / decoded_image.width() as f32;
-        let logo_height = decoded_image.height() as f32 * logo_scale;
-        let logo_height_cells = (logo_height / size.ypixel as f32).ceil() as usize;
-        */
-
     // Render 80% wide, centered
     let text_width = size.cols * 80 / 100;
     let x_pos = size.cols * 10 / 100;
@@ -67,15 +51,6 @@ fn run_confirmation_impl(message: &str, term: &mut TermWizTerminal) -> anyhow::R
         let mut changes = vec![
             Change::ClearScreen(ColorAttribute::Default),
             Change::CursorVisibility(CursorVisibility::Hidden),
-            /*
-            Change::Image(termwiz::surface::change::Image {
-                width: logo_width_cells,
-                height: logo_height_cells,
-                top_left: TextureCoordinate::new_f32(0., 0.),
-                bottom_right: TextureCoordinate::new_f32(1., 1.),
-                image: Arc::clone(&image_data),
-            }),
-            */
         ];
 
         for (y, row) in wrapped.split("\n").enumerate() {

--- a/wezterm-gui/src/overlay/confirm.rs
+++ b/wezterm-gui/src/overlay/confirm.rs
@@ -156,12 +156,22 @@ pub fn show_confirmation_overlay(
         _ => anyhow::bail!("Confirmation requires action to be defined by wezterm.action_callback"),
     };
 
-    if let Ok(true) = run_confirmation_impl(&args.message, &mut term) {
-        promise::spawn::spawn_into_main_thread(async move {
-            trampoline(name, window, pane);
-            anyhow::Result::<()>::Ok(())
-        })
-        .detach();
+    if let Ok(confirm) = run_confirmation_impl(&args.message, &mut term) {
+        if confirm {
+            promise::spawn::spawn_into_main_thread(async move {
+                trampoline(name, window, pane);
+                anyhow::Result::<()>::Ok(())
+            })
+            .detach();
+        } else if let Some(key_assignment) = args.cancel {
+            if let KeyAssignment::EmitEvent(id) = *key_assignment {
+                promise::spawn::spawn_into_main_thread(async move {
+                    trampoline(id, window, pane);
+                    anyhow::Result::<()>::Ok(())
+                })
+                .detach();
+            }
+        }
     }
     Ok(())
 }

--- a/wezterm-gui/src/overlay/confirm_close_pane.rs
+++ b/wezterm-gui/src/overlay/confirm_close_pane.rs
@@ -1,171 +1,10 @@
+use super::confirm::run_confirmation;
 use crate::TermWindow;
 use mux::pane::PaneId;
 use mux::tab::TabId;
 use mux::termwiztermtab::TermWizTerminal;
 use mux::window::WindowId;
 use mux::Mux;
-use termwiz::cell::AttributeChange;
-use termwiz::color::ColorAttribute;
-use termwiz::input::{InputEvent, KeyCode, KeyEvent, MouseButtons, MouseEvent};
-use termwiz::surface::{Change, CursorVisibility, Position};
-use termwiz::terminal::Terminal;
-
-fn run_confirmation_app(message: &str, term: &mut TermWizTerminal) -> anyhow::Result<bool> {
-    term.set_raw_mode()?;
-
-    let size = term.get_screen_size()?;
-
-    /*
-    use crate::termwindow::ICON_DATA;
-    use image::GenericImageView;
-    use std::sync::Arc;
-    use termwiz::surface::change::ImageData;
-    use termwiz::surface::TextureCoordinate;
-
-        let image_data = Arc::new(ImageData::with_raw_data(ICON_DATA.to_vec()));
-        let decoded_image = image::load_from_memory(ICON_DATA)?;
-        let logo_width_cells = 3usize;
-        let logo_width = logo_width_cells * size.xpixel;
-        let logo_scale = logo_width as f32 / decoded_image.width() as f32;
-        let logo_height = decoded_image.height() as f32 * logo_scale;
-        let logo_height_cells = (logo_height / size.ypixel as f32).ceil() as usize;
-        */
-
-    // Render 80% wide, centered
-    let text_width = size.cols * 80 / 100;
-    let x_pos = size.cols * 10 / 100;
-
-    // Fit text to the width
-    let wrapped = textwrap::fill(message, text_width);
-
-    let message_rows = wrapped.split("\n").count();
-    // Now we want to vertically center the prompt in the view.
-    // After the prompt there will be a blank line and then the "buttons",
-    // so we add two to the number of rows.
-    let top_row = (size.rows - (message_rows + 2)) / 2;
-
-    let button_row = top_row + message_rows + 1;
-    let mut active = ActiveButton::None;
-
-    let yes_x = x_pos;
-    let yes_w = 7;
-
-    let no_x =  yes_x + yes_w + 8 /* spacer */;
-    let no_w = 6;
-
-    #[derive(Copy, Clone, PartialEq, Eq)]
-    enum ActiveButton {
-        None,
-        Yes,
-        No,
-    }
-
-    let render = |term: &mut TermWizTerminal, active: ActiveButton| -> termwiz::Result<()> {
-        let mut changes = vec![
-            Change::ClearScreen(ColorAttribute::Default),
-            Change::CursorVisibility(CursorVisibility::Hidden),
-            /*
-            Change::Image(termwiz::surface::change::Image {
-                width: logo_width_cells,
-                height: logo_height_cells,
-                top_left: TextureCoordinate::new_f32(0., 0.),
-                bottom_right: TextureCoordinate::new_f32(1., 1.),
-                image: Arc::clone(&image_data),
-            }),
-            */
-        ];
-
-        for (y, row) in wrapped.split("\n").enumerate() {
-            let row = row.trim_end();
-            changes.push(Change::CursorPosition {
-                x: Position::Absolute(x_pos),
-                y: Position::Absolute(top_row + y),
-            });
-            changes.push(Change::Text(row.to_string()));
-        }
-
-        changes.push(Change::CursorPosition {
-            x: Position::Absolute(x_pos),
-            y: Position::Absolute(button_row),
-        });
-
-        if active == ActiveButton::Yes {
-            changes.push(AttributeChange::Reverse(true).into());
-        }
-        changes.push(" [Y]es ".into());
-        if active == ActiveButton::Yes {
-            changes.push(AttributeChange::Reverse(false).into());
-        }
-
-        changes.push("        ".into());
-
-        if active == ActiveButton::No {
-            changes.push(AttributeChange::Reverse(true).into());
-        }
-        changes.push(" [N]o ".into());
-        if active == ActiveButton::No {
-            changes.push(AttributeChange::Reverse(false).into());
-        }
-
-        term.render(&changes)?;
-        term.flush()
-    };
-
-    render(term, active)?;
-
-    while let Ok(Some(event)) = term.poll_input(None) {
-        match event {
-            InputEvent::Key(KeyEvent {
-                key: KeyCode::Char('y' | 'Y'),
-                ..
-            }) => {
-                return Ok(true);
-            }
-            InputEvent::Key(KeyEvent {
-                key: KeyCode::Char('n' | 'N'),
-                ..
-            })
-            | InputEvent::Key(KeyEvent {
-                key: KeyCode::Escape,
-                ..
-            }) => {
-                return Ok(false);
-            }
-            InputEvent::Mouse(MouseEvent {
-                x,
-                y,
-                mouse_buttons,
-                ..
-            }) => {
-                let x = x as usize;
-                let y = y as usize;
-                if y == button_row && x >= yes_x && x < yes_x + yes_w {
-                    active = ActiveButton::Yes;
-                    if mouse_buttons == MouseButtons::LEFT {
-                        return Ok(true);
-                    }
-                } else if y == button_row && x >= no_x && x < no_x + no_w {
-                    active = ActiveButton::No;
-                    if mouse_buttons == MouseButtons::LEFT {
-                        return Ok(false);
-                    }
-                } else {
-                    active = ActiveButton::None;
-                }
-
-                if mouse_buttons != MouseButtons::NONE {
-                    // Treat any other mouse button as cancel
-                    return Ok(false);
-                }
-            }
-            _ => {}
-        }
-
-        render(term, active)?;
-    }
-
-    Ok(false)
-}
 
 pub fn confirm_close_pane(
     pane_id: PaneId,
@@ -173,7 +12,7 @@ pub fn confirm_close_pane(
     mux_window_id: WindowId,
     window: ::window::Window,
 ) -> anyhow::Result<()> {
-    if run_confirmation_app("🛑 Really kill this pane?", &mut term)? {
+    if run_confirmation("🛑 Really kill this pane?", &mut term)? {
         promise::spawn::spawn_into_main_thread(async move {
             let mux = Mux::get();
             let tab = match mux.get_active_tab_for_window(mux_window_id) {
@@ -195,7 +34,7 @@ pub fn confirm_close_tab(
     _mux_window_id: WindowId,
     window: ::window::Window,
 ) -> anyhow::Result<()> {
-    if run_confirmation_app(
+    if run_confirmation(
         "🛑 Really kill this tab and all contained panes?",
         &mut term,
     )? {
@@ -216,7 +55,7 @@ pub fn confirm_close_window(
     window: ::window::Window,
     tab_id: TabId,
 ) -> anyhow::Result<()> {
-    if run_confirmation_app(
+    if run_confirmation(
         "🛑 Really kill this window and all contained tabs and panes?",
         &mut term,
     )? {
@@ -236,7 +75,7 @@ pub fn confirm_quit_program(
     window: ::window::Window,
     tab_id: TabId,
 ) -> anyhow::Result<()> {
-    if run_confirmation_app("🛑 Really Quit WezTerm?", &mut term)? {
+    if run_confirmation("🛑 Really Quit WezTerm?", &mut term)? {
         promise::spawn::spawn_into_main_thread(async move {
             use ::window::{Connection, ConnectionOps};
             let con = Connection::get().expect("call on gui thread");

--- a/wezterm-gui/src/overlay/confirm_close_pane.rs
+++ b/wezterm-gui/src/overlay/confirm_close_pane.rs
@@ -1,4 +1,4 @@
-use super::confirm::run_confirmation;
+use super::confirm;
 use crate::TermWindow;
 use mux::pane::PaneId;
 use mux::tab::TabId;
@@ -12,7 +12,7 @@ pub fn confirm_close_pane(
     mux_window_id: WindowId,
     window: ::window::Window,
 ) -> anyhow::Result<()> {
-    if run_confirmation("🛑 Really kill this pane?", &mut term)? {
+    if confirm::run_confirmation("🛑 Really kill this pane?", &mut term)? {
         promise::spawn::spawn_into_main_thread(async move {
             let mux = Mux::get();
             let tab = match mux.get_active_tab_for_window(mux_window_id) {
@@ -34,7 +34,7 @@ pub fn confirm_close_tab(
     _mux_window_id: WindowId,
     window: ::window::Window,
 ) -> anyhow::Result<()> {
-    if run_confirmation(
+    if confirm::run_confirmation(
         "🛑 Really kill this tab and all contained panes?",
         &mut term,
     )? {
@@ -55,7 +55,7 @@ pub fn confirm_close_window(
     window: ::window::Window,
     tab_id: TabId,
 ) -> anyhow::Result<()> {
-    if run_confirmation(
+    if confirm::run_confirmation(
         "🛑 Really kill this window and all contained tabs and panes?",
         &mut term,
     )? {
@@ -75,7 +75,7 @@ pub fn confirm_quit_program(
     window: ::window::Window,
     tab_id: TabId,
 ) -> anyhow::Result<()> {
-    if run_confirmation("🛑 Really Quit WezTerm?", &mut term)? {
+    if confirm::run_confirmation("🛑 Really Quit WezTerm?", &mut term)? {
         promise::spawn::spawn_into_main_thread(async move {
             use ::window::{Connection, ConnectionOps};
             let con = Connection::get().expect("call on gui thread");

--- a/wezterm-gui/src/overlay/mod.rs
+++ b/wezterm-gui/src/overlay/mod.rs
@@ -6,6 +6,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use wezterm_term::{TerminalConfiguration, TerminalSize};
 
+pub mod confirm;
 pub mod confirm_close_pane;
 pub mod copy;
 pub mod debug;


### PR DESCRIPTION
A confirmation menu similar to close menu is displayed.
If `yes` is selected, a custom event is emitted which causes the provided callback to be called.
If `no` is selected, no further action takes place.
The callback accepts parameters `window, pane`