### PR TITLE
lua-api-crates/mux: expose swap_active_with_index

### DIFF
--- a/docs/config/lua/MuxTab/swap_active_with_index.md
+++ b/docs/config/lua/MuxTab/swap_active_with_index.md
@@ -1,0 +1,54 @@
+# `tab:swap_active_with_index(pane_index, keep_focus)`
+
+Swaps the position of the active pane with the specified pane index. If `keep_focus` is false, focus will change to the selected pane, otherwise focus stays on the currently active pane in its new position.
+
+# Example: tmux-like pane marking and swapping
+
+```lua
+local marked_pane = nil
+
+wezterm.on('mark', function(window, pane)
+  id = pane:pane_id()
+  tab = window:active_tab()
+
+  marked_pane = { id, tab }
+end)
+
+wezterm.on('swap-pane', function(window, pane)
+  if not marked_pane then
+    wezterm.log_error 'No marked pane'
+    return
+  end
+
+  local cur_tab = window:active_tab()
+
+  -- Do nothing if marked pane is same as current
+  if marked_pane[1] == cur_tab:active_pane():pane_id() then
+    return
+  end
+
+  if marked_pane[2]:tab_id() ~= cur_tab:tab_id() then
+    wezterm.log_error 'Pane is on another tab'
+    return
+  end
+
+  local target_index = nil
+  for i, p in ipairs(cur_tab:panes()) do
+    if p:pane_id() == marked_pane[1] then
+      target_index = i - 1
+      break
+    end
+  end
+
+  if target_index then
+    cur_tab:swap_active_with_index(target_index, true)
+  end
+end)
+
+config = {
+  keys = {
+    { key = 'm', mods = 'CTRL', action = wezterm.action.EmitEvent 'mark' },
+    { key = 'm', mods = 'ALT', action = wezterm.action.EmitEvent 'swap-pane' },
+  },
+}
+```

--- a/docs/config/lua/MuxTab/swap_active_with_index.md
+++ b/docs/config/lua/MuxTab/swap_active_with_index.md
@@ -32,17 +32,7 @@ wezterm.on('swap-pane', function(window, pane)
     return
   end
 
-  local target_index = nil
-  for i, p in ipairs(cur_tab:panes()) do
-    if p:pane_id() == marked_pane[1] then
-      target_index = i - 1
-      break
-    end
-  end
-
-  if target_index then
-    cur_tab:swap_active_with_index(target_index, true)
-  end
+  cur_tab:swap_active_with_id(marked_pane[1], true)
 end)
 
 config = {

--- a/lua-api-crates/mux/src/tab.rs
+++ b/lua-api-crates/mux/src/tab.rs
@@ -155,5 +155,14 @@ impl UserData for MuxTab {
             }
             Ok(())
         });
+
+        methods.add_method("swap_active_with_index", |_, this, (pane_index, keep_focus): (usize, bool)| {
+            let mux = get_mux()?;
+            let tab = this.resolve(&mux)?;
+
+            let success = tab.swap_active_with_index(pane_index, keep_focus).is_some();
+
+            Ok(success)
+        });
     }
 }

--- a/lua-api-crates/mux/src/tab.rs
+++ b/lua-api-crates/mux/src/tab.rs
@@ -156,13 +156,19 @@ impl UserData for MuxTab {
             Ok(())
         });
 
-        methods.add_method("swap_active_with_index", |_, this, (pane_index, keep_focus): (usize, bool)| {
+        methods.add_method("swap_active_with_id", |_, this, (pane_id, keep_focus): (Value, bool)| {
             let mux = get_mux()?;
             let tab = this.resolve(&mux)?;
 
-            let success = tab.swap_active_with_index(pane_index, keep_focus).is_some();
+            let target_id: PaneId = from_lua(pane_id)?;
 
-            Ok(success)
+            match tab.idx_by_id(target_id) {
+                Some(index) => Ok(tab.swap_active_with_index(index, keep_focus).is_some()),
+                None => Err(mlua::Error::external(format!(
+                    "tab has no pane with ID {} to swap",
+                    target_id
+                )))
+            }
         });
     }
 }

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -751,6 +751,10 @@ impl Tab {
     pub fn get_zoomed_pane(&self) -> Option<Arc<dyn Pane>> {
         self.inner.lock().get_zoomed_pane()
     }
+
+    pub fn idx_by_id(&self, id: PaneId) -> Option<usize> {
+        self.inner.lock().idx_by_id(id)
+    }
 }
 
 impl TabInner {
@@ -2094,6 +2098,12 @@ impl TabInner {
 
     fn get_zoomed_pane(&self) -> Option<Arc<dyn Pane>> {
         self.zoomed.clone()
+    }
+
+    fn idx_by_id(&mut self, id: PaneId) -> Option<usize> {
+        self.iter_panes_ignoring_zoom()
+            .iter()
+            .position(|pane| pane.pane.pane_id() == id)
     }
 }
 


### PR DESCRIPTION
This is related to [this discussion of swapping panes ](https://github.com/wezterm/wezterm/discussions/3331). For an usage example:
```lua
local function swap_panes(dir)
  return wezterm.action_callback(function(win, pane)
    local tab = win:active_tab()
    local target_pane = tab:get_pane_direction(dir)
    if target_pane then
      local panes = tab:panes()
      local target_index = nil
      
      for i, p in ipairs(panes) do
        if p.pane_id == target_pane.pane_id then
          target_index = i - 1
          break
        end
      end
      
      if target_index then
        tab:swap_active_with_index(target_index, true)
      end
    end
  end)
end

config = {
  keys = {
    { key = 'h', mods = 'CTRL|ALT', action = swap_panes("Left") },
    { key = 'j', mods = 'CTRL|ALT', action = swap_panes("Down") },
    { key = 'k', mods = 'CTRL|ALT', action = swap_panes("Up") },
    { key = 'l', mods = 'CTRL|ALT', action = swap_panes("Right") },
  }
}
```