### PR TITLE
WIP: Makefile `servedocs` target with livereload; reorder subsections in "Config" and "Colors & Appearance"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,6 @@ build:
 fmt:
 	cargo +nightly fmt
 
+.PHONY: docs
+docs:
+	ci/build-docs.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt build check test
+.PHONY: all fmt build check test docs servedocs
 
 all: build
 
@@ -17,6 +17,8 @@ build:
 fmt:
 	cargo +nightly fmt
 
-.PHONY: docs
 docs:
 	ci/build-docs.sh
+
+servedocs:
+	ci/build-docs.sh serve

--- a/ci/build-docs.sh
+++ b/ci/build-docs.sh
@@ -29,7 +29,7 @@ function ghapi() {
   if hash gh 2>/dev/null && test \( -n "$BUILD_REASON" -a -n "$GH_TOKEN" \) -o -z "$BUILD_REASON"; then
     gh api $1
   else
-    curl https://api.github.com$1
+    curl -L https://api.github.com$1
   fi
 }
 
@@ -53,7 +53,7 @@ cp assets/fonts/SymbolsNerdFontMono-Regular.ttf docs/fonts/
 docker build -t wezterm/mkdocs-material -f ci/Dockerfile.docs .
 
 if [ "$SERVE" == "yes" ] ; then
-  docker run --rm -it --network=host -v ${PWD}:/docs wezterm/mkdocs-material serve
+  docker run --rm -it --network=host -v ${PWD}:/docs wezterm/mkdocs-material serve --livereload --dirtyreload
 else
