### PR TITLE
feat: Added support for window blur on KDE Wayland

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6456,6 +6456,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-protocols-plasma"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccaacc76703fefd6763022ac565b590fcade92202492381c95b2edfdf7d46b3"
+dependencies = [
+ "bitflags 2.9.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
 name = "wayland-protocols-wlr"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7167,6 +7180,7 @@ dependencies = [
  "wayland-client",
  "wayland-egl",
  "wayland-protocols",
+ "wayland-protocols-plasma",
  "wezterm-bidi",
  "wezterm-color-types",
  "wezterm-font",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ wayland-backend = "0.3.5"
 wayland-client = "0.31"
 wayland-egl = "0.32"
 wayland-protocols = "0.32"
+wayland-protocols-plasma = { version="0.3.6", features=["client"] }
 wezterm-bidi = { version="0.2.3", path = "bidi" }
 wezterm-blob-leases = { version="0.1.1", path = "wezterm-blob-leases"}
 wezterm-client = { path = "wezterm-client" }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -21,11 +21,11 @@ use crate::units::Dimension;
 use crate::unix::UnixDomain;
 use crate::wsl::WslDomain;
 use crate::{
-    default_config_with_overrides_applied, default_one_point_oh, default_one_point_oh_f64,
-    default_true, default_win32_acrylic_accent_color, GpuInfo, IntegratedTitleButtonColor,
-    KeyMapPreference, LoadedConfig, MouseEventTriggerMods, RgbaColor, SerialDomain, SystemBackdrop,
-    WebGpuPowerPreference, CONFIG_DIRS, CONFIG_FILE_OVERRIDE, CONFIG_OVERRIDES, CONFIG_SKIP,
-    HOME_DIR,
+    default_config_with_overrides_applied, default_false, default_one_point_oh,
+    default_one_point_oh_f64, default_true, default_win32_acrylic_accent_color, GpuInfo,
+    IntegratedTitleButtonColor, KeyMapPreference, LoadedConfig, MouseEventTriggerMods, RgbaColor,
+    SerialDomain, SystemBackdrop, WebGpuPowerPreference, CONFIG_DIRS, CONFIG_FILE_OVERRIDE,
+    CONFIG_OVERRIDES, CONFIG_SKIP, HOME_DIR,
 };
 use anyhow::Context;
 use luahelper::impl_lua_conversion_dynamic;
@@ -563,6 +563,10 @@ pub struct Config {
     /// Only works on MacOS
     #[dynamic(default)]
     pub macos_window_background_blur: i64,
+
+    /// Only works on MacOS
+    #[dynamic(default = "default_false")]
+    pub kde_window_background_blur: bool,
 
     /// Only works on Windows
     #[dynamic(default)]

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -821,3 +821,7 @@ fn default_one_point_oh() -> f32 {
 fn default_true() -> bool {
     true
 }
+
+fn default_false() -> bool {
+    false
+}

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -15,7 +15,7 @@ k9.workspace = true
 gl_generator.workspace = true
 
 [features]
-wayland = ["wayland-client", "smithay-client-toolkit", "wayland-egl", "wayland-protocols", "wayland-backend"]
+wayland = ["wayland-client", "smithay-client-toolkit", "wayland-egl", "wayland-protocols", "wayland-backend", "wayland-protocols-plasma"]
 
 [dependencies]
 async-channel.workspace = true
@@ -84,6 +84,7 @@ zvariant.workspace = true
 smithay-client-toolkit = {workspace=true, default-features=false, optional=true}
 wayland-backend = {workspace=true, features=["client_system", "rwh_06"], optional=true}
 wayland-protocols = {workspace=true, optional=true}
+wayland-protocols-plasma = {workspace=true, optional=true}
 wayland-client = {workspace=true, optional=true}
 wayland-egl = {workspace=true, optional=true}
 

--- a/window/src/os/wayland/state.rs
+++ b/window/src/os/wayland/state.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use libc::bind;
 use smithay_client_toolkit::compositor::{CompositorState, SurfaceData};
 use smithay_client_toolkit::data_device_manager::data_device::DataDevice;
 use smithay_client_toolkit::data_device_manager::data_source::CopyPasteSource;
@@ -26,12 +27,13 @@ use smithay_client_toolkit::{
     delegate_compositor, delegate_data_device, delegate_output, delegate_pointer, delegate_primary_selection, delegate_registry, delegate_seat, delegate_shm, delegate_subcompositor, delegate_xdg_shell, delegate_xdg_window, registry_handlers
 };
 use wayland_client::backend::ObjectId;
-use wayland_client::globals::GlobalList;
+use wayland_client::globals::{BindError, GlobalList};
 use wayland_client::protocol::wl_keyboard::WlKeyboard;
 use wayland_client::protocol::wl_output::WlOutput;
 use wayland_client::{delegate_dispatch, Connection, QueueHandle};
 use wayland_protocols::wp::text_input::zv3::client::zwp_text_input_manager_v3::ZwpTextInputManagerV3;
 use wayland_protocols::wp::text_input::zv3::client::zwp_text_input_v3::ZwpTextInputV3;
+use wayland_protocols_plasma::blur::client::org_kde_kwin_blur_manager::OrgKdeKwinBlurManager;
 
 use crate::x11::KeyboardWithFallback;
 
@@ -71,6 +73,7 @@ pub(super) struct WaylandState {
     pub(super) primary_selection_source: Option<(PrimarySelectionSource, String)>,
     pub(super) shm: Shm,
     pub(super) mem_pool: RefCell<SlotPool>,
+    pub(super) kde_blur_manager: Option<OrgKdeKwinBlurManager>,
 }
 
 impl WaylandState {
@@ -81,6 +84,14 @@ impl WaylandState {
         let compositor = CompositorState::bind(globals, qh)?;
         let subcompositor =
             SubcompositorState::bind(compositor.wl_compositor().clone(), globals, qh)?;
+
+        let blur_manager: Result<OrgKdeKwinBlurManager, BindError> =
+            globals.bind(qh, 1..=1, GlobalData);
+
+        let blur_manager = match blur_manager {
+            Ok(manager) => Some(manager),
+            Err(_) => None,
+        };
 
         let wayland_state = WaylandState {
             registry: RegistryState::new(globals),
@@ -113,6 +124,7 @@ impl WaylandState {
             primary_selection_source: None,
             shm,
             mem_pool: RefCell::new(mem_pool),
+            kde_blur_manager: blur_manager,
         };
         Ok(wayland_state)
     }

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -22,6 +22,7 @@ use raw_window_handle::{
 };
 use smithay_client_toolkit::compositor::{CompositorHandler, SurfaceData, SurfaceDataExt};
 use smithay_client_toolkit::data_device_manager::ReadPipe;
+use smithay_client_toolkit::globals::GlobalData;
 use smithay_client_toolkit::reexports::csd_frame::{
     DecorationsFrame, FrameAction, ResizeEdge, WindowState as SCTKWindowState,
 };
@@ -37,9 +38,12 @@ use smithay_client_toolkit::shell::WaylandSurface;
 use wayland_client::protocol::wl_callback::WlCallback;
 use wayland_client::protocol::wl_keyboard::{Event as WlKeyboardEvent, KeyState};
 use wayland_client::protocol::wl_pointer::{ButtonState, WlPointer};
+use wayland_client::protocol::wl_region::WlRegion;
 use wayland_client::protocol::wl_surface::WlSurface;
-use wayland_client::{Connection as WConnection, Proxy};
+use wayland_client::{Connection as WConnection, Dispatch, Proxy, QueueHandle};
 use wayland_egl::{is_available as egl_is_available, WlEglSurface};
+use wayland_protocols_plasma::blur::client::org_kde_kwin_blur::OrgKdeKwinBlur;
+use wayland_protocols_plasma::blur::client::org_kde_kwin_blur_manager::OrgKdeKwinBlurManager;
 use wezterm_font::FontConfiguration;
 use wezterm_input_types::{
     KeyboardLedStatus, Modifiers, MouseButtons, MouseEvent, MouseEventKind, MousePress,
@@ -320,6 +324,8 @@ impl WaylandWindow {
 
         wait_configure.recv().await?;
 
+        inner.borrow().update_window_background_blur();
+
         Ok(window_handle)
     }
 }
@@ -473,6 +479,14 @@ impl WindowOps for WaylandWindow {
 
     fn restore(&self) {
         WaylandConnection::with_window_inner(self.0, move |inner| Ok(inner.restore()));
+    }
+
+    fn config_did_change(&self, config: &ConfigHandle) {
+        let config = config.clone();
+        WaylandConnection::with_window_inner(self.0, move |inner| {
+            inner.config_did_change(config);
+            Ok(())
+        });
     }
 }
 #[derive(Default, Clone, Debug)]
@@ -1229,6 +1243,31 @@ impl WaylandWindowInner {
             window.unset_maximized();
         }
     }
+
+    fn config_did_change(&mut self, config: ConfigHandle) {
+        self.config = config;
+        self.update_window_background_blur();
+    }
+
+    fn update_window_background_blur(&self) {
+        let conn = WaylandConnection::get().unwrap().wayland();
+        let qh = conn.event_queue.borrow().handle();
+        let wayland_state = conn.wayland_state.borrow();
+        match &wayland_state.kde_blur_manager {
+            Some(manager) => {
+                let kde_blur = manager.create(self.surface(), &qh, GlobalData);
+                if self.config.kde_window_background_blur {
+                    kde_blur.set_region(None);
+                } else {
+                    kde_blur.release();
+                }
+                kde_blur.commit();
+            }
+            None => {
+                // Can't blur if there is no blur manager
+            }
+        }
+    }
 }
 
 impl WaylandState {
@@ -1380,6 +1419,47 @@ impl WindowHandler for WaylandState {
         _serial: u32,
     ) {
         self.handle_window_event(window, WaylandWindowEvent::Request(configure));
+    }
+}
+
+impl Dispatch<OrgKdeKwinBlurManager, GlobalData> for WaylandState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &OrgKdeKwinBlurManager,
+        _event: <OrgKdeKwinBlurManager as Proxy>::Event,
+        _data: &GlobalData,
+        _conn: &WConnection,
+        _qhandle: &wayland_client::QueueHandle<Self>,
+    ) {
+        // No events from OrgKdeKwinBlurManager...
+        unreachable!();
+    }
+}
+
+impl Dispatch<OrgKdeKwinBlur, GlobalData> for WaylandState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &OrgKdeKwinBlur,
+        _event: <OrgKdeKwinBlur as Proxy>::Event,
+        _data: &GlobalData,
+        _conn: &WConnection,
+        _qhandle: &wayland_client::QueueHandle<Self>,
+    ) {
+        // No events from OrgKdeKwinBlur...
+        unreachable!();
+    }
+}
+
+impl Dispatch<WlRegion, GlobalData> for WaylandState {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlRegion,
+        _event: <WlRegion as Proxy>::Event,
+        _data: &GlobalData,
+        _conn: &WConnection,
+        _qhandle: &QueueHandle<Self>,
+    ) {
+        unreachable!();
     }
 }
 

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -317,14 +317,14 @@ impl WaylandWindow {
             .events
             .assign_window(window_handle.clone());
 
+        inner.borrow().update_window_background_blur();
+
         {
             let windows = &conn.wayland_state.borrow().windows;
             windows.borrow_mut().insert(window_id, inner.clone());
         };
 
         wait_configure.recv().await?;
-
-        inner.borrow().update_window_background_blur();
 
         Ok(window_handle)
     }

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -678,7 +678,7 @@ impl WindowInner {
         }
     }
 
-    fn config_did_change(&mut self, config: &ConfigHandle) {
+    fn config_did_change(&mut self, config: ConfigHandle) {
         self.config = config.clone();
         self.apply_decoration();
     }
@@ -887,7 +887,7 @@ impl WindowOps for Window {
     fn config_did_change(&self, config: &ConfigHandle) {
         let config = config.clone();
         Connection::with_window_inner(self.0, move |inner| {
-            inner.config_did_change(&config);
+            inner.config_did_change(config);
             Ok(())
         });
     }


### PR DESCRIPTION
KDE Wayland background blur added, triggered by adding somthing similar to the configuratin:

```
local wezterm = require 'wezterm'
local config = wezterm.config_builder()
config.window_background_opacity = 0.2
config.kde_window_background_blur = true
```

Default behavior is:
```
config.kde_window_background_blur = false
```


### Blur Example:
![with_blur](https://github.com/user-attachments/assets/66021c8b-8905-4afa-88e8-7a8009dcdd5f)



