### PR TITLE
fix: tmux -CC error on %config-error

### DIFF
--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -114,7 +114,7 @@ impl TmuxDomainState {
                 // Tmux specific events
                 Event::ConfigError { error } => {
                     // tmux config file error, not our fault, just log it and go
-                    log::info!("The tmux configuration error: {error}");
+                    log::warn!("tmux configuration error: {error}");
                 }
                 Event::Exit { reason: _ } => {
                     *self.state.lock() = State::Exit;

--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -112,6 +112,10 @@ impl TmuxDomainState {
                 },
 
                 // Tmux specific events
+                Event::ConfigError { error } => {
+                    // tmux config file error, not our fault, just log it and go
+                    log::info!("The tmux configuration error: {error}");
+                }
                 Event::Exit { reason: _ } => {
                     *self.state.lock() = State::Exit;
                     let mut pane_map = self.remote_panes.lock();
@@ -215,6 +219,9 @@ impl TmuxDomainState {
                             tab.set_title(&format!("{}", name));
                         }
                     }
+                }
+                Event::UnlinkedWindowClose { window } => {
+                    let _ = self.remove_detached_window(*window);
                 }
                 _ => {}
             }

--- a/termwiz/src/tmux_cc/mod.rs
+++ b/termwiz/src/tmux_cc/mod.rs
@@ -52,6 +52,16 @@ pub enum Event {
         session: TmuxSessionId,
         session_name: String,
     },
+    ConfigError {
+        error: String,
+    },
+    Continue {
+        pane: TmuxPaneId,
+    },
+    ExtendedOutput {
+        pane: TmuxPaneId,
+        text: String,
+    },
     Exit {
         reason: Option<String>,
     },
@@ -61,11 +71,23 @@ pub enum Event {
         visible_layout: Option<String>,
         raw_flags: Option<String>,
     },
+    Message {
+        message: String,
+    },
     Output {
         pane: TmuxPaneId,
         text: String,
     },
     PaneModeChanged {
+        pane: TmuxPaneId,
+    },
+    PasteBufferChanged {
+        buffer: String,
+    },
+    PasteBufferDeleted {
+        buffer: String,
+    },
+    Pause {
         pane: TmuxPaneId,
     },
     SessionChanged {
@@ -78,6 +100,16 @@ pub enum Event {
     SessionsChanged,
     SessionWindowChanged {
         session: TmuxSessionId,
+        window: TmuxWindowId,
+    },
+    SubscriptionChanged,
+    UnlinkedWindowAdd {
+        window: TmuxWindowId,
+    },
+    UnlinkedWindowClose {
+        window: TmuxWindowId,
+    },
+    UnlinkedWindowRenamed {
         window: TmuxWindowId,
     },
     WindowAdd {
@@ -246,6 +278,32 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
                 session_name,
             })
         }
+        Rule::config_error => {
+            let mut pairs = pair.into_inner();
+            let error = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing name"))?
+                    .as_str(),
+            )?;
+            Ok(Event::ConfigError { error })
+        }
+        Rule::r#continue => {
+            let mut pairs = pair.into_inner();
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            Ok(Event::Continue { pane })
+        }
+        Rule::extended_output => {
+            let mut pairs = pair.into_inner();
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            let text = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::ExtendedOutput { pane, text })
+        }
         Rule::exit => {
             let mut pairs = pair.into_inner();
             let reason = pairs.next().map(|pair| pair.as_str().to_owned());
@@ -270,6 +328,16 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
                 raw_flags,
             })
         }