-  docker run --rm -e CARDS=true -v ${PWD}:/docs wezterm/mkdocs-material build
+  docker run --rm -e CARDS=true -v ${PWD}:/docs wezterm/mkdocs-material build --strict
 fi

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -1,4 +1,55 @@
-### Color Scheme
+The configuration settings described below assume you have created a
+`.wezterm.lua` or `wezterm.lua` containing at least the following:
+
+```lua
+local wezterm = require 'wezterm'
+local config = {}
+
+-- add your customizations here…
+
+return config
+```
+
+See [Configuration Files](files.md#configuration-files) for details
+of the configuration file format.
+
+## Text appearance
+
+In order to change he appearance of the terminal text in WezTerm, add the lines
+below to your config file before the `return config`.
+
+### Font face and size
+
+```lua
+config.font_size = 10
+config.font = wezterm.font 'JetBrains Mono'
+```
+
+_For more details, see [font_size](lua/config/font_size.md) and
+[font](lua/config/font.md)._
+
+### Text Background Opacity
+
+{{since('20201031-154415-9614e117')}}
+
+When using a background image or background opacity, the image content can
+have relatively low contrast with respect to the text you are trying to
+read in your terminal.
+
+The `text_background_opacity` setting specifies the alpha channel value to use
+for the background color of cells other than the default background color.
+
+The default for this setting is `1.0`, which means that the background
+color is fully opaque.
+
+The range of values permitted are `0.0` (completely translucent)
+through to `1.0` (completely opaque).
+
+```lua
+config.text_background_opacity = 0.3
+```
+
+## Color Scheme
 
 WezTerm ships with over 700 color schemes available from
 [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes#screenshots),
@@ -9,16 +60,11 @@ WezTerm ships with over 700 color schemes available from
 You can select a color scheme with a line like this:
 
 ```lua
-local wezterm = require 'wezterm'
-local config = {}
-
 config.color_scheme = 'Batman'
-
-return config
 ```
 
 You can find a list of available color schemes and screenshots
-in [The Color Schemes Section](../colorschemes/index.md).
+in the [Color Schemes](../colorschemes/index.md) section.
 
 If you'd like to automatically adjust your color scheme based on the
 system dark mode or light mode appearance, see the example in
@@ -34,7 +80,8 @@ system dark mode or light mode appearance, see the example in
 
 The `color_scheme` option takes precedence over the `colors` section below,
 and is mutually exclusive with it. If you want to merge/override colors
-you need to use [wezterm.color.get_default_colors()](lua/wezterm.color/get_default_colors.md) and explicitly merge them.
+you need to use [wezterm.color.get_default_colors()](lua/wezterm.color/get_default_colors.md)
+and explicitly merge them.
 
 {{since('20220903-194523-3bb1ed61')}}
 
@@ -52,9 +99,6 @@ you can use `#RRGGBB` to specify a color code using the
 usual hex notation; eg: `#000000` is equivalent to `black`:
 
 ```lua
-local wezterm = require 'wezterm'
-local config = {}
-
 config.colors = {
   -- The default text color
   foreground = 'silver',
@@ -131,8 +175,6 @@ config.colors = {
   quick_select_match_bg = { AnsiColor = 'Navy' },
   quick_select_match_fg = { Color = '#ffffff' },
 }
-
-return config
 ```
 
 {{since('20220101-133340-7edc5b5a')}}
@@ -222,8 +264,8 @@ builting color scheme.
 ### Defining a Color Scheme in a separate file
 
 If you'd like to factor your color schemes out into separate files, you
-can create a [TOML format](https://toml.io/en/) file with a `[colors]` section; take a look at [one of
-the available color schemes for an example](https://github.com/wez/wezterm/tree/main/config/src/scheme_data.rs).
+can create a [TOML format](https://toml.io/en/) file with a `[colors]` section;
+take a look at [one of the available color schemes for an example](https://github.com/wez/wezterm/tree/main/config/src/scheme_data.rs).
 
 It is recommended that you place your custom scheme in a directory
 named `$HOME/.config/wezterm/colors` if you're on a POSIX system.
@@ -242,11 +284,12 @@ config.color_scheme_dirs = { '/some/path/to/my/color/schemes' }
 Color scheme names that are defined in files in your `color_scheme_dirs` list
 take precedence over the built-in color schemes.
 
-### Dynamic Color Escape Sequences
+<a id="dynamic-colors"></a>
+## Dynamic Color Escape Sequences 
 
 Wezterm supports dynamically changing its color palette via escape sequences.
 
-[The dynamic-colors directory](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/dynamic-colors)
+The [`dynamic-colors` directory](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master/dynamic-colors)
 of the color scheme repo contains shell scripts that can change the color
 scheme immediately on the fly.  This can be used in your own scripts to alter
 the terminal appearance programmatically:
@@ -260,7 +303,7 @@ $ for scheme in *.sh ; do ; echo $scheme ; \
 
   <video width="80%" controls src="../screenshots/wezterm-dynamic-colors.mp4" loop></video>
 
-### Tab Bar Appearance & Colors
+## Tab Bar Appearance & Colors
 
 The tab bar has two modes; the default is a native looking style, but
 it is also possible to enable a retro aesthetic.  The configuration
@@ -278,7 +321,7 @@ details.
 * [tab_max_width](lua/config/tab_max_width.md) sets the maximum width, measured in cells,
   of a given tab when using retro tab mode.
 
-#### Native (Fancy) Tab Bar appearance
+### Native (Fancy) Tab Bar appearance
 
 The following options affect the fancy tab bar:
 
@@ -316,7 +359,7 @@ config.colors = {
 In addition, the tab bar colors mentioned below also apply
 to the items displayed in the tab bar.
 
-#### Retro Tab Bar appearance
+### Retro Tab Bar appearance
 
 The following options control the appearance of the tab bar:
 
@@ -396,13 +439,27 @@ config.colors = {
 }
 ```
 
+## Window appearance
+
+### Initial Geometry
+
+You can set the initial geometry for new windows like so:
+
+```lua
+config.initial_cols = 120
+config.initial_rows = 28
+```
+
+_For more information, see [initial_cols](lua/config/initial_cols.md) and
+[initial_rows](lua/config/initial_rows.md)._
+
 ### Window Padding
 
 You may add padding around the edges of the terminal area.
 
 [See the window_padding docs for more info](lua/config/window_padding.md)
 
-## Styling Inactive Panes
+### Styling Inactive Panes
 
 {{since('20201031-154415-9614e117')}}
 
@@ -439,7 +496,7 @@ The range of these values is 0.0 and up; they are used to multiply the existing
 values, so the default of 1.0 preserves the existing component, whilst 0.5 will
 reduce it by half, and 2.0 will double the value.
 
-## Window Background Image
+### Window Background Image
 
 ![Screenshot](../screenshots/wezterm-vday-screenshot.png)
 
@@ -488,7 +545,7 @@ If you'd like to have control over scaling, tiling/repeating, scrolling
 behavior and more, take a look at the more powerful
 [background](lua/config/background.md) configuration option.
 
-## Window Background Gradient
+### Window Background Gradient
 
 {{since('20210814-124438-54e29167')}}
 
@@ -497,7 +554,7 @@ behavior and more, take a look at the more powerful
 See [window_background_gradient](lua/config/window_background_gradient.md)
 for configuration information on gradients.
 
-## Window Background Opacity
+### Window Background Opacity
 
 {{since('20201031-154415-9614e117')}}
 
@@ -521,25 +578,3 @@ performance.
 ```lua
 config.window_background_opacity = 1.0
 ```
-
-## Text Background Opacity
-
-{{since('20201031-154415-9614e117')}}
-
-When using a background image or background opacity, the image content can
-have relatively low contrast with respect to the text you are trying to
-read in your terminal.
-
-The `text_background_opacity` setting specifies the alpha channel value to use
-for the background color of cells other than the default background color.
-
-The default for this setting is `1.0`, which means that the background
-color is fully opaque.
-
-The range of values permitted are `0.0` (completely translucent)
-through to `1.0` (completely opaque).
-
-```lua
-config.text_background_opacity = 0.3
-```
-

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -11,14 +11,25 @@ local wezterm = require 'wezterm'
 -- This will hold the configuration.
 local config = wezterm.config_builder()
 
--- This is where you actually apply your config choices
+-- This is where you actually apply your config choices.
 
--- For example, changing the color scheme:
+-- For example, changing the initial geometry for new windows:
+config.initial_cols = 120
+config.initial_rows = 28
+
+-- or, changing the font size and color scheme.
+config.font_size = 10
 config.color_scheme = 'AdventureTime'
 
--- and finally, return the configuration to wezterm
+-- Finally, return the configuration to wezterm:
 return config
 ```
+
+_See [wezterm.config_builder](lua/wezterm/config_builder.md),
+[initial_cols](lua/config/initial_cols.md),
+[initial_rows](lua/config/initial_rows.md),
+[font_size](lua/config/font_size.md), and
+[color_scheme](lua/config/color_schemes.md) for details._
 
 ## Configuration Files
 

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -25,11 +25,13 @@ config.color_scheme = 'AdventureTime'
 return config
 ```
 
-_See [wezterm.config_builder](lua/wezterm/config_builder.md),
-[initial_cols](lua/config/initial_cols.md),
-[initial_rows](lua/config/initial_rows.md),
-[font_size](lua/config/font_size.md), and
-[color_scheme](lua/config/color_schemes.md) for details._
+For more details, see:
+
+- [wezterm.config_builder](lua/wezterm/config_builder.md)
+- [initial_cols](lua/config/initial_cols.md)
+- [initial_rows](lua/config/initial_rows.md)
+- [font_size](lua/config/font_size.md)
+- [color_scheme](lua/config/color_schemes.md)
 
 ## Configuration Files
 

--- a/docs/config/files.md
+++ b/docs/config/files.md
@@ -1,4 +1,3 @@
-
 ## Quick Start
 
 Create a file named `.wezterm.lua` in your home directory, with the following
@@ -35,7 +34,7 @@ For more details, see:
 
 ## Configuration Files
 
-`wezterm` will look for a [lua](https://www.lua.org/manual/5.3/manual.html)
+WezTerm will look for a [Lua](https://www.lua.org/manual/5.3/manual.html)
 configuration file using the logic shown below.
 
 !!! tip
@@ -78,10 +77,10 @@ error will be shown and the default configuration will be used instead.
     drive mode.  It is **not** recommended to store your configs in that
     location if you are not running off a thumb drive.
 
-`wezterm` will watch the config file that it loads; if/when it changes, the
+WezTerm will watch the config file that it loads; if/when it changes, the
 configuration will be automatically reloaded and the majority of options will
-take effect immediately.  You may also use the `CTRL+SHIFT+R` keyboard shortcut
-to force the configuration to be reloaded.
+take effect immediately.  You may also use the <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd>
+keyboard shortcut to force the configuration to be reloaded.
 
 !!! info
     **The configuration file may be evaluated multiple times for each wezterm
@@ -91,33 +90,14 @@ to force the configuration to be reloaded.
     processes can result in many of them being spawned over time if you launch
     many copies of wezterm, or are frequently reloading your config file.
 
-### Configuration Overrides
+### Configuration File Structure
 
-{{since('20210314-114017-04b7cedd')}}
+Since WezTerm's configuration is written in the Lua programming language,
+you're permitted a great degree of flexibility; your configuration can even be
+broken up into [separate modules](#making-your-own-lua-modules).
 
-`wezterm` allows overriding configuration values via the command line; here are
-a couple of examples:
-
-```bash
-$ wezterm --config enable_scroll_bar=true
-$ wezterm --config 'exit_behavior="Hold"'
-```
-
-Configuration specified via the command line will always override the values
-provided by the configuration file, even if the configuration file is reloaded.
-
-Each window can have an additional set of window-specific overrides applied to
-it by code in your configuration file.  That's useful for eg: setting
-transparency or any other arbitrary option on a per-window basis.  Read the
-[window:set_config_overrides](lua/window/set_config_overrides.md) documentation
-for more information and examples of how to use that functionality.
-
-## Configuration File Structure
-
-The `wezterm.lua` configuration file is a lua script which allows for a high
-degree of flexibility.   The script is expected to return a configuration
-table, so a basic empty (and rather useless!) configuration file will look like
-this:
+The configuration script is expected to return a configuration table, so a
+basic empty (and rather useless!) configuration file will look like this:
 
 ```lua
 return {}
@@ -166,7 +146,7 @@ just the config assignments:
 config.color_scheme = 'Batman'
 ```
 
-## Making your own Lua Modules
+### Making Your Own Lua Modules
 
 If you'd like to break apart your configuration into multiple files, you'll
 be interested in this information.
@@ -221,8 +201,30 @@ helpers.apply_to_config(config)
 return config
 ```
 
+<a id="configuration-overrides"></a><!-- old section name, to preserve inbound links -->
+## Overriding Config Settings from the Command Line 
+
+{{since('20210314-114017-04b7cedd')}}
+
+WezTerm allows overriding configuration values via the command line; here are
+a couple of examples:
+
+```bash
+$ wezterm --config enable_scroll_bar=true
+$ wezterm --config 'exit_behavior="Hold"'
+```
+
+Configuration specified via the command line will always override the values
+provided by the configuration file, even if the configuration file is reloaded.
+
+Each window can have an additional set of window-specific overrides applied to
+it by code in your configuration file.  That's useful for eg: setting
+transparency or any other arbitrary option on a per-window basis.  Read the
+[window:set_config_overrides](lua/window/set_config_overrides.md) documentation
+for more information and examples of how to use that functionality.
 
 ## Configuration Reference
 
 Continue browsing this section of the docs for an overview of the commonly
-adjusted settings, or visit the [Lua Config Reference](lua/config/index.md) for a more detailed list of possibilities.
+adjusted settings, or visit the [Lua Config Reference](lua/config/index.md) for
+a more detailed list of possibilities.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,11 @@ hide:
   - toc
 ---
 
-*WezTerm is a powerful cross-platform terminal emulator and multiplexer written by <a href="https://github.com/wez/">@wez</a> and implemented in <a href="https://www.rust-lang.org/">Rust</a>*
+!!! tip "These docs are searchable!"
+    Press <kbd>S</kbd> or click on the magnifying glass icon to activate the
+    search function.
+
+WezTerm is a powerful cross-platform terminal emulator and multiplexer written by <a href="https://github.com/wez/">@wez</a> and implemented in <a href="https://www.rust-lang.org/">Rust</a>.
 
 ![Screenshot](screenshots/wezterm-vday-screenshot.png)
 
@@ -11,20 +15,17 @@ hide:
 
 ## Features
 
-* Runs on Linux, macOS, Windows 10 and FreeBSD
-* [Multiplex terminal panes, tabs and windows on local and remote hosts, with native mouse and scrollback](multiplexing.md)
-* <a href="https://github.com/tonsky/FiraCode#fira-code-monospaced-font-with-programming-ligatures">Ligatures</a>, Color Emoji and font fallback, with true color and [dynamic color schemes](config/appearance.md).
+* Runs on Linux, macOS, Windows, and FreeBSD
+* [Multiplexing](multiplexing.md): terminal panes, tabs and windows on local and remote hosts, with native mouse and scrollback
+* Ligatures, where supported by the font (_e.g._ <a href="https://github.com/tonsky/FiraCode#fira-code-monospaced-font-with-programming-ligatures">Fira Code</a>);
+  color emoji and font fallback
+* True color and [dynamic color schemes](config/appearance.md#dynamic-colors)
 * [Hyperlinks](hyperlinks.md)
-* [A full list of features can be found here](features.md)
 
-Looking for a [configuration reference?](config/files.md)
-
-**These docs are searchable: press `S` or click on the magnifying glass icon
-to activate the search function!**
+A full list of features can be found [here](features.md); the full
+configuration reference may be found [here](config/files.md).
 
 <figure markdown>
-
 ![Screenshot](screenshots/two.png)
-
-<figcaption>Screenshot of wezterm on macOS, running vim</figcaption>
+<figcaption>Screenshot of WezTerm on macOS, running vim</figcaption>
 </figure>

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -50,8 +50,6 @@ theme:
     - toc.follow
 plugins:
   - include-markdown
-  - tags:
-      tags_file: tags.md
   - macros:
       module_name: mkdocs_macros
   - search:

--- a/docs/mkdocs-base.yml
+++ b/docs/mkdocs-base.yml
@@ -8,7 +8,6 @@ repo_name: wez/wezterm
 edit_uri: edit/main/docs/
 docs_dir: docs
 site_dir: gh_pages
-strict: true
 theme:
   name: material
   logo: favicon.svg


### PR DESCRIPTION
Marked "WIP" since it stacks on the commits from #6412 

Assuming that gets merged, this PR will add:

- a `make servedocs` target that live-reloads, with the mkdocs `--dirtyreload` option, which reduces build time from ~30 seconds to just seconds
  * this required removing `strict: true` from `docs/mkdocs-base.yml`, but adding `--strict` to the `make build` target (:eyes: not sure if this will break CI, though)
- better subsection structure for "Config" and "Colors & Appearance," so that similar config settings are grouped together
- many small stylistic fixes elsewhere, including the index