### PR TITLE
use correct link for u2500 box drawing characters.

### DIFF
--- a/docs/config/lua/config/custom_block_glyphs.md
+++ b/docs/config/lua/config/custom_block_glyphs.md
@@ -14,7 +14,7 @@ Ideally this option wouldn't exist, but it is present to work around a [hinting 
 
 |Block|What|Since|
 |-----|----|-----|
-|[U2500](https://www.unicode.org/charts/PDF/U2580.pdf)|Box Drawing|*20210814-124438-54e29167*|
+|[U2500](https://www.unicode.org/charts/PDF/U2500.pdf)|Box Drawing|*20210814-124438-54e29167*|
 |[U2580](https://www.unicode.org/charts/PDF/U2580.pdf)|unicode block elements|*20210314-114017-04b7cedd*|
 |[U1FB00](https://www.unicode.org/charts/PDF/U1FB00.pdf)|Symbols for Legacy Computing (Sextants and Smooth mosaic graphics)|*20210814-124438-54e29167*|
 |[U1CC00](https://www.unicode.org/charts/PDF/U1CC00.pdf)|Symbols for Legacy Computing Supplement (Block mosaic terminal graphic characters)|*???*|


### PR DESCRIPTION
Correct link for u2500, was pointing to 2580.