### PR TITLE
Add `Clone` derive to `termwiz::surface::Surface`

### DIFF
--- a/termwiz/src/surface/mod.rs
+++ b/termwiz/src/surface/mod.rs
@@ -101,7 +101,7 @@ pub const SEQ_ZERO: SequenceNo = 0;
 /// difference between the updated screen and apply those changes to
 /// the render target, and then use `get_changes` to render those without
 /// repainting the world on each update.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Surface {
     width: usize,
     height: usize,


### PR DESCRIPTION
I think this is my first PR here, so just wanted give a big thank you for all the wonderful code in this repo! ❤️

I don't know if this change is a small thing, or of course I wouldn't be surprised if it were a big thing.

Just a little context as to why it would be useful for me. I'm currently accessing some `Surface` instances between threads and so using locks. But in certain cases it would just be much simpler to share copies of surfaces between threads instead.

I'd also be interested if there were some other way of making quick duplicates?