### PR TITLE
Avoid duplication of `index.md` in `SUMMARY.md`

### DIFF
--- a/ci/generate-docs.py
+++ b/ci/generate-docs.py
@@ -508,6 +508,6 @@ with open("../mkdocs.yml", "w") as f:
 
 
 with open("SUMMARY.md", "w") as f:
-    f.write("[root](index.md)\n")
+    f.write("[root]\n")
     for page in TOC:
         page.render(f, depth=1, mode="mdbook")


### PR DESCRIPTION
This fixes the following `mdbook build` error when using `mdbook-0.4.48`: 
```
2025-04-08 11:43:27 [ERROR] (mdbook::utils): Error: Summary parsing failed for file="/tmp/wezterm/docs/./SUMMARY.md"
2025-04-08 11:43:27 [ERROR] (mdbook::utils):    Caused By: Duplicate file in SUMMARY.md: "index.md"
```

Fixes #6858 