### PR TITLE
FAQ docs for MacOS PATH note

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -354,8 +354,10 @@ wezterm.action.SpawnCommandInNewWindow {
   },
 }
 ```
+Note: For zsh users, you may need to add -l or -i to the above if the PATH settings are specified
+in .zprofile or .zshrc repectively. Homebrew users probably need -l. 
 
-another option is to explicitly use the full path to the program on your system,
+Another option is to explicitly use the full path to the program on your system,
 something like:
 
 ```lua


### PR DESCRIPTION
Added a note to the FAQ section due to an issue I ran into. 

A [plugin](https://github.com/MLFlexer/smart_workspace_switcher.wezterm) I use wasn't working so I tried figuring it out. It uses zoxide via run_child_process which ran into the issue that is [referenced in the FAQ](https://wezterm.org/faq.html?h=#im-on-macos-and-wezterm-cannot-find-things-in-my-path). Turns out, "zsh -c ..." runs a non-interactive non-login zsh shell. Since I installed zoxide via Homebrew and Homebrew has its PATH modifications in .zprofile it wasn't getting picked up even with the current suggested solution. (.zprofile is only parsed for zsh "login shell") Adding -l fixed it. 

Hope this helps!