### PR TITLE
symlink judiciously to make LaunchServices happy

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -144,7 +144,11 @@
               cp -r assets/macos/WezTerm.app "$OUT_APP"
               rm $OUT_APP/*.dylib
               cp -r assets/shell-integration/* "$OUT_APP"
-              ln -s $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP"
+              # macOS will only recognize our application bundle
+              # if the binaries are inside of it. Move them there
+              # and create symbolic links for them in bin/.
+              mv $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP"
+              ln -s "$OUT_APP"/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$out/bin"
             '';
 
           postInstall = ''


### PR DESCRIPTION
Fixes #6731.

Now that WezTerm uses UNUserNotificationCenter, it needs to have a proper app bundle. Rather than symlinking from `WezTerm.app/` to `bin/`, do it the other way around.