### PR TITLE
Remove `mode` from `PushKittyState` CSI representation

### DIFF
--- a/term/src/terminalstate/performer.rs
+++ b/term/src/terminalstate/performer.rs
@@ -537,17 +537,13 @@ impl<'a> Performer<'a> {
                         .push(KeyboardEncoding::Kitty(flags));
                 }
             }
-            CSI::Keyboard(Keyboard::PushKittyState { flags, mode }) => {
+            CSI::Keyboard(Keyboard::PushKittyState(flags)) => {
                 if self.config.enable_kitty_keyboard() {
                     let current_flags = match self.screen().keyboard_stack.last() {
                         Some(KeyboardEncoding::Kitty(flags)) => *flags,
                         _ => KittyKeyboardFlags::NONE,
                     };
-                    let flags = match mode {
-                        KittyKeyboardMode::AssignAll => flags,
-                        KittyKeyboardMode::SetSpecified => current_flags | flags,
-                        KittyKeyboardMode::ClearSpecified => current_flags - flags,
-                    };
+                    let flags = current_flags | flags;
                     let screen = self.screen_mut();
                     screen.keyboard_stack.push(KeyboardEncoding::Kitty(flags));
                     if screen.keyboard_stack.len() > 128 {

--- a/termwiz/src/escape/csi.rs
+++ b/termwiz/src/escape/csi.rs
@@ -68,10 +68,7 @@ pub enum Keyboard {
         flags: KittyKeyboardFlags,
         mode: KittyKeyboardMode,
     },
-    PushKittyState {
-        flags: KittyKeyboardFlags,
-        mode: KittyKeyboardMode,
-    },
+    PushKittyState(KittyKeyboardFlags),
     PopKittyState(u32),
     QueryKittySupport,
     ReportKittyState(KittyKeyboardFlags),
@@ -126,9 +123,7 @@ impl Display for CSI {
             CSI::Keyboard(Keyboard::SetKittyState { flags, mode }) => {
                 write!(f, "={};{}u", flags.bits(), *mode as u16)?
             }
-            CSI::Keyboard(Keyboard::PushKittyState { flags, mode }) => {
-                write!(f, ">{};{}u", flags.bits(), *mode as u16)?
-            }
+            CSI::Keyboard(Keyboard::PushKittyState(flags)) => write!(f, ">{}u", flags.bits())?,
             CSI::Keyboard(Keyboard::PopKittyState(n)) => write!(f, "<{}u", *n)?,
             CSI::Keyboard(Keyboard::QueryKittySupport) => write!(f, "?u")?,
             CSI::Keyboard(Keyboard::ReportKittyState(flags)) => write!(f, "?{}u", flags.bits())?,
@@ -1789,30 +1784,14 @@ impl<'a> CSIParser<'a> {
                     _ => return Err(()),
                 },
             })),
-            ('u', [CsiParam::P(b'>')]) => Ok(CSI::Keyboard(Keyboard::PushKittyState {
-                flags: KittyKeyboardFlags::NONE,
-                mode: KittyKeyboardMode::AssignAll,
-            })),
+            ('u', [CsiParam::P(b'>')]) => Ok(CSI::Keyboard(Keyboard::PushKittyState(
+                KittyKeyboardFlags::NONE,
+            ))),
             ('u', [CsiParam::P(b'>'), CsiParam::Integer(flags)]) => {
-                Ok(CSI::Keyboard(Keyboard::PushKittyState {
-                    flags: KittyKeyboardFlags::from_bits_truncate(
-                        (*flags).try_into().map_err(|_| ())?,
-                    ),
-                    mode: KittyKeyboardMode::AssignAll,
-                }))
+                Ok(CSI::Keyboard(Keyboard::PushKittyState(
+                    KittyKeyboardFlags::from_bits_truncate((*flags).try_into().map_err(|_| ())?),
+                )))
             }
-            (
-                'u',
-                [CsiParam::P(b'>'), CsiParam::Integer(flags), CsiParam::P(b';'), CsiParam::Integer(mode)],
-            ) => Ok(CSI::Keyboard(Keyboard::PushKittyState {
-                flags: KittyKeyboardFlags::from_bits_truncate((*flags).try_into().map_err(|_| ())?),
-                mode: match *mode {
-                    1 => KittyKeyboardMode::AssignAll,
-                    2 => KittyKeyboardMode::SetSpecified,
-                    3 => KittyKeyboardMode::ClearSpecified,
-                    _ => return Err(()),
-                },
-            })),
             ('u', [CsiParam::P(b'?')]) => Ok(CSI::Keyboard(Keyboard::QueryKittySupport)),
             ('u', [CsiParam::P(b'?'), CsiParam::Integer(flags)]) => {
                 Ok(CSI::Keyboard(Keyboard::ReportKittyState(


### PR DESCRIPTION
The [Kitty Keyboard document] specifies

    CSI = flags ; mode u

in the "Progressive enhancement" section stating that the `mode` (which controls how the flags are set) is optional. It then talks about pushing and popping flags - useful for applications using an alternate screen - with the sequence

    CSI > flags u  # for push, if flags omitted default to zero
    CSI < number u # to pop number entries, defaulting to 1 if unspecified

Termwiz previously also emitted and accepted the `mode` for the "push" command, but I believe it is a mistake. The docs don't explicitly mention the mode here - which you might think is because it is optional - but also the Kitty codebase does not accept a mode:

* [`screen_push_key_encoding_flags`] does not accept a `how` parameter like the definition of `screen_set_key_encoding_flags` above it.
* the Python client used to record and replay commands has a function of the same name which also lacks a `how` parameter: <https://github.com/kovidgoyal/kitty/blob/b0371d970fac15a414ea15fcf25c20269b4b4f65/kitty/client.py#L184-L185>

[Kitty Keyboard document]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
[`screen_push_key_encoding_flags`]: https://github.com/kovidgoyal/kitty/blob/b0371d970fac15a414ea15fcf25c20269b4b4f65/kitty/screen.c#L1692-L1704