### PR TITLE
fix: tmux -CC error on %config-error

### DIFF
--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -123,6 +123,10 @@ impl TmuxDomainState {
                         log::debug!("Tmux pane {} havn't been attached", pane);
                     }
                 }
+                Event::ConfigError { error } => {
+                    // tmux config file error, not our fault, just log it and go
+                    log::info!("The tmux configuration error: '{}'", error);
+                }
                 Event::WindowAdd { window } => {
                     // Only handle the new tab, the first empty window handled by sync_window_state
                     if !self.gui_window.lock().is_none() {

--- a/termwiz/src/tmux_cc/mod.rs
+++ b/termwiz/src/tmux_cc/mod.rs
@@ -41,14 +41,52 @@ pub enum Event {
         flags: i64,
     },
     Guarded(Guarded),
-    Output {
+    ClientDetached {
+        client_name: String,
+    },
+    ClientSessionChanged {
+        client_name: String,
+        session: TmuxSessionId,
+        session_name: String,
+    },
+    ConfigError {
+        error: String,
+    },
+    Continue {
+        pane: TmuxPaneId,
+    },
+    ExtendedOutput {
         pane: TmuxPaneId,
         text: String,
     },
     Exit {
         reason: Option<String>,
     },
-    SessionsChanged,
+    LayoutChange {
+        window: TmuxWindowId,
+        layout: String,
+        visible_layout: Option<String>,
+        raw_flags: Option<String>,
+    },
+    Message {
+        message: String,
+    },
+    Output {
+        pane: TmuxPaneId,
+        text: String,
+    },
+    PaneModeChanged {
+        pane: TmuxPaneId,
+    },
+    PasteBufferChanged {
+        buffer: String,
+    },
+    PasteBufferDeleted {
+        buffer: String,
+    },
+    Pause {
+        pane: TmuxPaneId,
+    },
     SessionChanged {
         session: TmuxSessionId,
         name: String,
@@ -60,16 +98,16 @@ pub enum Event {
         session: TmuxSessionId,
         window: TmuxWindowId,
     },
-    ClientSessionChanged {
-        client_name: String,
-        session: TmuxSessionId,
-        session_name: String,
+    SessionsChanged,
+    SubscriptionChanged,
+    UnlinkedWindowAdd {
+        window: TmuxWindowId,
     },
-    ClientDetached {
-        client_name: String,
+    UnlinkedWindowClose {
+        window: TmuxWindowId,
     },
-    PaneModeChanged {
-        pane: TmuxPaneId,
+    UnlinkedWindowRenamed {
+        window: TmuxWindowId,
     },
     WindowAdd {
         window: TmuxWindowId,
@@ -84,12 +122,6 @@ pub enum Event {
     WindowRenamed {
         window: TmuxWindowId,
         name: String,
-    },
-    LayoutChange {
-        window: TmuxWindowId,
-        layout: String,
-        visible_layout: Option<String>,
-        raw_flags: Option<String>,
     },
 }
 
@@ -208,71 +240,6 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
                 flags,
             })
         }
-        Rule::exit => {
-            let mut pairs = pair.into_inner();
-            let reason = pairs.next().map(|pair| pair.as_str().to_owned());
-            Ok(Event::Exit { reason })
-        }
-        Rule::sessions_changed => Ok(Event::SessionsChanged),
-        Rule::pane_mode_changed => {
-            let mut pairs = pair.into_inner();
-            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
-            Ok(Event::PaneModeChanged { pane })
-        }
-        Rule::window_add => {
-            let mut pairs = pair.into_inner();
-            let window =
-                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
-            Ok(Event::WindowAdd { window })
-        }
-        Rule::window_close => {
-            let mut pairs = pair.into_inner();
-            let window =
-                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
-            Ok(Event::WindowClose { window })
-        }
-        Rule::window_pane_changed => {
-            let mut pairs = pair.into_inner();
-            let window =
-                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
-            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
-            Ok(Event::WindowPaneChanged { window, pane })
-        }
-        Rule::window_renamed => {
-            let mut pairs = pair.into_inner();
-            let window =
-                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
-            let name = unvis(
-                pairs
-                    .next()
-                    .ok_or_else(|| anyhow!("missing name"))?
-                    .as_str(),
-            )?;
-            Ok(Event::WindowRenamed { window, name })
-        }
-        Rule::output => {
-            let mut pairs = pair.into_inner();
-            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
-            let text = unvis(
-                pairs
-                    .next()
-                    .ok_or_else(|| anyhow!("missing text"))?
-                    .as_str(),
-            )?;
-            Ok(Event::Output { pane, text })
-        }
-        Rule::session_changed => {
-            let mut pairs = pair.into_inner();
-            let session =
-                parse_session_id(pairs.next().ok_or_else(|| anyhow!("missing session id"))?)?;
-            let name = unvis(
-                pairs
-                    .next()
-                    .ok_or_else(|| anyhow!("missing name"))?
-                    .as_str(),
-            )?;
-            Ok(Event::SessionChanged { session, name })
-        }
         Rule::client_session_changed => {
             let mut pairs = pair.into_inner();
             let client_name = unvis(
@@ -305,23 +272,36 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
             )?;
             Ok(Event::ClientDetached { client_name })
         }
-        Rule::session_renamed => {
+        Rule::config_error => {
             let mut pairs = pair.into_inner();
-            let name = unvis(
+            let error = unvis(
                 pairs
                     .next()
                     .ok_or_else(|| anyhow!("missing name"))?
                     .as_str(),
             )?;
-            Ok(Event::SessionRenamed { name })
+            Ok(Event::ConfigError { error })
         }
-        Rule::session_window_changed => {
+        Rule::r#continue => {
             let mut pairs = pair.into_inner();
-            let session =
-                parse_session_id(pairs.next().ok_or_else(|| anyhow!("missing session id"))?)?;
-            let window =
-                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
-            Ok(Event::SessionWindowChanged { session, window })
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            Ok(Event::Continue { pane })
+        }
+        Rule::extended_output => {
+            let mut pairs = pair.into_inner();
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            let text = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::ExtendedOutput { pane, text })
+        }
+        Rule::exit => {
+            let mut pairs = pair.into_inner();
+            let reason = pairs.next().map(|pair| pair.as_str().to_owned());
+            Ok(Event::Exit { reason })
         }
         Rule::layout_change => {
             let mut pairs = pair.into_inner();
@@ -342,22 +322,154 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
                 raw_flags,
             })
         }
-        Rule::pane_id
-        | Rule::word
-        | Rule::client_name
-        | Rule::window_id
-        | Rule::session_id
-        | Rule::window_layout
+        Rule::message => {
+            let mut pairs = pair.into_inner();
+            let message = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::Message { message })
+        }
+        Rule::output => {
+            let mut pairs = pair.into_inner();
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            let text = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::Output { pane, text })
+        }
+        Rule::pane_mode_changed => {
+            let mut pairs = pair.into_inner();
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            Ok(Event::PaneModeChanged { pane })
+        }
+        Rule::paste_buffer_changed => {
+            let mut pairs = pair.into_inner();
+            let buffer = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::PasteBufferChanged { buffer })
+        }
+        Rule::paste_buffer_deleted => {
+            let mut pairs = pair.into_inner();
+            let buffer = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::PasteBufferDeleted { buffer })
+        }
+        Rule::pause => {
+            let mut pairs = pair.into_inner();
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            Ok(Event::Pause { pane })
+        }
+        Rule::session_changed => {
+            let mut pairs = pair.into_inner();
+            let session =
+                parse_session_id(pairs.next().ok_or_else(|| anyhow!("missing session id"))?)?;
+            let name = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing name"))?
+                    .as_str(),
+            )?;
+            Ok(Event::SessionChanged { session, name })
+        }
+        Rule::session_renamed => {
+            let mut pairs = pair.into_inner();
+            let name = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing name"))?
+                    .as_str(),
+            )?;
+            Ok(Event::SessionRenamed { name })
+        }
+        Rule::session_window_changed => {
+            let mut pairs = pair.into_inner();
+            let session =
+                parse_session_id(pairs.next().ok_or_else(|| anyhow!("missing session id"))?)?;
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::SessionWindowChanged { session, window })
+        }
+        Rule::sessions_changed => Ok(Event::SessionsChanged),
+        Rule::subscription_changed => Ok(Event::SubscriptionChanged),
+        Rule::unlinked_window_add => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::UnlinkedWindowAdd { window })
+        }
+        Rule::unlinked_window_close => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::UnlinkedWindowClose { window })
+        }
+        Rule::unlinked_window_renamed => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::UnlinkedWindowRenamed { window })
+        }
+        Rule::window_add => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::WindowAdd { window })
+        }
+        Rule::window_close => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::WindowClose { window })
+        }
+        Rule::window_pane_changed => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            Ok(Event::WindowPaneChanged { window, pane })
+        }
+        Rule::window_renamed => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            let name = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing name"))?
+                    .as_str(),
+            )?;
+            Ok(Event::WindowRenamed { window, name })
+        }
+        Rule::EOI
         | Rule::any_text
