### PR TITLE
feat(mark-last-tab): append last tab name with '*'

### DIFF
--- a/docs/config/lua/TabInformation.md
+++ b/docs/config/lua/TabInformation.md
@@ -10,6 +10,7 @@ The `TabInformation` struct contains the following fields:
 * `tab_id` - the identifier for the tab
 * `tab_index` - the logical tab position within its containing window, with 0 indicating the leftmost tab
 * `is_active` - is true if this tab is the active tab
+* `is_last` - is true if this tab is the previous active tab - last tab.
 * `active_pane` - the [PaneInformation](PaneInformation.md) for the active pane in this tab
 * `window_id` - the ID of the window that contains this tab {{since('20220807-113146-c2fee766', inline=True)}}
 * `window_title` - the title of the window that contains this tab {{since('20220807-113146-c2fee766', inline=True)}}

--- a/docs/config/lua/TabInformation.md
+++ b/docs/config/lua/TabInformation.md
@@ -10,7 +10,7 @@ The `TabInformation` struct contains the following fields:
 * `tab_id` - the identifier for the tab
 * `tab_index` - the logical tab position within its containing window, with 0 indicating the leftmost tab
 * `is_active` - is true if this tab is the active tab
-* `is_last` - is true if this tab is the previous active tab - last tab.
+* `is_last_active` - is true if this tab is the previously active tab. {{since('nightly', inline=True)}}
 * `active_pane` - the [PaneInformation](PaneInformation.md) for the active pane in this tab
 * `window_id` - the ID of the window that contains this tab {{since('20220807-113146-c2fee766', inline=True)}}
 * `window_title` - the title of the window that contains this tab {{since('20220807-113146-c2fee766', inline=True)}}

--- a/docs/config/lua/window-events/format-tab-title.md
+++ b/docs/config/lua/window-events/format-tab-title.md
@@ -46,8 +46,8 @@ wezterm.on(
         { Text = ' ' .. title .. ' ' },
       }
     end
-    if tab.is_last then
-      -- Green color and append '*' to last tab.
+    if tab.is_last_active then
+      -- Green color and append '*' to previously active tab.
       return {
         { Background = { Color = 'green' } },
         { Text = ' ' .. title .. '*' },

--- a/docs/config/lua/window-events/format-tab-title.md
+++ b/docs/config/lua/window-events/format-tab-title.md
@@ -46,6 +46,13 @@ wezterm.on(
         { Text = ' ' .. title .. ' ' },
       }
     end
+    if tab.is_last then
+      -- Green color and append '*' to last tab.
+      return {
+        { Background = { Color = 'green' } },
+        { Text = ' ' .. title .. '*' },
+      }
+    end
     return title
   end
 )

--- a/mux/src/window.rs
+++ b/mux/src/window.rs
@@ -176,23 +176,7 @@ impl Window {
     }
 
     pub fn save_last_active(&mut self) {
-        const LAST_TAB_MARK: char = '*';
-        if let Some(idx) = self.get_last_active_idx() {
-            self.get_by_idx(idx).map(|tab| {
-                let mut rename = tab.get_title();
-                if rename.ends_with(LAST_TAB_MARK) {
-                    rename.pop();
-                    tab.set_title(&rename)
-                }
-            });
-        }
-
-        self.last_active = self.get_by_idx(self.active).map(|tab| {
-            let mut rename = tab.get_title();
-            rename.push(LAST_TAB_MARK);
-            tab.set_title(&rename);
-            tab.tab_id()
-        });
+        self.last_active = self.get_by_idx(self.active).map(|tab| tab.tab_id());
     }
 
     #[inline]

