### PR TITLE
Disable modifyOtherKeys by default

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -239,6 +239,8 @@ pub struct Config {
     pub enable_kitty_graphics: bool,
     #[dynamic(default)]
     pub enable_kitty_keyboard: bool,
+    #[dynamic(default)]
+    pub enable_modify_other_keys: bool,
 
     /// Whether the terminal should respond to requests to read the
     /// title string.

--- a/config/src/terminal.rs
+++ b/config/src/terminal.rs
@@ -82,6 +82,10 @@ impl wezterm_term::TerminalConfiguration for TermConfig {
         self.configuration().enable_title_reporting
     }
 
+    fn enable_modify_other_keys(&self) -> bool {
+        self.configuration().enable_modify_other_keys
+    }
+
     fn enable_kitty_keyboard(&self) -> bool {
         self.configuration().enable_kitty_keyboard
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@ usually the best available version.
 As features stabilize some brief notes about them will accumulate here.
 
 #### Changed
+* modifyOtherKeys support has been turned off by default. Use [enable_modify_other_keys](config/lua/config/enable_modify_other_keys.md)`=true` to enable it.
 * Wayland: currently being reimplemented, it maybe more unstable than usual.
   Please file GH issues for any problems you see.
   Many thanks to @tzx and @tmccombs! #4777 #5781

--- a/docs/config/key-encoding.md
+++ b/docs/config/key-encoding.md
@@ -59,7 +59,8 @@ The kitty protocol allows applications to request varying degrees of
 enhancement over the standard encoding scheme and also allows for more modifier
 keys (notably: `CMD`/`Super`/`Windows`) to be reported to the application.
 
-[enable_kitty_keyboard](lua/config/enable_kitty_keyboard.md) controls whether
+[enable_modify_other_keys](lua/config/enable_modify_other_keys.md) and
+[enable_kitty_keyboard](lua/config/enable_kitty_keyboard.md) control whether
 wezterm will honor the application requests to modify the keyboard encoding.
 
 ## Windows

--- a/docs/config/lua/config/enable_modify_other_keys.md
+++ b/docs/config/lua/config/enable_modify_other_keys.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - keys
+---
+# `enable_modify_other_keys = false`
+
+When set to `true`, wezterm will honor XTerm's modifyOtherKeys escape
+sequences that modify the [keyboard encoding](../../key-encoding.md).

--- a/term/src/config.rs
+++ b/term/src/config.rs
@@ -176,6 +176,10 @@ pub trait TerminalConfiguration: Downcast + std::fmt::Debug + Send + Sync {
         false
     }
 
+    fn enable_modify_other_keys(&self) -> bool {
+        false
+    }
+
     fn enable_kitty_keyboard(&self) -> bool {
         false
     }

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -1952,11 +1952,18 @@ impl TerminalState {
                 resource: XtermKeyModifierResource::OtherKeys,
                 value,
             } => {
-                self.modify_other_keys = match value {
-                    Some(0) => None,
-                    _ => value,
-                };
-                log::debug!("XtermKeyMode OtherKeys -> {:?}", self.modify_other_keys);
+                let enable_modify_other_keys = self.config.enable_modify_other_keys();
+                if enable_modify_other_keys {
+                    self.modify_other_keys = match value {
+                        Some(0) => None,
+                        _ => value,
+                    };
+                }
+                log::debug!(
+                    "XtermKeyMode OtherKeys -> {:?} [enabled={}]",
+                    self.modify_other_keys,
+                    enable_modify_other_keys,
+                );
             }
 
             Mode::XtermKeyMode { resource, value } => {


### PR DESCRIPTION
Given a non-English or non-default keyboard layout, requesting modifyOtherKeys
level 1 may send wrong keys. For example with

	setxkbmap -layout us -variant dvp

pressing shift-4 will wrongly include the shift
modifier. It works in XTerm.

Let's disable this by default, similar to enable_kitty_keyboard.

Users of English keyboard layouts are better off using the kitty keyboard
protocol anyway, which properly supports shifted keys.

Of course this patch is a tradeoff (not sure how much appetite there is
for this; I can do more research). I will say that it does help people
typing on a non-English keyboard in Kakoune (which requests modifyOtherKeys
unconditionally).

Closes #6087
(probably also others)

Originally reported at https://github.com/fish-shell/fish-shell/issues/11204
