### PR TITLE
Introduce `win32_window_appearance` to override Windows setting

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -19,6 +19,7 @@ use crate::ssh::{SshBackend, SshDomain};
 use crate::tls::{TlsDomainClient, TlsDomainServer};
 use crate::units::Dimension;
 use crate::unix::UnixDomain;
+use crate::window::Win32WindowAppearance;
 use crate::wsl::WslDomain;
 use crate::{
     default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
@@ -580,6 +581,10 @@ pub struct Config {
     /// Only works on Wayland compositors that support ext-background-effect-v1 protocol
     #[dynamic(default)]
     pub wayland_window_background_blur: bool,
+
+    /// Explicitly sets the window appearance on Windows
+    #[dynamic(default)]
+    pub win32_window_appearance: Win32WindowAppearance,
 
     /// Only works on Windows
     #[dynamic(default)]

--- a/config/src/window.rs
+++ b/config/src/window.rs
@@ -7,3 +7,11 @@ pub enum WindowLevel {
     Normal = 0,
     AlwaysOnTop = 3,
 }
+
+#[derive(Debug, Default, Clone, ToDynamic, PartialEq, Eq, FromDynamic)]
+pub enum Win32WindowAppearance {
+    #[default]
+    System,
+    Light,
+    Dark,
+}

--- a/docs/config/lua/config/win32_acrylic_accent_color.md
+++ b/docs/config/lua/config/win32_acrylic_accent_color.md
@@ -11,4 +11,5 @@ When combined with `win32_system_backdrop = "Acrylic"` on Windows systems
 earlier than build 22621, this option specifies the accent color used with
 the *Acrylic* composition effect.
 
-See also [win32_system_backdrop](win32_system_backdrop.md).
+See also [win32_system_backdrop](win32_system_backdrop.md) and [win32_window_appearance](win32_window_appearance.md).
+

--- a/docs/config/lua/config/win32_system_backdrop.md
+++ b/docs/config/lua/config/win32_system_backdrop.md
@@ -35,6 +35,8 @@ a similar effect on macOS.
 See also [wayland_window_background_blur](wayland_window_background_blur.md) for a similar
 effect on Linux Wayland.
 
+See [win32_window_appearance](win32_window_appearance.md) how to override the app appearance set in Windows.
+
 ## Acrylic
 
 ```lua

--- a/docs/config/lua/config/win32_window_appearance.md
+++ b/docs/config/lua/config/win32_window_appearance.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - appearance
+---
+
+# `win32_window_appearance = SETTING`
+
+{{since('nightly')}}
+
+On Windows, you can set dark or light appearance. This makes both, Windows and apps, dark or light. You can also select different appearance for Windows and apps if they prefer for example dark Windows and light apps.
+
+By default, WezTerm follows the app appearance setting configured in Windows.
+
+This setting allows to override it from the configuration.
+
+The possible values for `win32_window_appearance` are:
+
+* `"System"` - follow app appearance set in Windows settings (default)
+* `"Light"` - use the light appearance
+* `"Dark"` - use the dark appearance
+
+Now, for example, all your other apps can be light while WezTerm will appear dark.
+
+Combined with [win32_system_backdrop](win32_system_backdrop.md), WezTerm will use dark *Mica* or *Tabbed* variant.

--- a/window/src/os/windows/connection.rs
+++ b/window/src/os/windows/connection.rs
@@ -5,7 +5,8 @@ use crate::screen::{ScreenInfo, Screens};
 use crate::spawn::*;
 use crate::{Appearance, ScreenRect};
 use anyhow::Context;
-use config::ConfigHandle;
+use config::window::Win32WindowAppearance;
+use config::{configuration, ConfigHandle};
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::ffi::OsString;
@@ -38,6 +39,11 @@ pub struct Connection {
 }
 
 pub(crate) fn get_appearance() -> Appearance {
+    match configuration().win32_window_appearance {
+        Win32WindowAppearance::Dark => return Appearance::Dark,
+        Win32WindowAppearance::Light => return Appearance::Light,
+        Win32WindowAppearance::System => (),
+    };
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     match hkcu.open_subkey("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize") {
         Ok(theme) => {


### PR DESCRIPTION
When you set a custom appearance in Windows you can select dark Windows appearance and light app appearance.

![image](https://github.com/user-attachments/assets/3050aace-7e80-4ee3-aa4a-fe924e8ae76e)

But even though you may like your we pages to display in black on white, you may not like WezTerm to appear light.

![image](https://github.com/user-attachments/assets/8563ba06-0b5e-47d9-8131-3fd5bcca6091)

When set to `'Dark'`, the new `win32_window_appearance` setting allows to remedy just that.

![image](https://github.com/user-attachments/assets/97b52e09-2bf9-4539-9728-2e4ad0e5df3d)

There's also #6521 providing the same functionality on MacOS.

Closes #5873. Closes #6767. 
