### PR TITLE
Fix Nix build by disabling broken cargo-auditable step

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -38,16 +38,16 @@
     "harfbuzz": {
       "flake": false,
       "locked": {
-        "lastModified": 1719502711,
-        "narHash": "sha256-2ieCf3ftNk851FZBDPVl+7QHWBqD729KiUxUyxi26Yg=",
+        "lastModified": 1740783589,
+        "narHash": "sha256-ac8hV7QFuxcKtVb0m6UhOEz6bXGqQr/qkRtIdpNbbWU=",
         "owner": "harfbuzz",
         "repo": "harfbuzz",
-        "rev": "9c03576c49db6e7207d9bcdfe3abd170a809157f",
+        "rev": "3ef8709829a5884517ad91a97b32b9435b2f20d1",
         "type": "github"
       },
       "original": {
         "owner": "harfbuzz",
-        "ref": "9.0.0",
+        "ref": "10.4.0",
         "repo": "harfbuzz",
         "type": "github"
       }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -25,7 +25,7 @@
       flake = false;
     };
     harfbuzz = {
-      url = "github:harfbuzz/harfbuzz/9.0.0";
+      url = "github:harfbuzz/harfbuzz/10.4.0";
       flake = false;
     };
     libpng = {
@@ -131,14 +131,17 @@
               --replace-fail 'hash hostnamectl 2>/dev/null' 'command type -P hostnamectl &>/dev/null'
           '';
 
+          # Disable cargo-auditable until https://github.com/rust-secure-code/cargo-auditable/issues/124 is fixed
+          auditable = false;
+
           preFixup =
-            lib.optionalString stdenv.isLinux ''
+            lib.optionalString stdenv.isLinux /* bash */ ''
               patchelf \
                 --add-needed "${pkgs.libGL}/lib/libEGL.so.1" \
                 --add-needed "${pkgs.vulkan-loader}/lib/libvulkan.so.1" \
                 $out/bin/wezterm-gui
             ''
-            + lib.optionalString stdenv.isDarwin ''
+            + lib.optionalString stdenv.isDarwin /* bash */ ''
               mkdir -p "$out/Applications"
               OUT_APP="$out/Applications/WezTerm.app"
               cp -r assets/macos/WezTerm.app "$OUT_APP"


### PR DESCRIPTION
The full build failure can be seen in https://github.com/wezterm/wezterm/pull/6952#issuecomment-2869963774
Basically the final errors look like:
```
thread 'main' panicked at cargo-auditable/src/collect_audit_data.rs:79:9:
cargo metadata failure: error: Package `wezterm-cell v0.1.0 (/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/wezterm-cell)` does not have feature `image`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.
Dependency `image` would be enabled by these features:
	- `use_image`

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: could not compile `termwiz` (example "key_tester")

Caused by:
  process didn't exit successfully: `/nix/store/15q6pmv9id9kibfx441315mhy43aj6c9-cargo-auditable-0.6.5/bin/cargo-auditable rustc --crate-name key_tester --edition=2018 termwiz/examples/key_tester.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type bin --emit=dep-info,link -C opt-level=3 -C embed-bitcode=no --cfg 'feature="default"' --cfg 'feature="image"' --cfg 'feature="pest"' --cfg 'feature="pest_derive"' --cfg 'feature="serde"' --cfg 'feature="sha2"' --cfg 'feature="tmux_cc"' --cfg 'feature="use_image"' --cfg 'feature="use_serde"' --cfg 'feature="wezterm-blob-leases"' --check-cfg 'cfg(docsrs,test)' --check-cfg 'cfg(feature, values("cassowary", "default", "docs", "fnv", "image", "pest", "pest_derive", "serde", "sha2", "tmux_cc", "use_image", "use_serde", "wezterm-blob-leases", "widgets"))' -C metadata=eede3e145c517938 -C extra-filename=-6bd863f4345ad0b4 --out-dir /build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/examples --target x86_64-unknown-linux-gnu -C linker=/nix/store/dc6bahp3f5af2rxz3pal9m3kp4vx4rpy-gcc-wrapper-14.2.1.20250322/bin/cc -L dependency=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps -L dependency=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/release/deps --extern anyhow=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libanyhow-2d1e859d2d90f453.rlib --extern bitflags=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libbitflags-bcf29e1255144cfc.rlib --extern criterion=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libcriterion-986e1a10de3f7adb.rlib --extern env_logger=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libenv_logger-4b3cd7d7cce4ec57.rlib --extern fancy_regex=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libfancy_regex-bfb32d020181d0ec.rlib --extern filedescriptor=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libfiledescriptor-f81fae91c0dd434f.rlib --extern finl_unicode=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libfinl_unicode-0e02cbd939710b38.rlib --extern fixedbitset=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libfixedbitset-8ece84311566d5c9.rlib --extern image=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libimage-47375a1aeac16905.rlib --extern k9=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libk9-0b6e9b7c877bce6d.rlib --extern libc=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/liblibc-cc963ad55760ae34.rlib --extern log=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/liblog-f74da54c9282a1c3.rlib --extern memmem=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libmemmem-3b9a8730a55c6773.rlib --extern nix=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libnix-2a9d2137689b6b40.rlib --extern num_derive=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/release/deps/libnum_derive-51f6934e71ecd6d0.so --extern num_traits=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libnum_traits-e02d769fcbc3c35f.rlib --extern ordered_float=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libordered_float-3d5c345149ecbbdd.rlib --extern pest=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libpest-4099b20380a9e047.rlib --extern pest_derive=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/release/deps/libpest_derive-5331d47d354bee90.so --extern phf=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libphf-e91dfea7d5225d74.rlib --extern serde=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libserde-eadeaa06d08b1a73.rlib --extern sha2=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libsha2-c87d3f4760884e5a.rlib --extern signal_hook=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libsignal_hook-0fecd547118fd57e.rlib --extern siphasher=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libsiphasher-5e141d9d78dcc5c2.rlib --extern terminfo=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libterminfo-6cc7436a1f92b0de.rlib --extern termios=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libtermios-cd8eda573840f4a7.rlib --extern termwiz=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libtermwiz-9728e18bcb891b6a.rlib --extern thiserror=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libthiserror-665d7121d13d4d2b.rlib --extern ucd_trie=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libucd_trie-3c6803dcdfd3dbbb.rlib --extern unicode_segmentation=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libunicode_segmentation-653e7b921206e048.rlib --extern vtparse=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libvtparse-d785a21e35bc6116.rlib --extern wezterm_bidi=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_bidi-1ae7e4d7f0c54570.rlib --extern wezterm_blob_leases=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_blob_leases-63bd1308ea5cbb60.rlib --extern wezterm_cell=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_cell-16b50489a47fe323.rlib --extern wezterm_char_props=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_char_props-aba3bef5acb4befb.rlib --extern wezterm_color_types=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_color_types-db62785339978d9c.rlib --extern wezterm_dynamic=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_dynamic-b0076d64f0796380.rlib --extern wezterm_escape_parser=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_escape_parser-b72c300ad5082c98.rlib --extern wezterm_input_types=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_input_types-3358ef2e6c2b2277.rlib --extern wezterm_surface=/build/vv8miyr02x217mwpr865zdhnh777pfkl-source/target/x86_64-unknown-linux-gnu/release/deps/libwezterm_surface-4542c74447753aad.rlib -C target-feature=-crt-static` (exit status: 101)
```

---

I've found the following issues that might be related, but I tried a few options and feature renames without any success..
https://github.com/rust-secure-code/cargo-auditable/issues/124
https://github.com/rust-lang/cargo/issues/10788
https://github.com/rust-lang/cargo/issues/12336