-        | Rule::line
-        | Rule::line_entire
-        | Rule::EOI
-        | Rule::number
+        | Rule::client_name
         | Rule::layout_split_pane
         | Rule::layout_pane
         | Rule::layout_split_horizontal
         | Rule::layout_split_vertical
-        | Rule::layout_window => anyhow::bail!("Should not reach here"),
+        | Rule::layout_window
+        | Rule::line
+        | Rule::line_entire
+        | Rule::number
+        | Rule::pane_id
+        | Rule::session_id
+        | Rule::window_id
+        | Rule::window_layout
+        | Rule::word => anyhow::bail!("Should not reach here"),
     }
 }
 
@@ -617,35 +729,46 @@ fn parse_layout_inner(
                 stack.push(pane);
             }
             Rule::EOI
-            | Rule::number
-            | Rule::client_session_changed
             | Rule::any_text
-            | Rule::pane_id
-            | Rule::window_id
-            | Rule::word
-            | Rule::window_layout
-            | Rule::line_entire
-            | Rule::line
-            | Rule::session_id
-            | Rule::client_name
-            | Rule::client_detached
             | Rule::begin
+            | Rule::client_detached
+            | Rule::client_name
+            | Rule::client_session_changed
+            | Rule::config_error
+            | Rule::r#continue
             | Rule::end
             | Rule::error
             | Rule::exit
