### PR TITLE
fix: use config.default_prog for SpawnCommand (#6955)

### DIFF
--- a/wezterm-gui/src/spawn.rs
+++ b/wezterm-gui/src/spawn.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Context};
+use config::configuration;
 use config::keyassignment::SpawnCommand;
 use config::TermConfig;
 use mux::activity::Activity;
@@ -75,11 +76,13 @@ pub async fn spawn_command_internal(
     ) {
         (None, None, true) => None,
         _ => {
+            let config = configuration();
+            let default_builder = config.build_prog(None, config.default_prog.as_ref(), None)?;
             let mut builder = spawn
                 .args
                 .as_ref()
                 .map(|args| CommandBuilder::from_argv(args.iter().map(Into::into).collect()))
-                .unwrap_or_else(CommandBuilder::new_default_prog);
+                .unwrap_or(default_builder);
             for (k, v) in spawn.set_environment_variables.iter() {
                 builder.env(k, v);
             }

--- a/wezterm-gui/src/spawn.rs
+++ b/wezterm-gui/src/spawn.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, bail, Context};
-use config::configuration;
 use config::keyassignment::SpawnCommand;
-use config::TermConfig;
+use config::{configuration, TermConfig};
 use mux::activity::Activity;
 use mux::domain::SplitSource;
 use mux::tab::SplitRequest;


### PR DESCRIPTION
SpawnCommand implementation was revised as part of #6850 to support environment variables and cwd unconditionally. This introduced an issue where CommandBuilder::new_default_prog was used in lieu of config.default_prog.