### PR TITLE
Display quick select label and match in bold

### DIFF
--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -19,7 +19,7 @@ use termwiz::surface::{SequenceNo, SEQ_ZERO};
 use url::Url;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, StableRowIndex, TerminalSize,
+    Clipboard, Intensity, KeyCode, KeyModifiers, Line, MouseEvent, StableRowIndex, TerminalSize,
 };
 use window::WindowOps;
 
@@ -601,7 +601,8 @@ impl Pane for QuickSelectOverlay {
                                                 .quick_select_match_fg
                                                 .unwrap_or(AnsiColor::Green.into()),
                                         )
-                                        .set_reverse(false);
+                                        .set_reverse(false)
+                                        .set_intensity(Intensity::Bold);
                                 }
                             }
                             for (idx, c) in m.label.chars().enumerate() {
@@ -619,7 +620,8 @@ impl Pane for QuickSelectOverlay {
                                         .quick_select_label_fg
                                         .unwrap_or(AnsiColor::Olive.into()),
                                 )
-                                .set_reverse(false);
+                                .set_reverse(false)
+                                .set_intensity(Intensity::Bold);
                                 line.set_cell(m.range.start + idx, Cell::new(c, attr), SEQ_ZERO);
                             }
                         }
@@ -691,7 +693,8 @@ impl Pane for QuickSelectOverlay {
                                         .quick_select_match_fg
                                         .unwrap_or(AnsiColor::Green.into()),
                                 )
-                                .set_reverse(false);
+                                .set_reverse(false)
+                                .set_intensity(Intensity::Bold);
                         }
                     }
                     for (idx, c) in m.label.chars().enumerate() {
@@ -709,7 +712,8 @@ impl Pane for QuickSelectOverlay {
                                 .quick_select_label_fg
                                 .unwrap_or(AnsiColor::Olive.into()),
                         )
-                        .set_reverse(false);
+                        .set_reverse(false)
+                        .set_intensity(Intensity::Bold);
                         line.set_cell(m.range.start + idx, Cell::new(c, attr), SEQ_ZERO);
                     }
                 }


### PR DESCRIPTION
Quick select with label bold, match bold
![Screenshot 2025-02-26 at 09 53 00](https://github.com/user-attachments/assets/ae1bfdd5-bb49-469e-ad3d-1a6150c5b474)


Quick select with label bold, match regular
![Screenshot 2025-02-26 at 09 49 30](https://github.com/user-attachments/assets/1922904f-e374-42d2-8298-8e1bb59dbf49)


Quick select with label regular, match regular
![Screenshot 2025-02-26 at 09 50 35](https://github.com/user-attachments/assets/d14974c1-9b25-4f30-9051-4aeb82358adc)