+        Rule::message => {
+            let mut pairs = pair.into_inner();
+            let message = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::Message { message })
+        }
         Rule::output => {
             let mut pairs = pair.into_inner();
             let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
@@ -285,6 +353,31 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
             let mut pairs = pair.into_inner();
             let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
             Ok(Event::PaneModeChanged { pane })
+        }
+        Rule::paste_buffer_changed => {
+            let mut pairs = pair.into_inner();
+            let buffer = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::PasteBufferChanged { buffer })
+        }
+        Rule::paste_buffer_deleted => {
+            let mut pairs = pair.into_inner();
+            let buffer = unvis(
+                pairs
+                    .next()
+                    .ok_or_else(|| anyhow!("missing text"))?
+                    .as_str(),
+            )?;
+            Ok(Event::PasteBufferDeleted { buffer })
+        }
+        Rule::pause => {
+            let mut pairs = pair.into_inner();
+            let pane = parse_pane_id(pairs.next().ok_or_else(|| anyhow!("missing pane id"))?)?;
+            Ok(Event::Pause { pane })
         }
         Rule::session_changed => {
             let mut pairs = pair.into_inner();
@@ -317,6 +410,25 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
             Ok(Event::SessionWindowChanged { session, window })
         }
         Rule::sessions_changed => Ok(Event::SessionsChanged),
