### PR TITLE
Fix "error: unknown codegen option: ` target-feature`" when running `cargo build --release` on MSVC Windows

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,4 @@ ar = "x86_64-w64-mingw32-gcc-ar"
 # and openssl-src does that based on the crt-static feature being
 # enabled for the target, so let's turn that on here.
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C target-feature=+crt-static"]
+rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
This patch removes a space in the `rustflags` TOML variable definition for MSVC Windows in `.cargo/config.toml`  that seems to cause issues with rust compilation.

## Background

I tried building Wezterm from source on Windows 11. Followed the installation guide today (2025-02-24). Fresh install of rustc (`rustc 1.85.0 (4d91de4e4 2025-02-17)`) and Strawberry Perl (v5.40). Building off of main.

Before this patch:
```sh
Larry Smith@NucBoxG3Plus ~/r/wezterm (main)> cargo build --release
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `C:\Users\Larry Smith\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin\rustc.exe - --crate-name ___ --print=file-names "-C target-feature=+crt-static" --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit code: 1)
  --- stderr
  error: unknown codegen option: ` target-feature`
```

After this patch:
```
Larry Smith@NucBoxG3Plus ~/r/wezterm (main) [101]> cargo build --release
   Compiling openssl-sys v0.9.105
   Compiling phf_shared v0.11.3
   Compiling icu_locid v1.5.0
   Compiling nom v7.1.3
   Compiling profiling v1.0.16
   Compiling generic-array v0.14.7
   Compiling num-rational v0.4.2
   Compiling rayon-core v1.12.1
   Compiling getrandom v0.3.1

[... and so on]
```

Sorry, don't know exactly why this makes a difference, but at the very least this fix worked for me, so figured I'd open a PR if no one's opposed. Thank you guys so much for this project!