### PR TITLE
Imgcat enhancements

### DIFF
--- a/assets/shell-completion/fish
+++ b/assets/shell-completion/fish
@@ -189,7 +189,7 @@ complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l resample-filter -
 complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l resize -d 'Pre-process the image to resize it to the specified dimensions, expressed as eg: 800x600 (width x height). The resize is independent of other parameters that control the image placement and dimensions in the terminal; this is provided as a convenience preprocessing step' -r
 complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l no-preserve-aspect-ratio -d 'Do not respect the aspect ratio.  The default is to respect the aspect ratio'
 complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l no-move-cursor -d 'Do not move the cursor after displaying the image. Note that when used like this from the shell, there is a very high chance that shell prompt will overwrite the image; you may wish to also use `--hold` in that case'
-complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l hold -d 'Wait for enter to be pressed after displaying the image'
+complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l hold -d 'Wait for enter/escape/ctrl-c/ctrl-d to be pressed after displaying the image'
 complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l no-resample -d 'Do not resample images whose frames are larger than the max-pixels value. Note that this will typically result in the image refusing to display in wezterm'
 complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -l show-resample-timing -d 'When resampling or resizing, display some diagnostics around the timing/performance of that operation'
 complete -c wezterm -n "__fish_seen_subcommand_from imgcat" -s h -l help -d 'Print help (see more with \'--help\')'

--- a/assets/shell-completion/zsh
+++ b/assets/shell-completion/zsh
@@ -422,7 +422,7 @@ _arguments "${_arguments_options[@]}" \
 '--resize=[Pre-process the image to resize it to the specified dimensions, expressed as eg\: 800x600 (width x height). The resize is independent of other parameters that control the image placement and dimensions in the terminal; this is provided as a convenience preprocessing step]:WIDTHxHEIGHT: ' \
 '--no-preserve-aspect-ratio[Do not respect the aspect ratio.  The default is to respect the aspect ratio]' \
 '--no-move-cursor[Do not move the cursor after displaying the image. Note that when used like this from the shell, there is a very high chance that shell prompt will overwrite the image; you may wish to also use \`--hold\` in that case]' \
-'--hold[Wait for enter to be pressed after displaying the image]' \
+'--hold[Wait for enter/escape/ctrl-c/ctrl-d to be pressed after displaying the image]' \
 '--no-resample[Do not resample images whose frames are larger than the max-pixels value. Note that this will typically result in the image refusing to display in wezterm]' \
 '--show-resample-timing[When resampling or resizing, display some diagnostics around the timing/performance of that operation]' \
 '-h[Print help (see more with '\''--help'\'')]' \

--- a/docs/examples/cmd-synopsis-wezterm-imgcat--help.txt
+++ b/docs/examples/cmd-synopsis-wezterm-imgcat--help.txt
@@ -36,7 +36,7 @@ Options:
           that case
 
       --hold
-          Wait for enter to be pressed after displaying the image
+          Wait for enter/escape/ctrl-c/ctrl-d to be pressed after displaying the image
 
       --tmux-passthru <TMUX_PASSTHRU>
           How to manage passing the escape through to tmux

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -587,6 +587,7 @@ impl ImgCatCommand {
         }
 
         if self.hold {
+            term.set_raw_mode()?;
             while let Ok(Some(event)) = term.poll_input(None) {
                 match event {
                     InputEvent::Key(KeyEvent {

--- a/wezterm/src/main.rs
+++ b/wezterm/src/main.rs
@@ -9,7 +9,7 @@ use std::io::Read;
 use termwiz::caps::Capabilities;
 use termwiz::escape::esc::{Esc, EscCode};
 use termwiz::escape::OneBased;
-use termwiz::input::{InputEvent, KeyCode, KeyEvent};
+use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers};
 use termwiz::surface::change::Change;
 use termwiz::surface::Position;
 use termwiz::terminal::{ScreenSize, Terminal};
@@ -181,7 +181,7 @@ struct ImgCatCommand {
     #[arg(long)]
     no_move_cursor: bool,
 
-    /// Wait for enter to be pressed after displaying the image
+    /// Wait for enter/escape/ctrl-c/ctrl-d to be pressed after displaying the image
     #[arg(long)]
     hold: bool,
 
@@ -590,10 +590,16 @@ impl ImgCatCommand {
             term.set_raw_mode()?;
             while let Ok(Some(event)) = term.poll_input(None) {
                 match event {
-                    InputEvent::Key(KeyEvent {
-                        key: KeyCode::Enter,
-                        modifiers: _,
-                    }) => {
+                    InputEvent::Key(
+                        KeyEvent {
+                            key: KeyCode::Enter | KeyCode::Escape,
+                            modifiers: _,
+                        }
+                        | KeyEvent {
+                            key: KeyCode::Char('c') | KeyCode::Char('d'),
+                            modifiers: Modifiers::CTRL,
+                        },
+                    ) => {
                         break;
                     }
                     _ => {}


### PR DESCRIPTION
* Set raw mode when polling input in order to avoid local echo if `--hold` option is set
* Add key modifier combinations to exit polling input if `--hold` option is set:
  * `ctrl-c`
  * `ctrl-d`
  * `Escape` 