--- a/mux/src/window.rs
+++ b/mux/src/window.rs
@@ -176,7 +176,23 @@ impl Window {
     }
 
     pub fn save_last_active(&mut self) {
-        self.last_active = self.get_by_idx(self.active).map(|tab| tab.tab_id());
+        const LAST_TAB_MARK: char = '*';
+        if let Some(idx) = self.get_last_active_idx() {
+            self.get_by_idx(idx).map(|tab| {
+                let mut rename = tab.get_title();
+                if rename.ends_with(LAST_TAB_MARK) {
+                    rename.pop();
+                    tab.set_title(&rename)
+                }
+            });
+        }
+
+        self.last_active = self.get_by_idx(self.active).map(|tab| {
+            let mut rename = tab.get_title();
+            rename.push(LAST_TAB_MARK);
+            tab.set_title(&rename);
+            tab.tab_id()
+        });
     }
 
     #[inline]

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -212,7 +212,7 @@ pub struct TabInformation {
     pub tab_id: TabId,
     pub tab_index: usize,
     pub is_active: bool,
-    pub is_last: bool,
+    pub is_last_active: bool,
     pub active_pane: Option<PaneInformation>,
     pub window_id: MuxWindowId,
     pub tab_title: String,
@@ -223,7 +223,7 @@ impl UserData for TabInformation {
         fields.add_field_method_get("tab_id", |_, this| Ok(this.tab_id));
         fields.add_field_method_get("tab_index", |_, this| Ok(this.tab_index));
         fields.add_field_method_get("is_active", |_, this| Ok(this.is_active));
-        fields.add_field_method_get("is_last", |_, this| Ok(this.is_last));
+        fields.add_field_method_get("is_last_active", |_, this| Ok(this.is_last_active));
         fields.add_field_method_get("active_pane", |_, this| {
             if let Some(pane) = &this.active_pane {
                 Ok(Some(pane.clone()))
@@ -3462,7 +3462,10 @@ impl TermWindow {
                     tab_index: idx,
                     tab_id: tab.tab_id(),
                     is_active: tab_index == idx,
-                    is_last: window.get_last_active_idx().map(|last| last == idx).unwrap_or(false),
+                    is_last_active: window
+                        .get_last_active_idx()
+                        .map(|last_active| last_active == idx)
+                        .unwrap_or(false),
                     window_id: self.mux_window_id,
                     tab_title: tab.get_title(),
                     active_pane: panes

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -212,6 +212,7 @@ pub struct TabInformation {
     pub tab_id: TabId,
     pub tab_index: usize,
     pub is_active: bool,
+    pub is_last: bool,
     pub active_pane: Option<PaneInformation>,
     pub window_id: MuxWindowId,
     pub tab_title: String,
@@ -222,6 +223,7 @@ impl UserData for TabInformation {
         fields.add_field_method_get("tab_id", |_, this| Ok(this.tab_id));
         fields.add_field_method_get("tab_index", |_, this| Ok(this.tab_index));
         fields.add_field_method_get("is_active", |_, this| Ok(this.is_active));
+        fields.add_field_method_get("is_last", |_, this| Ok(this.is_last));
         fields.add_field_method_get("active_pane", |_, this| {
             if let Some(pane) = &this.active_pane {
                 Ok(Some(pane.clone()))
@@ -3460,6 +3462,11 @@ impl TermWindow {
                     tab_index: idx,
                     tab_id: tab.tab_id(),
                     is_active: tab_index == idx,
+                    is_last: if let Some(tab_index_last) = window.get_last_active_idx() {
+                        tab_index_last == idx
+                    } else {
+                        false
+                    },
                     window_id: self.mux_window_id,
                     tab_title: tab.get_title(),
                     active_pane: panes

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3462,11 +3462,7 @@ impl TermWindow {
                     tab_index: idx,
                     tab_id: tab.tab_id(),
                     is_active: tab_index == idx,
-                    is_last: if let Some(tab_index_last) = window.get_last_active_idx() {
-                        tab_index_last == idx
-                    } else {
-                        false
-                    },
+                    is_last: window.get_last_active_idx().map(|last| last == idx).unwrap_or(false),
                     window_id: self.mux_window_id,
                     tab_title: tab.get_title(),
                     active_pane: panes


### PR DESCRIPTION
I think there should be a better method instead of make the save function so crowded. But this works for now similar to `tmux` windows. But, `tmux` is using '\*' for current and '-' for last Hardcoded '\*'