### PR TITLE
Improve documentation of `pane:paste` vs `pane:send_paste`

### DIFF
--- a/docs/config/lua/pane/paste.md
+++ b/docs/config/lua/pane/paste.md
@@ -2,11 +2,11 @@
 
 {{since('20201031-154415-9614e117')}}
 
-Sends the supplied `text` string to the input of the pane as if it
-were pasted from the clipboard, except that the clipboard is not involved.
+!!! info "*Since: Version 20221119-145034-49b9839f*"
+    Alias of [`send_paste`](send_paste.md) for backwards compatibility with prior releases.
 
-If the terminal attached to the pane is set to bracketed paste mode then
-the text will be sent as a bracketed paste.
-
-Otherwise the string will be streamed into the input in chunks of
-approximately 1KB each.
+{%
+    include-markdown "./send_paste.md"
+    start="<!--shared-paste-description-BEGIN-->"
+    end="<!--shared-paste-description-END-->"
+%}

--- a/docs/config/lua/pane/send_paste.md
+++ b/docs/config/lua/pane/send_paste.md
@@ -2,7 +2,12 @@
 
 {{since('20220624-141144-bd1b7c5d')}}
 
-Sends text to the pane as though it was pasted. If bracketed paste mode is
-enabled then the text will be sent as a bracketed paste. Otherwise, it will
-be sent as-is.
+<!--shared-paste-description-BEGIN-->
+Sends the supplied `text` string to the input of the pane as if it
+were pasted from the clipboard, except that the clipboard is not involved.
+Newlines are rewritten according to the
+[`canonicalize_pasted_newlines`](../config/canonicalize_pasted_newlines.md) setting.
 
+If the terminal attached to the pane is set to bracketed paste mode then
+the text will be sent as a bracketed paste, and newlines will not be rewritten.
+<!--shared-paste-description-END-->


### PR DESCRIPTION
Since 20221119-145034-49b9839f (https://github.com/wezterm/wezterm/commit/42e4a51a2825e1a4166d6bd2dc92571c9494550c), `paste` has been an alias of `send_paste`, but this was not documented. I went commit-reading to find this out, so went ahead and fixed the docs to explain.