+        Rule::subscription_changed => Ok(Event::SubscriptionChanged),
+        Rule::unlinked_window_add => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::UnlinkedWindowAdd { window })
+        }
+        Rule::unlinked_window_close => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::UnlinkedWindowClose { window })
+        }
+        Rule::unlinked_window_renamed => {
+            let mut pairs = pair.into_inner();
+            let window =
+                parse_window_id(pairs.next().ok_or_else(|| anyhow!("missing window id"))?)?;
+            Ok(Event::UnlinkedWindowRenamed { window })
+        }
         Rule::window_add => {
             let mut pairs = pair.into_inner();
             let window =
@@ -351,13 +463,13 @@ fn parse_line(line: &str) -> anyhow::Result<Event> {
         Rule::EOI
         | Rule::any_text
         | Rule::client_name
-        | Rule::line
-        | Rule::line_entire
         | Rule::layout_pane
         | Rule::layout_split_horizontal
         | Rule::layout_split_pane
         | Rule::layout_split_vertical
         | Rule::layout_window
+        | Rule::line
+        | Rule::line_entire
         | Rule::number
         | Rule::pane_id
         | Rule::session_id
@@ -628,23 +740,34 @@ fn parse_layout_inner(
             | Rule::client_detached
             | Rule::client_name
             | Rule::client_session_changed
+            | Rule::config_error
+            | Rule::r#continue
             | Rule::end
             | Rule::error
             | Rule::exit
+            | Rule::extended_output
             | Rule::layout_change
             | Rule::layout_split_pane
             | Rule::layout_window
             | Rule::line
             | Rule::line_entire
+            | Rule::message
             | Rule::number
             | Rule::output
             | Rule::pane_id
             | Rule::pane_mode_changed
+            | Rule::paste_buffer_changed
+            | Rule::paste_buffer_deleted
+            | Rule::pause
             | Rule::session_changed
             | Rule::session_id
             | Rule::session_renamed
             | Rule::session_window_changed
             | Rule::sessions_changed
+            | Rule::subscription_changed
+            | Rule::unlinked_window_add
+            | Rule::unlinked_window_close
+            | Rule::unlinked_window_renamed
             | Rule::window_add
             | Rule::window_close
             | Rule::window_id
@@ -875,6 +998,16 @@ here
 %output %1 \\033[K\\033[?2004h
 %exit
 %exit I said so
+%config-error /home/joe/.tmux.conf:1: unknown command: dadsafafasdf
+%continue %2
+%extended-output %1 \\033[1m\\033[7m%\\033[27m\\033[1m\\033[0m    \\015 \\015
+%message message text
+%unlinked-window-add @40
+%unlinked-window-renamed @41
+%paste-buffer-changed just something
+%paste-buffer-deleted just something else
+%pause %3
+%subscription-changed something we don't handle so far
 ";
 
         let mut p = Parser::new();
@@ -892,7 +1025,7 @@ here
                 }),
                 Event::WindowAdd { window: 1 },
                 Event::WindowClose { window: 38 },
-                Event::WindowClose { window: 39 },
+                Event::UnlinkedWindowClose { window: 39 },
                 Event::SessionsChanged,
                 Event::SessionChanged {
                     session: 1,
@@ -939,6 +1072,27 @@ here
                 Event::Exit {
                     reason: Some("I said so".to_owned())
                 },
+                Event::ConfigError {
+                    error: "/home/joe/.tmux.conf:1: unknown command: dadsafafasdf".to_owned()
+                },
+                Event::Continue { pane: 2 },
+                Event::ExtendedOutput {
+                    pane: 1,
+                    text: "\x1b[1m\x1b[7m%\x1b[27m\x1b[1m\x1b[0m    \r \r".to_owned()
+                },
+                Event::Message {
+                    message: "message text".to_owned()
+                },
+                Event::UnlinkedWindowAdd { window: 40 },
+                Event::UnlinkedWindowRenamed { window: 41 },
+                Event::PasteBufferChanged {
+                    buffer: "just something".to_owned()
+                },
+                Event::PasteBufferDeleted {
+                    buffer: "just something else".to_owned()
+                },
+                Event::Pause { pane: 3 },
+                Event::SubscriptionChanged,
             ],
             events
         );

--- a/termwiz/src/tmux_cc/tmux.pest
+++ b/termwiz/src/tmux_cc/tmux.pest
@@ -20,16 +20,27 @@ error = { "%error " ~ number ~ " " ~ number ~ " " ~ number }
 // Tmux specific rules
 client_session_changed = { "%client-session-changed " ~ client_name ~ " " ~ session_id ~ " " ~any_text }
 client_detached = { "%client-detached " ~ client_name }
+config_error = { "%config-error " ~ any_text }
+continue = { "%continue " ~ pane_id }
 exit = { "%exit" ~ (" " ~ any_text)? }
+extended_output = { "%extended-output " ~ pane_id ~ " " ~ any_text }
 layout_change = { "%layout-change " ~ window_id ~ " " ~ (window_layout ~ " " ~ window_layout ~ " " ~any_text | window_layout) }
+message = { "%message " ~ any_text }
 output = { "%output " ~ pane_id ~ " " ~ any_text }
 pane_mode_changed = { "%pane-mode-changed " ~ pane_id }
+paste_buffer_changed = { "%paste-buffer-changed " ~ any_text }
+paste_buffer_deleted = { "%paste-buffer-deleted " ~ any_text }
+pause = { "%pause " ~ pane_id }
 session_changed = { "%session-changed " ~ session_id ~ " " ~ any_text }
 session_renamed = { "%session-renamed " ~ any_text }
 session_window_changed = { "%session-window-changed " ~ session_id ~ " " ~ window_id }
 sessions_changed = { "%sessions-changed" }
+subscription_changed = { "%subscription-changed " ~ any_text }
+unlinked_window_add = { "%unlinked-window-add " ~ window_id }
+unlinked_window_close = { "%unlinked-window-close " ~ window_id }
+unlinked_window_renamed = { "%unlinked-window-renamed " ~ window_id }
 window_add = { "%window-add " ~ window_id }
-window_close = { ("%window-close " | "%unlinked-window-close ") ~ window_id }
+window_close = { "%window-close " ~ window_id }
 window_pane_changed = { "%window-pane-changed " ~ window_id ~ " " ~ pane_id }
 window_renamed = { "%window-renamed " ~ window_id ~ " " ~ any_text }
 
@@ -42,14 +53,25 @@ line = _{ (
   // Tmux specific rules
   client_detached |
   client_session_changed |
+  config_error |
+  continue |
   exit |
+  extended_output |
   layout_change |
+  message |
   output |
   pane_mode_changed |
+  paste_buffer_changed |
+  paste_buffer_deleted |
+  pause |
   session_changed |
   session_renamed |
   session_window_changed |
   sessions_changed |
+  subscription_changed |
+  unlinked_window_add |
+  unlinked_window_close |
+  unlinked_window_renamed |
   window_add |
   window_close |
   window_pane_changed |


### PR DESCRIPTION
refs: #6763

In the PR, the %config-error is handled

we also add all events we missed according to latest Tmux 3.6 version although most of them we are not interested but we need to parse them in case they come by accident.

Looks messy, but not all are real changes, because I move the rules in alphabet order to easily organize the code later.