### PR TITLE
Make some termwiz dependency optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,7 +5589,6 @@ dependencies = [
  "hex",
  "image",
  "k9",
- "lazy_static",
  "libc",
  "log",
  "memmem",
@@ -6547,7 +6546,6 @@ version = "0.3.0"
 dependencies = [
  "csscolorparser",
  "deltae",
- "lazy_static",
  "serde",
  "wezterm-dynamic",
 ]
@@ -6723,7 +6721,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
  "euclid",
- "lazy_static",
  "serde",
  "wezterm-dynamic",
 ]

--- a/color-types/Cargo.toml
+++ b/color-types/Cargo.toml
@@ -13,6 +13,5 @@ use_serde = ["serde"]
 [dependencies]
 csscolorparser = {workspace=true, features=["lab"]}
 deltae.workspace = true
-lazy_static.workspace = true
 serde = {workspace=true, features = ["derive"], optional=true}
 wezterm-dynamic.workspace = true

--- a/color-types/src/lib.rs
+++ b/color-types/src/lib.rs
@@ -4,14 +4,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
+use std::sync::LazyLock;
 use wezterm_dynamic::{FromDynamic, FromDynamicOptions, ToDynamic, Value};
 
-lazy_static::lazy_static! {
-    static ref SRGB_TO_F32_TABLE: [f32;256] = generate_srgb8_to_linear_f32_table();
-    static ref F32_TO_U8_TABLE: [u32;104] = generate_linear_f32_to_srgb8_table();
-    static ref RGB_TO_SRGB_TABLE: [u8;256] = generate_rgb_to_srgb8_table();
-    static ref RGB_TO_F32_TABLE: [f32;256] = generate_rgb_to_linear_f32_table();
-}
+static SRGB_TO_F32_TABLE: LazyLock<[f32; 256]> = LazyLock::new(generate_srgb8_to_linear_f32_table);
+static F32_TO_U8_TABLE: LazyLock<[u32; 104]> = LazyLock::new(generate_linear_f32_to_srgb8_table);
+static RGB_TO_SRGB_TABLE: LazyLock<[u8; 256]> = LazyLock::new(generate_rgb_to_srgb8_table);
+static RGB_TO_F32_TABLE: LazyLock<[f32; 256]> = LazyLock::new(generate_rgb_to_linear_f32_table);
 
 fn generate_rgb_to_srgb8_table() -> [u8; 256] {
     let mut table = [0; 256];
@@ -330,9 +329,7 @@ impl From<Color> for SrgbaTuple {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref NAMED_COLORS: HashMap<String, SrgbaTuple> = build_colors();
-}
+static NAMED_COLORS: LazyLock<HashMap<String, SrgbaTuple>> = LazyLock::new(build_colors);
 
 fn build_colors() -> HashMap<String, SrgbaTuple> {
     let mut map = HashMap::new();

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -22,7 +22,6 @@ fixedbitset.workspace = true
 fnv = {workspace=true, optional=true}
 hex.workspace = true
 image = {workspace=true, optional=true}
-lazy_static.workspace = true
 libc.workspace = true
 log.workspace = true
 memmem.workspace = true

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -33,7 +33,7 @@ pest.workspace = true
 pest_derive.workspace = true
 phf.workspace = true
 serde = {workspace=true, features = ["rc", "derive"], optional=true}
-sha2.workspace = true
+sha2 = {workspace=true, optional=true}
 siphasher.workspace = true
 terminfo.workspace = true
 thiserror.workspace = true
@@ -41,16 +41,18 @@ ucd-trie.workspace = true
 unicode-segmentation.workspace = true
 vtparse.workspace = true
 wezterm-bidi.workspace = true
-wezterm-blob-leases.workspace = true
+wezterm-blob-leases = {workspace=true, optional=true}
 wezterm-color-types.workspace = true
 wezterm-dynamic.workspace = true
 wezterm-input-types.workspace = true
 
 [features]
+default = ["image"]
 widgets = ["cassowary", "fnv"]
 use_serde = ["serde", "wezterm-color-types/use_serde", "wezterm-blob-leases/serde", "bitflags/serde", "wezterm-input-types/serde"]
-use_image = ["image"]
-docs = ["widgets", "use_serde"]
+use_image = ["image", "dep:image"]
+image = ["sha2", "wezterm-blob-leases"]
+docs = ["widgets", "use_serde", "image"]
 
 [dev-dependencies]
 criterion.workspace = true

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -29,8 +29,8 @@ memmem.workspace = true
 num-derive.workspace = true
 num-traits.workspace = true
 ordered-float.workspace = true
-pest.workspace = true
-pest_derive.workspace = true
+pest = {workspace=true, optional=true}
+pest_derive = {workspace=true, optional=true}
 phf.workspace = true
 serde = {workspace=true, features = ["rc", "derive"], optional=true}
 sha2 = {workspace=true, optional=true}
@@ -47,12 +47,13 @@ wezterm-dynamic.workspace = true
 wezterm-input-types.workspace = true
 
 [features]
-default = ["image"]
+default = ["image", "tmux_cc"]
 widgets = ["cassowary", "fnv"]
 use_serde = ["serde", "wezterm-color-types/use_serde", "wezterm-blob-leases/serde", "bitflags/serde", "wezterm-input-types/serde"]
 use_image = ["image", "dep:image"]
 image = ["sha2", "wezterm-blob-leases"]
-docs = ["widgets", "use_serde", "image"]
+tmux_cc = ["pest", "pest_derive"]
+docs = ["widgets", "use_serde", "image", "tmux_cc"]
 
 [dev-dependencies]
 criterion.workspace = true

--- a/termwiz/src/error.rs
+++ b/termwiz/src/error.rs
@@ -72,6 +72,7 @@ pub enum InternalError {
     #[error(transparent)]
     FileDescriptor(#[from] filedescriptor::Error),
 
+    #[cfg(feature = "image")]
     #[error(transparent)]
     BlobLease(#[from] wezterm_blob_leases::Error),
 

--- a/termwiz/src/escape/mod.rs
+++ b/termwiz/src/escape/mod.rs
@@ -6,6 +6,7 @@
 //! semantic meaning to them.  It can also encode the semantic values as
 //! escape sequences.  It provides encoding and decoding functionality
 //! only; it does not provide terminal emulation facilities itself.
+#[cfg(feature = "tmux_cc")]
 use crate::tmux_cc::Event;
 use num_derive::*;
 use std::fmt::{Display, Error as FmtError, Formatter, Write as FmtWrite};
@@ -219,6 +220,7 @@ pub enum DeviceControlMode {
     /// A self contained (Enter, Data*, Exit) sequence
     ShortDeviceControl(Box<ShortDeviceControl>),
     /// Tmux parsed events
+    #[cfg(feature = "tmux_cc")]
     TmuxEvents(Box<Vec<Event>>),
 }
 
@@ -243,6 +245,7 @@ impl Display for DeviceControlMode {
             Self::Exit => Ok(()),
             Self::Data(c) => f.write_char(*c as char),
             Self::ShortDeviceControl(s) => s.fmt(f),
+            #[cfg(feature = "tmux_cc")]
             Self::TmuxEvents(_) => write!(f, "tmux event"),
         }
     }
@@ -255,6 +258,7 @@ impl std::fmt::Debug for DeviceControlMode {
             Self::Exit => write!(fmt, "Exit"),
             Self::Data(b) => write!(fmt, "Data({:?} 0x{:x})", *b as char, *b),
             Self::ShortDeviceControl(s) => write!(fmt, "ShortDeviceControl({:?})", s),
+            #[cfg(feature = "tmux_cc")]
             Self::TmuxEvents(_) => write!(fmt, "tmux event"),
         }
     }

--- a/termwiz/src/escape/osc.rs
+++ b/termwiz/src/escape/osc.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Error as FmtError, Formatter, Result as FmtResult};
 use std::str;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ColorOrQuery {
@@ -483,9 +484,7 @@ struct OscMap {
     variant_to_code: HashMap<OperatingSystemCommandCode, &'static str>,
 }
 
-lazy_static::lazy_static! {
-    static ref OSC_MAP: OscMap = OscMap::new();
-}
+static OSC_MAP: LazyLock<OscMap> = LazyLock::new(OscMap::new);
 
 impl OperatingSystemCommandCode {
     fn from_code(code: &str) -> Option<Self> {

--- a/termwiz/src/escape/parser/mod.rs
+++ b/termwiz/src/escape/parser/mod.rs
@@ -3,9 +3,11 @@ use crate::escape::{
     Action, DeviceControlMode, EnterDeviceControlMode, Esc, OperatingSystemCommand,
     ShortDeviceControl, CSI,
 };
+#[cfg(feature = "tmux_cc")]
 use crate::tmux_cc::Event;
 use log::error;
 use num_traits::FromPrimitive;
+#[cfg(feature = "tmux_cc")]
 use std::borrow::BorrowMut;
 use std::cell::RefCell;
 use vtparse::{CsiParam, VTActor, VTParser};
@@ -47,6 +49,7 @@ struct ParseState {
     sixel: Option<SixelBuilder>,
     dcs: Option<ShortDeviceControl>,
     get_tcap: Option<GetTcapBuilder>,
+    #[cfg(feature = "tmux_cc")]
     tmux_state: Option<RefCell<crate::tmux_cc::Parser>>,
 }
 
@@ -76,6 +79,7 @@ impl Parser {
     }
 
     /// advance with tmux parser, bypass VTParse
+    #[cfg(feature = "tmux_cc")]
     fn advance_tmux_bytes(&mut self, bytes: &[u8]) -> anyhow::Result<Vec<Event>> {
         let parser_state = self.state.borrow();
         let tmux_state = parser_state.tmux_state.as_ref().unwrap();
@@ -84,7 +88,9 @@ impl Parser {
     }
 
     pub fn parse<F: FnMut(Action)>(&mut self, bytes: &[u8], mut callback: F) {
+        #[cfg(feature = "tmux_cc")]
         let is_tmux_mode: bool = self.state.borrow().tmux_state.is_some();
+        #[cfg(feature = "tmux_cc")]
         if is_tmux_mode {
             match self.advance_tmux_bytes(bytes) {
                 Ok(tmux_events) => {
@@ -105,13 +111,14 @@ impl Parser {
                         .parse(unparsed_str.as_bytes(), &mut perform);
                 }
             }
-        } else {
-            let mut perform = Performer {
-                callback: &mut callback,
-                state: &mut self.state.borrow_mut(),
-            };
-            self.state_machine.parse(bytes, &mut perform);
+            return;
         }
+
+        let mut perform = Performer {
+            callback: &mut callback,
+            state: &mut self.state.borrow_mut(),
+        };
+        self.state_machine.parse(bytes, &mut perform);
     }
 
     /// A specialized version of the parser that halts after recognizing the
@@ -243,6 +250,7 @@ impl<'a, F: FnMut(Action)> VTActor for Performer<'a, F> {
                 data: vec![],
             });
         } else {
+            #[cfg(feature = "tmux_cc")]
             if byte == b'p' && params == [1000] {
                 // into tmux_cc mode
                 self.state.borrow_mut().tmux_state =
@@ -267,6 +275,7 @@ impl<'a, F: FnMut(Action)> VTActor for Performer<'a, F> {
         } else if let Some(tcap) = self.state.get_tcap.as_mut() {
             tcap.push(data);
         } else {
+            #[cfg(feature = "tmux_cc")]
             if let Some(tmux_state) = &self.state.tmux_state {
                 let mut tmux_parser = tmux_state.borrow_mut();
                 match tmux_parser.advance_byte(data) {
@@ -282,9 +291,9 @@ impl<'a, F: FnMut(Action)> VTActor for Performer<'a, F> {
                         self.state.tmux_state = None; // drop tmux state
                     }
                 }
-            } else {
-                (self.callback)(Action::DeviceControl(DeviceControlMode::Data(data)));
+                return;
             }
+            (self.callback)(Action::DeviceControl(DeviceControlMode::Data(data)));
         }
     }
 

--- a/termwiz/src/lib.rs
+++ b/termwiz/src/lib.rs
@@ -66,6 +66,7 @@ mod readbuf;
 pub mod render;
 pub mod surface;
 pub mod terminal;
+#[cfg(feature = "tmux_cc")]
 pub mod tmux_cc;
 #[cfg(feature = "widgets")]
 pub mod widgets;

--- a/termwiz/src/lib.rs
+++ b/termwiz/src/lib.rs
@@ -53,6 +53,7 @@ pub mod color;
 pub mod error;
 pub mod escape;
 pub mod hyperlink;
+#[cfg(feature = "image")]
 pub mod image;
 pub mod input;
 pub mod istty;

--- a/termwiz/src/nerdfonts.rs
+++ b/termwiz/src/nerdfonts.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
-lazy_static::lazy_static! {
-    pub static ref NERD_FONTS: HashMap<&'static str, char> = build_map();
-}
+pub static NERD_FONTS: LazyLock<HashMap<&'static str, char>> = LazyLock::new(build_map);
 
 pub use crate::nerdfonts_data::NERD_FONT_GLYPHS;
 

--- a/termwiz/src/render/terminfo.rs
+++ b/termwiz/src/render/terminfo.rs
@@ -4,8 +4,11 @@ use crate::cell::{AttributeChange, Blink, CellAttributes, Intensity, Underline};
 use crate::color::{ColorAttribute, ColorSpec};
 use crate::escape::csi::{Cursor, Edit, EraseInDisplay, EraseInLine, Sgr, CSI};
 use crate::escape::esc::EscCode;
-use crate::escape::osc::{ITermDimension, ITermFileData, ITermProprietary, OperatingSystemCommand};
+use crate::escape::osc::OperatingSystemCommand;
+#[cfg(feature = "image")]
+use crate::escape::osc::{ITermDimension, ITermFileData, ITermProprietary};
 use crate::escape::{Esc, OneBased};
+#[cfg(feature = "image")]
 use crate::image::{ImageDataType, TextureCoordinate};
 use crate::render::RenderTty;
 use crate::surface::{Change, CursorShape, CursorVisibility, LineAttribute, Position};
@@ -580,6 +583,7 @@ impl TerminfoRenderer {
                         }
                     }
                 },
+                #[cfg(feature = "image")]
                 Change::Image(image) => {
                     if self.caps.iterm2_image() {
                         let data = if image.top_left == TextureCoordinate::new_f32(0.0, 0.0)

--- a/termwiz/src/surface/change.rs
+++ b/termwiz/src/surface/change.rs
@@ -1,10 +1,12 @@
 use crate::cell::{unicode_column_width, AttributeChange, CellAttributes};
 use crate::color::ColorAttribute;
+#[cfg(feature = "image")]
 pub use crate::image::{ImageData, TextureCoordinate};
 use crate::surface::{CursorShape, CursorVisibility, Position};
 use finl_unicode::grapheme_clusters::Graphemes;
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "image")]
 use std::sync::Arc;
 
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
@@ -63,6 +65,7 @@ pub enum Change {
     /// of the screen, the screen will scroll up.
     /// The cursor Y position is unchanged by rendering the Image.
     /// The cursor X position will be incremented by `Image::width` cells.
+    #[cfg(feature = "image")]
     Image(Image),
     /// Scroll the `region_size` lines starting at `first_row` upwards
     /// by `scroll_count` lines.  The `scroll_count` lines at the top of
@@ -228,6 +231,7 @@ impl ChangeSequence {
                 }
                 self.update_render_height();
             }
+            #[cfg(feature = "image")]
             Change::Image(im) => {
                 self.cursor_x += im.width;
                 self.render_y_max = self.render_y_max.max(self.cursor_y + im.height as isize);
@@ -280,6 +284,7 @@ impl ChangeSequence {
 /// The top left cell from that image, if it were to be included in a diff,
 /// would be recorded as `width=1`, `height=1`, `top_left=(0,0)`, `bottom_right=(1/4,1/3)`.
 #[cfg_attr(feature = "use_serde", derive(Serialize, Deserialize))]
+#[cfg(feature = "image")]
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Image {
     /// measured in cells

--- a/termwiz/src/surface/line/vecstorage.rs
+++ b/termwiz/src/surface/line/vecstorage.rs
@@ -16,7 +16,9 @@ impl VecStorage {
         Self { cells }
     }
 
+    #[cfg_attr(not(feature = "image"), allow(unused_mut, unused_variables))]
     pub(crate) fn set_cell(&mut self, idx: usize, mut cell: Cell, clear_image_placement: bool) {
+        #[cfg(feature = "image")]
         if !clear_image_placement {
             if let Some(images) = self.cells[idx].attrs().images() {
                 for image in images {

--- a/termwiz/src/surface/mod.rs
+++ b/termwiz/src/surface/mod.rs
@@ -1,9 +1,9 @@
 use crate::cell::{Cell, CellAttributes};
 use crate::color::ColorAttribute;
+#[cfg(feature = "image")]
 use crate::image::ImageCell;
 use crate::surface::line::CellRef;
 use finl_unicode::grapheme_clusters::Graphemes;
-use ordered_float::NotNan;
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
@@ -13,7 +13,9 @@ use wezterm_dynamic::{FromDynamic, ToDynamic};
 pub mod change;
 pub mod line;
 
-pub use self::change::{Change, Image, LineAttribute, TextureCoordinate};
+pub use self::change::{Change, LineAttribute};
+#[cfg(feature = "image")]
+pub use self::change::{Image, TextureCoordinate};
 pub use self::line::Line;
 
 /// Position holds 0-based positioning information, where
@@ -297,6 +299,7 @@ impl Surface {
             Change::CursorColor(color) => self.cursor_color = *color,
             Change::CursorShape(shape) => self.cursor_shape = Some(*shape),
             Change::CursorVisibility(visibility) => self.cursor_visibility = *visibility,
+            #[cfg(feature = "image")]
             Change::Image(image) => self.add_image(image),
             Change::Title(text) => self.title = text.to_owned(),
             Change::ScrollRegionUp {
@@ -313,7 +316,10 @@ impl Surface {
         }
     }
 
+    #[cfg(feature = "image")]
     fn add_image(&mut self, image: &Image) {
+        use ordered_float::NotNan;
+
         let xsize = (image.bottom_right.x - image.top_left.x) / image.width as f32;
         let ysize = (image.bottom_right.y - image.top_left.y) / image.height as f32;
 

--- a/wezterm-input-types/Cargo.toml
+++ b/wezterm-input-types/Cargo.toml
@@ -12,7 +12,6 @@ license = "MIT"
 [dependencies]
 bitflags.workspace = true
 euclid.workspace = true
-lazy_static.workspace = true
 serde = {workspace=true, features = ["rc", "derive"], optional=true}
 wezterm-dynamic.workspace = true
 

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Write;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use wezterm_dynamic::{FromDynamic, ToDynamic};
 
 pub struct PixelUnit;
@@ -1141,10 +1141,10 @@ impl PhysKeyCode {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref PHYSKEYCODE_MAP: HashMap<String, PhysKeyCode> = PhysKeyCode::make_map();
-    static ref INV_PHYSKEYCODE_MAP: HashMap<PhysKeyCode, String> = PhysKeyCode::make_inv_map();
-}
+static PHYSKEYCODE_MAP: LazyLock<HashMap<String, PhysKeyCode>> =
+    LazyLock::new(PhysKeyCode::make_map);
+static INV_PHYSKEYCODE_MAP: LazyLock<HashMap<PhysKeyCode, String>> =
+    LazyLock::new(PhysKeyCode::make_inv_map);
 
 impl TryFrom<&str> for PhysKeyCode {
     type Error = String;


### PR DESCRIPTION
Makes some `termwiz` dependencies optional so it's lighter weight for users.

Context: https://discord.com/channels/968932220549103686/1358968929414021190