### PR TITLE
fix: honor environment variables and cwd unconditionally for SpawnCommand

### DIFF
--- a/wezterm-gui/src/spawn.rs
+++ b/wezterm-gui/src/spawn.rs
@@ -68,8 +68,12 @@ pub async fn spawn_command_internal(
         None
     };
 
-    let cmd_builder = if let Some(args) = spawn.args {
-        let mut builder = CommandBuilder::from_argv(args.iter().map(Into::into).collect());
+    let cmd_builder = {
+        let mut builder = if let Some(args) = spawn.args {
+            CommandBuilder::from_argv(args.iter().map(Into::into).collect())
+        } else {
+            CommandBuilder::new_default_prog()
+        };
         for (k, v) in spawn.set_environment_variables.iter() {
             builder.env(k, v);
         }
@@ -77,8 +81,6 @@ pub async fn spawn_command_internal(
             builder.cwd(cwd);
         }
         Some(builder)
-    } else {
-        None
     };
 
     let workspace = mux.active_workspace().clone();

--- a/wezterm-gui/src/spawn.rs
+++ b/wezterm-gui/src/spawn.rs
@@ -71,9 +71,9 @@ pub async fn spawn_command_internal(
     let cmd_builder = match (
         spawn.args.as_ref(),
         spawn.cwd.as_ref(),
-        !spawn.set_environment_variables.is_empty(),
+        spawn.set_environment_variables.is_empty(),
     ) {
-        (None, None, false) => None,
+        (None, None, true) => None,
         _ => {
             let mut builder = spawn
                 .args


### PR DESCRIPTION
The SpawnCommand specifies information about a new command to be spawned. If the args field is omitted, the default program for the target domain is spawned. However, this also causes other fields like environment variables and cwd to be wiped out.

The command builder now behaves consistently for all fields, whether the args field is set or omitted.

Fixes #6845 