### PR TITLE
Remove redundant character checks in Launcher, InputSelector

### DIFF
--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -506,13 +506,13 @@ impl LauncherState {
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('j'),
                     ..
-                }) if !self.filtering && !self.alphabet.contains("j") => {
+                }) if !self.filtering => {
                     self.move_down();
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('k'),
                     ..
-                }) if !self.filtering && !self.alphabet.contains("k") => {
+                }) if !self.filtering => {
                     self.move_up();
                 }
                 InputEvent::Key(KeyEvent {

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -260,13 +260,13 @@ impl SelectorState {
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('j'),
                     ..
-                }) if !self.filtering && !self.args.alphabet.contains("j") => {
+                }) if !self.filtering => {
                     self.move_down();
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('k'),
                     ..
-                }) if !self.filtering && !self.args.alphabet.contains("k") => {
+                }) if !self.filtering => {
                     self.move_up();
                 }
                 InputEvent::Key(KeyEvent {


### PR DESCRIPTION
We don't need to check if the alphabet includes `j`, `k` because if a character is included in the alphabet, the code corresponding to the first arm is executed