### PR TITLE
Fix build fails when the target dir doesn't exist

### DIFF
--- a/wezterm-gui/build.rs
+++ b/wezterm-gui/build.rs
@@ -11,7 +11,9 @@ fn main() {
             .ok()
             .and_then(|cwd| cwd.parent().map(|p| p.to_path_buf()))
             .unwrap();
-        let exe_output_dir = repo_dir.join("target").join(profile);
+        let exe_output_dir = std::env::var("CARGO_TARGET_DIR")
+            .and_then(|s| Ok(std::path::PathBuf::from(s)))
+            .unwrap_or(repo_dir.join("target").join(profile));
         let windows_dir = repo_dir.join("assets").join("windows");
 
         let conhost_dir = windows_dir.join("conhost");


### PR DESCRIPTION
 at the default location on Windows

Wezterm copies some OpenConsole.exe etc files there during build, but if you use custom build dir the build aborts since the copy operation fails

So this PR reads `CARGO_TARGET_DIR` env var first, and then uses that env var dir to copy the files to