+            | Rule::extended_output
+            | Rule::layout_split_pane
+            | Rule::layout_window
+            | Rule::layout_change
+            | Rule::line
+            | Rule::line_entire
+            | Rule::message
+            | Rule::number
             | Rule::output
+            | Rule::pane_id
             | Rule::pane_mode_changed
+            | Rule::paste_buffer_changed
+            | Rule::paste_buffer_deleted
+            | Rule::pause
             | Rule::session_changed
+            | Rule::session_id
             | Rule::session_renamed
             | Rule::session_window_changed
             | Rule::sessions_changed
+            | Rule::subscription_changed
+            | Rule::unlinked_window_add
+            | Rule::unlinked_window_close
+            | Rule::unlinked_window_renamed
             | Rule::window_add
             | Rule::window_close
+            | Rule::window_id
+            | Rule::window_layout
             | Rule::window_pane_changed
             | Rule::window_renamed
-            | Rule::layout_split_pane
-            | Rule::layout_window
-            | Rule::layout_change => anyhow::bail!("Should not reach here"),
+            | Rule::word => anyhow::bail!("Should not reach here"),
         }
     }
 
@@ -869,6 +992,16 @@ here
 %output %1 \\033[K\\033[?2004h
 %exit
 %exit I said so
+%config-error /home/joe/.tmux.conf:1: unknown command: dadsafafasdf
+%continue %2
+%extended_output \\033[1m\\033[7m%\\033[27m\\033[1m\\033[0m    \\015 \\015
+%message message text
+%unlinked_window_add @40
+%unlinked_window_renamed @41
+%paste_buffer_changed just something
+%paste_buffer_deleted just something else
+%pause %3
+%subscription_changed something we don't handle so far
 ";
 
         let mut p = Parser::new();

--- a/termwiz/src/tmux_cc/tmux.pest
+++ b/termwiz/src/tmux_cc/tmux.pest
@@ -14,37 +14,60 @@ error = { "%error " ~ number ~ " " ~ number ~ " " ~ number }
 
 client_session_changed = { "%client-session-changed " ~ client_name ~ " " ~ session_id ~ " " ~any_text }
 client_detached = { "%client-detached " ~ client_name }
-output = { "%output " ~ pane_id ~ " " ~ any_text }
+config_error = { "%config-error " ~ any_text }
+continue = { "%continue " ~ pane_id }
 exit = { "%exit" ~ (" " ~ any_text)? }
-sessions_changed = { "%sessions-changed" }
+extended_output = { "%extended-output " ~ pane_id ~ any_text }
+layout_change = { "%layout-change " ~ window_id ~ " " ~ (window_layout ~ " " ~ window_layout ~ " " ~any_text | window_layout) }
+message = { "%message " ~ any_text }
+output = { "%output " ~ pane_id ~ " " ~ any_text }
 pane_mode_changed = { "%pane-mode-changed " ~ pane_id }
-window_add = { "%window-add " ~ window_id }
-window_close = { ("%window-close " | "%unlinked-window-close ") ~ window_id }
-window_pane_changed = { "%window-pane-changed " ~ window_id ~ " " ~ pane_id }
-window_renamed = { "%window-renamed " ~ window_id ~ " " ~ any_text }
+paste_buffer_changed = { "%paste-buffer-changed " ~ any_text }
+paste_buffer_deleted = { "%paste-buffer-deleted " ~ any_text }
+pause = { "%pause " ~ pane_id }
 session_changed = { "%session-changed " ~ session_id ~ " " ~ any_text }
 session_renamed = { "%session-renamed " ~ any_text }
 session_window_changed = { "%session-window-changed " ~ session_id ~ " " ~ window_id }
-layout_change = { "%layout-change " ~ window_id ~ " " ~ (window_layout ~ " " ~ window_layout ~ " " ~any_text | window_layout) }
+sessions_changed = { "%sessions-changed" }
+subscription_changed = { " %subscription-changed " ~ any_text }
+unlinked_window_add = { "%unlinked-window-add " ~ window_id }
+unlinked_window_close = { "%unlinked-window-close " ~ window_id }
+unlinked_window_renamed = { "%unlinked-window-renamed " ~ window_id }
+window_add = { "%window-add " ~ window_id }
+window_close = { "%window-close " ~ window_id }
+window_pane_changed = { "%window-pane-changed " ~ window_id ~ " " ~ pane_id }
+window_renamed = { "%window-renamed " ~ window_id ~ " " ~ any_text }
 
 line = _{ (
-  client_session_changed |
-  client_detached |
   begin |
   end |
   error |
+
+  client_session_changed |
+  client_detached |
+  config_error |
+  continue |
   exit |
+  extended_output |
+  layout_change |
+  message |
   output |
   pane_mode_changed |
+  paste_buffer_changed |
+  paste_buffer_deleted |
+  pause |
   session_changed |
   session_renamed |
   session_window_changed |
   sessions_changed |
+  subscription_changed |
+  unlinked_window_add |
+  unlinked_window_close |
+  unlinked_window_renamed |
   window_add |
   window_close |
   window_pane_changed |
-  window_renamed |
-  layout_change
+  window_renamed
 ) }
 
 line_entire = _{ SOI ~ line ~ EOI }


### PR DESCRIPTION
refs: #6763

In the PR, the %config-error is handled

we also add all events we missed according to latest Tmux 3.6 version although most of them we are not interested but we need to parse them in case they come by accident.

Looks messy, but not all are real changes, because I move the rules in alphabet order to easily organize the code later. 