### PR TITLE
docs: fix typo in plugins.md

### DIFF
--- a/docs/config/plugins.md
+++ b/docs/config/plugins.md
@@ -4,7 +4,7 @@
 <!-- See also https://github.com/wez/wezterm/commit/e4ae8a844d8feaa43e1de34c5cc8b4f07ce525dd -->
 
 A Wezterm plugin is a package of Lua files that provide
-some some predefined functionality not in the core product.
+some predefined functionality not in the core product.
 
 A plugin is distributed via a Git URL.
 


### PR DESCRIPTION
I think the word 'some' is duplicated here.