### PR TITLE
docs: fix title of get_progress() page

### DIFF
--- a/docs/config/lua/pane/get_progress.md
+++ b/docs/config/lua/pane/get_progress.md
@@ -1,4 +1,4 @@
-# `pane:get_title()`
+# `pane:get_progress()`
 
 {{since('nightly')}}
 


### PR DESCRIPTION
Quick change to make the heading of the [`pane:get_progress()`](https://wezterm.org/config/lua/pane/get_progress.html) doc page match the actual method name.