### PR TITLE
Add configuration option for Launcher label background and foreground color

### DIFF
--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -173,6 +173,9 @@ pub struct Palette {
 
     pub input_selector_label_fg: Option<ColorSpec>,
     pub input_selector_label_bg: Option<ColorSpec>,
+
+    pub launcher_label_fg: Option<ColorSpec>,
+    pub launcher_label_bg: Option<ColorSpec>,
 }
 impl_lua_conversion_dynamic!(Palette);
 
@@ -224,6 +227,8 @@ impl Palette {
             quick_select_match_bg: overlay!(quick_select_match_bg),
             input_selector_label_fg: overlay!(input_selector_label_fg),
             input_selector_label_bg: overlay!(input_selector_label_bg),
+            launcher_label_fg: overlay!(launcher_label_fg),
+            launcher_label_bg: overlay!(launcher_label_bg),
         }
     }
 }

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -133,6 +133,9 @@ config.colors = {
 
   input_selector_label_bg = { AnsiColor = 'Black' }, -- {{since('nightly', inline=True)}}
   input_selector_label_fg = { Color = '#ffffff' }, -- {{since('nightly', inline=True)}}
+
+  launcher_label_bg = { AnsiColor = 'Black' }, -- {{since('nightly', inline=True)}}
+  launcher_label_fg = { Color = '#ffffff' }, -- {{since('nightly', inline=True)}}
 }
 
 return config

--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -393,6 +393,11 @@ impl LauncherState {
         let max_label_len = labels.iter().map(|s| s.len()).max().unwrap_or(0);
         let mut labels_iter = labels.into_iter();
 
+        let config = configuration();
+        let colors = &config.resolved_palette;
+        let launcher_label_fg = colors.launcher_label_fg;
+        let launcher_label_bg = colors.launcher_label_bg;
+
         for (row_num, (entry_idx, entry)) in self
             .filtered_entries
             .iter()
@@ -416,7 +421,19 @@ impl LauncherState {
             // and we are not filtering
             if !self.filtering {
                 if let Some(label) = labels_iter.next() {
+                    if let Some(launcher_label_bg) = launcher_label_bg {
+                        changes.push(AttributeChange::Background(launcher_label_bg.into()).into());
+                    }
+                    if let Some(launcher_label_fg) = launcher_label_fg {
+                        changes.push(AttributeChange::Foreground(launcher_label_fg.into()).into());
+                    }
                     changes.push(Change::Text(format!(" {label:>max_label_len$}. ")));
+                    if launcher_label_bg.is_some() {
+                        changes.push(AttributeChange::Background(ColorAttribute::Default).into());
+                    }
+                    if launcher_label_fg.is_some() {
+                        changes.push(AttributeChange::Foreground(ColorAttribute::Default).into());
+                    }
                 } else {
                     changes.push(Change::Text(" ".repeat(max_label_len + 3)));
                 }


### PR DESCRIPTION
Add below configuration option in config.colors:
* `launcher_label_bg`
* `launcher_label_fg`

If above mentioned options are not set in the configuration file then:
* `launcher_label_bg` defaults to default background color
* `launcher_label_fg` defaults to default foreground color