### PR TITLE
Feature/user dropped events

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2020,6 +2020,7 @@ pub enum DroppedFileQuoting {
     /// Always double quote the file name
     WindowsAlwaysQuoted,
 }
+impl_lua_conversion_dynamic!(DroppedFileQuoting);
 
 impl Default for DroppedFileQuoting {
     fn default() -> Self {

--- a/lua-api-crates/termwiz-funcs/src/lib.rs
+++ b/lua-api-crates/termwiz-funcs/src/lib.rs
@@ -1,5 +1,6 @@
 use config::lua::get_or_create_module;
 use config::lua::mlua::{self, IntoLua, Lua};
+use config::DroppedFileQuoting;
 use finl_unicode::grapheme_clusters::Graphemes;
 use luahelper::impl_lua_conversion_dynamic;
 use std::str::FromStr;
@@ -45,6 +46,14 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
     wezterm_mod.set(
         "permute_any_or_no_mods",
         lua.create_function(permute_any_or_no_mods)?,
+    )?;
+
+    wezterm_mod.set(
+        "quote",
+        lua.create_function(|_, (s, quoting): (String, DroppedFileQuoting)| {
+            let result = quoting.escape(&s);
+            Ok(result)
+        })?,
     )?;
 
     Ok(())

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1013,12 +1013,48 @@ impl TermWindow {
                 }
                 Ok(true)
             }
+            // Combine the dropped events into one match so we can fire an event to
+            // alter the texts or urls before sending them to the pane
             WindowEvent::DroppedString(text) => {
                 let pane = match self.get_active_pane_or_overlay() {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                pane.send_paste(text.as_str())?;
+                let txt = match config::run_immediate_with_lua_config(|lua| {
+                    if let Some(lua) = lua {
+                        let tabs = self.get_tab_information();
+                        let panes = self.get_pane_information();
+                        let active_tab = tabs.iter().find(|t| t.is_active).cloned();
+                        let active_pane = panes.iter().find(|p| p.is_active).cloned();
+
+                        let v = config::lua::emit_sync_callback(
+                            &*lua,
+                            (
+                                "user-dropped-string".to_string(),
+                                (
+                                    tabs,
+                                    panes,
+                                    active_tab.clone(),
+                                    active_pane.clone(),
+                                    text.clone(),
+                                ),
+                            ),
+                        )?;
+                        match &v {
+                            mlua::Value::Nil => Ok(None),
+                            _ => Ok(Some(String::from_lua(v, &*lua)?)),
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                }) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        log::warn!("user-dropped-string: {}", err);
+                        Some(text.clone())
+                    }
+                };
+                pane.send_paste(txt.as_deref().unwrap_or(&text))?;
                 Ok(true)
             }
             WindowEvent::DroppedUrl(urls) => {
@@ -1026,13 +1062,76 @@ impl TermWindow {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let urls = urls
-                    .iter()
-                    .map(|url| self.config.quote_dropped_files.escape(&url.to_string()))
-                    .collect::<Vec<_>>()
-                    .join(" ")
-                    + " ";
-                pane.send_paste(urls.as_str())?;
+                let urls_string = match config::run_immediate_with_lua_config(|lua| {
+                    if let Some(lua) = lua {
+                        let tabs = self.get_tab_information();
+                        let panes = self.get_pane_information();
+                        let active_tab = tabs.iter().find(|t| t.is_active).cloned();
+                        let active_pane = panes.iter().find(|p| p.is_active).cloned();
+                        // We need to pass the urls as a lua table to the
+                        // callback so that the lua code can modify them
+                        let urls = urls.iter().map(|url| url.to_string()).collect::<Vec<_>>();
+
+                        let seq = lua.create_sequence_from(urls.iter().map(|s| s.as_str()))?;
+                        let v = config::lua::emit_sync_callback(
+                            &*lua,
+                            (
+                                "user-dropped-urls".to_string(),
+                                (
+                                    tabs,
+                                    panes,
+                                    active_tab.clone(),
+                                    active_pane.clone(),
+                                    urls.clone(),
+                                ),
+                            ),
+                        )?;
+                        match &v {
+                            mlua::Value::Nil => Ok(None),
+                            mlua::Value::Table(t) => {
+                                // if returns a table, convert to a string joined by spaces
+                                let mut urls_string = String::new();
+                                for i in 1..=t.len()? {
+                                    if let Some(v) = t.get(i)? {
+                                        if !urls_string.is_empty() {
+                                            urls_string.push(' ');
+                                        }
+                                        urls_string.push_str(&String::from_lua(v, &*lua)?);
+                                    }
+                                }
+                                if urls_string.is_empty() {
+                                    return Ok(None);
+                                }
+                                Ok(Some(urls_string))
+                            }
+                            mlua::Value::String(s) => {
+                                let v = s.to_str()?;
+                                if v.is_empty() {
+                                    return Ok(None);
+                                }
+                                Ok(Some(v.to_string()))
+                            }
+                            _ => Ok(Some(String::from_lua(v, &*lua)?)),
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                }) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        log::warn!("user-dropped-urls: {}", err);
+                        None
+                    }
+                };
+                pane.send_paste(
+                    urls_string.as_deref().unwrap_or(
+                        &urls
+                            .iter()
+                            .map(|url| url.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" "),
+                    ),
+                )?;
                 Ok(true)
             }
             WindowEvent::DroppedFile(paths) => {
@@ -1040,17 +1139,91 @@ impl TermWindow {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let paths = paths
-                    .iter()
-                    .map(|path| {
-                        self.config
-                            .quote_dropped_files
-                            .escape(&path.to_string_lossy())
-                    })
-                    .collect::<Vec<_>>()
-                    .join(" ")
-                    + " ";
-                pane.send_paste(&paths)?;
+                let paths_string = match config::run_immediate_with_lua_config(|lua| {
+                    if let Some(lua) = lua {
+                        let tabs = self.get_tab_information();
+                        let panes = self.get_pane_information();
+                        let active_tab = tabs.iter().find(|t| t.is_active).cloned();
+                        let active_pane = panes.iter().find(|p| p.is_active).cloned();
+                        let paths = paths
+                            .iter()
+                            .map(|path| path.to_string_lossy())
+                            .collect::<Vec<_>>();
+
+                        let v = config::lua::emit_sync_callback(
+                            &*lua,
+                            (
+                                "user-dropped-paths".to_string(),
+                                (
+                                    tabs,
+                                    panes,
+                                    active_tab.clone(),
+                                    active_pane.clone(),
+                                    paths.clone(),
+                                ),
+                            ),
+                        )?;
+                        match &v {
+                            mlua::Value::Nil => Ok(None),
+                            mlua::Value::Table(t) => {
+                                // if returns a table, convert to a string joined by spaces
+                                let mut paths_string = String::new();
+                                for i in 1..=t.len()? {
+                                    if let Some(v) = t.get(i)? {
+                                        if !paths_string.is_empty() {
+                                            paths_string.push(' ');
+                                        }
+                                        paths_string.push_str(&String::from_lua(v, &*lua)?);
+                                    }
+                                }
+                                if paths_string.is_empty() {
+                                    return Ok(None);
+                                }
+                                Ok(Some(paths_string))
+                            }
+                            mlua::Value::String(s) => {
+                                let v = s.to_str()?;
+                                if v.is_empty() {
+                                    return Ok(None);
+                                }
+                                Ok(Some(v.to_string()))
+                            }
+                            _ => Ok(Some(String::from_lua(v, &*lua)?)),
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                }) {
+                    Ok(s) => s,
+                    Err(err) => {
+                        log::warn!("user-dropped-paths: {}", err);
+                        None
+                    }
+                };
+                // let paths = paths
+                //     .iter()
+                //     .map(|path| {
+                //         self.config
+                //             .quote_dropped_files
+                //             .escape(&path.to_string_lossy())
+                //     })
+                //     .collect::<Vec<_>>()
+                //     .join(" ")
+                //     + " ";
+                pane.send_paste(
+                    paths_string.as_deref().unwrap_or(
+                        (paths
+                            .iter()
+                            .map(|path| {
+                                self.config
+                                    .quote_dropped_files
+                                    .escape(&path.to_string_lossy())
+                            })
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                            + " ").as_str()
+                    ),
+                )?;
                 Ok(true)
             }
             WindowEvent::DraggedFile(_) => Ok(true),

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1013,47 +1013,12 @@ impl TermWindow {
                 }
                 Ok(true)
             }
-            // Combine the dropped events into one match so we can fire an event to
-            // alter the texts or urls before sending them to the pane
             WindowEvent::DroppedString(text) => {
                 let pane = match self.get_active_pane_or_overlay() {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let txt = match config::run_immediate_with_lua_config(|lua| {
-                    if let Some(lua) = lua {
-                        let tabs = self.get_tab_information();
-                        let panes = self.get_pane_information();
-                        let active_tab = tabs.iter().find(|t| t.is_active).cloned();
-                        let active_pane = panes.iter().find(|p| p.is_active).cloned();
-
-                        let v = config::lua::emit_sync_callback(
-                            &*lua,
-                            (
-                                "user-dropped-string".to_string(),
-                                (
-                                    tabs,
-                                    panes,
-                                    active_tab.clone(),
-                                    active_pane.clone(),
-                                    text.clone(),
-                                ),
-                            ),
-                        )?;
-                        match &v {
-                            mlua::Value::Nil => Ok(None),
-                            _ => Ok(Some(String::from_lua(v, &*lua)?)),
-                        }
-                    } else {
-                        Ok(None)
-                    }
-                }) {
-                    Ok(s) => s,
-                    Err(err) => {
-                        log::warn!("user-dropped-string: {}", err);
-                        Some(text.clone())
-                    }
-                };
+                let txt = self.run_lua_callback( "user-dropped-string", vec![text.clone()]);
                 pane.send_paste(txt.as_deref().unwrap_or(&text))?;
                 Ok(true)
             }
@@ -1062,67 +1027,10 @@ impl TermWindow {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let urls_string = match config::run_immediate_with_lua_config(|lua| {
-                    if let Some(lua) = lua {
-                        let tabs = self.get_tab_information();
-                        let panes = self.get_pane_information();
-                        let active_tab = tabs.iter().find(|t| t.is_active).cloned();
-                        let active_pane = panes.iter().find(|p| p.is_active).cloned();
-                        // We need to pass the urls as a lua table to the
-                        // callback so that the lua code can modify them
-                        let urls = urls.iter().map(|url| url.to_string()).collect::<Vec<_>>();
-
-                        let seq = lua.create_sequence_from(urls.iter().map(|s| s.as_str()))?;
-                        let v = config::lua::emit_sync_callback(
-                            &*lua,
-                            (
-                                "user-dropped-urls".to_string(),
-                                (
-                                    tabs,
-                                    panes,
-                                    active_tab.clone(),
-                                    active_pane.clone(),
-                                    urls.clone(),
-                                ),
-                            ),
-                        )?;
-                        match &v {
-                            mlua::Value::Nil => Ok(None),
-                            mlua::Value::Table(t) => {
-                                // if returns a table, convert to a string joined by spaces
-                                let mut urls_string = String::new();
-                                for i in 1..=t.len()? {
-                                    if let Some(v) = t.get(i)? {
-                                        if !urls_string.is_empty() {
-                                            urls_string.push(' ');
-                                        }
-                                        urls_string.push_str(&String::from_lua(v, &*lua)?);
-                                    }
-                                }
-                                if urls_string.is_empty() {
-                                    return Ok(None);
-                                }
-                                Ok(Some(urls_string))
-                            }
-                            mlua::Value::String(s) => {
-                                let v = s.to_str()?;
-                                if v.is_empty() {
-                                    return Ok(None);
-                                }
-                                Ok(Some(v.to_string()))
-                            }
-                            _ => Ok(Some(String::from_lua(v, &*lua)?)),
-                        }
-                    } else {
-                        Ok(None)
-                    }
-                }) {
-                    Ok(s) => s,
-                    Err(err) => {
-                        log::warn!("user-dropped-urls: {}", err);
-                        None
-                    }
-                };
+                let urls_string = self.run_lua_callback( 
+                    "user-dropped-urls",
+                    urls.iter().map(|url| url.to_string()).collect::<Vec<_>>(),
+                );
                 pane.send_paste(
                     urls_string.as_deref().unwrap_or(
                         &urls
@@ -1139,77 +1047,13 @@ impl TermWindow {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let paths_string = match config::run_immediate_with_lua_config(|lua| {
-                    if let Some(lua) = lua {
-                        let tabs = self.get_tab_information();
-                        let panes = self.get_pane_information();
-                        let active_tab = tabs.iter().find(|t| t.is_active).cloned();
-                        let active_pane = panes.iter().find(|p| p.is_active).cloned();
-                        let paths = paths
-                            .iter()
-                            .map(|path| path.to_string_lossy())
-                            .collect::<Vec<_>>();
-
-                        let v = config::lua::emit_sync_callback(
-                            &*lua,
-                            (
-                                "user-dropped-paths".to_string(),
-                                (
-                                    tabs,
-                                    panes,
-                                    active_tab.clone(),
-                                    active_pane.clone(),
-                                    paths.clone(),
-                                ),
-                            ),
-                        )?;
-                        match &v {
-                            mlua::Value::Nil => Ok(None),
-                            mlua::Value::Table(t) => {
-                                // if returns a table, convert to a string joined by spaces
-                                let mut paths_string = String::new();
-                                for i in 1..=t.len()? {
-                                    if let Some(v) = t.get(i)? {
-                                        if !paths_string.is_empty() {
-                                            paths_string.push(' ');
-                                        }
-                                        paths_string.push_str(&String::from_lua(v, &*lua)?);
-                                    }
-                                }
-                                if paths_string.is_empty() {
-                                    return Ok(None);
-                                }
-                                Ok(Some(paths_string))
-                            }
-                            mlua::Value::String(s) => {
-                                let v = s.to_str()?;
-                                if v.is_empty() {
-                                    return Ok(None);
-                                }
-                                Ok(Some(v.to_string()))
-                            }
-                            _ => Ok(Some(String::from_lua(v, &*lua)?)),
-                        }
-                    } else {
-                        Ok(None)
-                    }
-                }) {
-                    Ok(s) => s,
-                    Err(err) => {
-                        log::warn!("user-dropped-paths: {}", err);
-                        None
-                    }
-                };
-                // let paths = paths
-                //     .iter()
-                //     .map(|path| {
-                //         self.config
-                //             .quote_dropped_files
-                //             .escape(&path.to_string_lossy())
-                //     })
-                //     .collect::<Vec<_>>()
-                //     .join(" ")
-                //     + " ";
+                let paths_string = self.run_lua_callback( 
+                    "user-dropped-paths",
+                    paths
+                        .iter()
+                        .map(|path| path.to_string_lossy().to_string())
+                        .collect::<Vec<_>>(),
+                );
                 pane.send_paste(
                     paths_string.as_deref().unwrap_or(
                         (paths
@@ -1221,12 +1065,75 @@ impl TermWindow {
                             })
                             .collect::<Vec<_>>()
                             .join(" ")
-                            + " ").as_str()
+                            + " ")
+                            .as_str(),
                     ),
                 )?;
                 Ok(true)
             }
             WindowEvent::DraggedFile(_) => Ok(true),
+        }
+    }
+    fn run_lua_callback(
+        &mut self, 
+        event_name: &str, 
+        data: Vec<String>
+    ) -> Option<String> {
+        match config::run_immediate_with_lua_config(|lua| {
+            if let Some(lua) = lua {
+                let tabs = self.get_tab_information();
+                let panes = self.get_pane_information();
+                let active_tab = tabs.iter().find(|t| t.is_active).cloned();
+                let active_pane = panes.iter().find(|p| p.is_active).cloned();
+                let (modifiers, _) = self.current_modifier_and_leds;
+
+                let v = config::lua::emit_sync_callback(
+                    &lua,
+                    (
+                        event_name.to_string(),
+                        (
+                            active_tab.clone(),
+                            active_pane.clone(),
+                            modifiers.to_string(),
+                            data.clone(),
+                        ),
+                    ),
+                )?;
+                match &v {
+                    mlua::Value::Nil => Ok(None),
+                    mlua::Value::Table(t) => {
+                        let mut result_string = String::new();
+                        for i in 1..=t.len()? {
+                            if let Some(v) = t.get(i)? {
+                                if !result_string.is_empty() {
+                                    result_string.push(' ');
+                                }
+                                result_string.push_str(&String::from_lua(v, &lua)?);
+                            }
+                        }
+                        if result_string.is_empty() {
+                            return Ok(None);
+                        }
+                        Ok(Some(result_string))
+                    }
+                    mlua::Value::String(s) => {
+                        let v = s.to_str()?;
+                        if v.is_empty() {
+                            return Ok(Some("".to_string()));
+                        }
+                        Ok(Some(v.to_string()))
+                    }
+                    _ => Ok(Some(String::from_lua(v, &lua)?)),
+                }
+            } else {
+                Ok(None)
+            }
+        }) {
+            Ok(s) => s,
+            Err(err) => {
+                log::warn!("{}: {}", event_name, err);
+                None
+            }
         }
     }
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1018,7 +1018,7 @@ impl TermWindow {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let txt = self.run_lua_callback( "user-dropped-string", vec![text.clone()]);
+                let txt = self.user_dropped_event( "user-dropped-string", vec![text.clone()]);
                 pane.send_paste(txt.as_deref().unwrap_or(&text))?;
                 Ok(true)
             }
@@ -1027,7 +1027,7 @@ impl TermWindow {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let urls_string = self.run_lua_callback( 
+                let urls_string = self.user_dropped_event( 
                     "user-dropped-urls",
                     urls.iter().map(|url| url.to_string()).collect::<Vec<_>>(),
                 );
@@ -1047,7 +1047,7 @@ impl TermWindow {
                     Some(pane) => pane,
                     None => return Ok(true),
                 };
-                let paths_string = self.run_lua_callback( 
+                let paths_string = self.user_dropped_event( 
                     "user-dropped-paths",
                     paths
                         .iter()
@@ -1074,7 +1074,7 @@ impl TermWindow {
             WindowEvent::DraggedFile(_) => Ok(true),
         }
     }
-    fn run_lua_callback(
+    fn user_dropped_event(
         &mut self, 
         event_name: &str, 
         data: Vec<String>


### PR DESCRIPTION
@wez

This is just a draft so that I can get some comments going, since I have a few questions and decisions to be made...

I know I need to get the docs made, but for the moment and for reference, the current event handlers...

```lua
local wezterm = require("wezterm") --[[@as Wezterm]]
local inspect = require("inspect")

--- Generic event handler for when a user drops something URLs/Paths/String
--- This is called when the user drags and drops something into the terminal
--- Modifiers are only provided  if the user is holding down a key while
--- dropping and the wezterm window is focused when the drop occurs
--- @param tab table The current tab
--- @param pane table The current pane
--- @param mods string The keyboard modifiers (Ctrl, Shift, Alt, etc.) separated by '|'
--- @param drops table<string> The list of drops (URLs, paths, or strings)
--- @return string|nil A string to override the default content or nil to use the default behavior
function generic_handler(tab, pane, mods, drops)
  for _, drop in ipairs(drops) do
    -- examples of different quoting styles
    wezterm.log_info("Windows", wezterm.quote(drop, "Windows"))
    wezterm.log_info("Posix", wezterm.quote(drop, "Posix"))
    wezterm.log_info("SpacesOnly", wezterm.quote(drop, "SpacesOnly"))
    wezterm.log_info("WindowsAlwaysQuoted", wezterm.quote(drop, "WindowsAlwaysQuoted"))
    -- json encoding a string will escape quotes and other special characters
    wezterm.log_info("Serde", wezterm.serde.json_encode(drop))

    -- if any drop has a .git extension we dont want to rely on the default behavior
    -- we create an action_callback to escape the sync and get access to window and pane objects
    -- we will use the pane:send_text instead of the paste
    if drop:match("%.git$") then
      -- example of putting a command and a ctrl-c before the string is executed
      local cmd_string = "\3" -- "\3" to send a ctrl-c
        .. "git clone " -- turn this into a command to run
        .. drop -- the url
        .. " # " -- comment to ensure any existing text is ignored
        .. "\r" -- return a carriage return to execute the command

      wezterm.log_info("git url detected", drop, cmd_string)

      -- create an action_callback for to escape the sync callback
      -- but we need to pass the pane id to it so we can send the text to the correct pane
      local action = wezterm.action_callback(function(_wid, pid, ...)
        local p = wezterm.mux.get_pane(pid)
        -- send the cmd string to the pane
        p:send_text(cmd_string)
      end)

      -- this can probably be handled a different way, but this is a quick example
      -- by stealing the generated event name from the KeyAssignment::EmitEvent that action_callback
      -- returns
      wezterm.emit(action.EmitEvent, tab.window_id, pane.pane_id)
      return ""
    end
  end

  -- let's say we want to also handle drops when the user is holding down a key
  -- when the ALT key is held down we want to check if the paths are directories
  -- within the current working directory and if not we want to copy them to it
  if mods:find("ALT") then
    wezterm.log_info("ALT key held down, checking files")
    local cwd = pane.current_working_dir.path
    local copier_event = wezterm.action_callback(function(_, _, ...)
      function basename(s)
        return string.gsub(s, "(.*[/\\])(.*)", "%2")
      end
      for _, drop in ipairs(drops) do
        -- run child process `realpath` to see if the drop is within the cwd
        local ok, stdo, stde =
          wezterm.run_child_process({ "realpath", "--relative-to", cwd, wezterm.quote(drop, "Posix") })
        if ok and string.find(stdo, "..", 1, true) then
          wezterm.log_info("copying", drop, "to", cwd)
          wezterm.background_child_process({ "cp", "-r", drop, cwd })
        end
      end
    end)
    -- this can probably be handled a different way, but this is a quick example
    -- by stealing the event name from the KeyAssignment::EmitEvent that action_callback
    -- generates
    wezterm.emit(copier_event.EmitEvent)
    -- override the default behavior since we are handling it ourselves
    return ""
  end

  return nil -- returning nothing does default behavior
end

--- Event handler for when a user drops something URLs
--- This is called when the user drags and drops something into the terminal
--- Modifiers are only provided  if the user is holding down a key while
--- dropping and the wezterm window is focused when the drop occurs
--- @param tab table The current tab
--- @param pane table The current pane
--- @param mods string The keyboard modifiers (Ctrl, Shift, Alt, etc.) separated by '|'
--- @param urls table<string> The list of drops (URLs, paths, or strings)
--- @return string|nil A string to override the default content or nil to use the default behavior
wezterm.on("user-dropped-urls", function(tab, pane, mods, urls)
  wezterm.log_info("user-dropped-urls", inspect(urls))
  return generic_handler(tab, pane, mods, urls)
end)

--- Event handler for when a user drops something Paths
--- This is called when the user drags and drops something into the terminal
--- Modifiers are only provided  if the user is holding down a key while
--- dropping and the wezterm window is focused when the drop occurs
--- @param tab table The current tab
--- @param pane table The current pane
--- @param mods string The keyboard modifiers (Ctrl, Shift, Alt, etc.) separated by '|'
--- @param paths table<string> The list of drops (URLs, paths, or strings)
--- @return string|nil A string to override the default content or nil to use the default behavior
wezterm.on("user-dropped-paths", function(tab, pane, mods, paths)
  wezterm.log_info("user-dropped-paths", inspect(paths))
  return generic_handler(tab, pane, mods, paths)
end)

--- Event handler for when a user drops something String
--- This is called when the user drags and drops something into the terminal
--- Modifiers are only provided  if the user is holding down a key while
--- dropping and the wezterm window is focused when the drop occurs
--- @param tab table The current tab
--- @param pane table The current pane
--- @param mods string The keyboard modifiers (Ctrl, Shift, Alt, etc.) separated by '|'
--- @param strings table<string> The list of drops (URLs, paths, or strings)
--- @return string|nil A string to override the default content or nil to use the default behavior
wezterm.on("user-dropped-string", function(tab, pane, mods, strings)
  wezterm.log_info("user-dropped-string", inspect(strings))
  return generic_handler(tab, pane, mods, strings)
end)

```


