### PR TITLE
fix: deal with Windows Terminal mouse move with no buttons SGR report

### DIFF
--- a/termwiz/src/escape/csi.rs
+++ b/termwiz/src/escape/csi.rs
@@ -2220,6 +2220,7 @@ impl<'a> CSIParser<'a> {
             // other encodings is added and this block is likely copied and pasted
             // or refactored for re-use with them.
             ('M', 35) => MouseButton::None, // mouse motion with no buttons
+            ('m', 35) => MouseButton::None, // mouse motion with no buttons (in Windows Terminal)
             ('M', 3) => MouseButton::None,  // legacy notification about button release
             ('m', 3) => MouseButton::None,  // release+press doesn't make sense
             _ => {


### PR DESCRIPTION
Deal with Windows Terminal's version of a mouse-move-with-no-buttons SGR report. See https://github.com/zellij-org/zellij/issues/4065#issuecomment-2734898397