### PR TITLE
Add JumpToMatchingBracket CopyMode KeyAssignment

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -720,6 +720,7 @@ pub enum CopyModeAssignment {
     JumpBackward { prev_char: bool },
     JumpAgain,
     JumpReverse,
+    JumpToMatchingBracket,
 }
 
 pub type KeyTable = HashMap<(KeyCode, Modifiers), KeyTableEntry>;

--- a/docs/config/lua/keyassignment/CopyMode/JumpToMatchingBracket.md
+++ b/docs/config/lua/keyassignment/CopyMode/JumpToMatchingBracket.md
@@ -1,0 +1,25 @@
+# CopyMode `JumpToMatchingBracket`
+
+{{since('nightly')}}
+
+Moves the CopyMode cursor position to the position of the matching bracket
+if found. This applies to the bracket pairs `{}`, `[]`, `()`
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+
+return {
+  key_tables = {
+    copy_mode = {
+      {
+        key = '%',
+        mods = 'NONE',
+        action = act.CopyMode 'JumpToMatchingBracket',
+      },
+    },
+  },
+}
+```
+
+

--- a/docs/examples/default-copy-mode-key-table.markdown
+++ b/docs/examples/default-copy-mode-key-table.markdown
@@ -43,6 +43,16 @@ return {
       { key = '0', mods = 'NONE', action = act.CopyMode 'MoveToStartOfLine' },
       { key = ';', mods = 'NONE', action = act.CopyMode 'JumpAgain' },
       {
+        key = '%',
+        mods = 'NONE',
+        action = act.CopyMode 'JumpToMatchingBracket',
+      },
+      {
+        key = '%',
+        mods = 'SHIFT',
+        action = act.CopyMode 'JumpToMatchingBracket',
+      },
+      {
         key = 'F',
         mods = 'NONE',
         action = act.CopyMode { JumpBackward = { prev_char = false } },

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -1061,6 +1061,71 @@ impl CopyRenderable {
         }
     }
 
+    fn jump_to_matching_bracket(&mut self) {
+        let y = self.cursor.y;
+        let (_top, lines) = self.delegate.get_lines(y..y + 1);
+        if let Some(line) = lines.get(0) {
+            if let Some(cell) = line.get_cell(self.cursor.x) {
+                let cursor_bracket = cell.str();
+                let (direction, matching_bracket) = match cursor_bracket {
+                    "{" => (1, "}"),
+                    "(" => (1, ")"),
+                    "[" => (1, "]"),
+                    "}" => (-1, "{"),
+                    ")" => (-1, "("),
+                    "]" => (-1, "["),
+                    _ => return,
+                };
+                let mut balance = direction;
+                let dims = self.delegate.get_dimensions();
+
+                let range_to_process = if direction == 1 {
+                    y..dims.scrollback_top + dims.scrollback_rows as isize
+                } else {
+                    dims.scrollback_top..y + 1
+                };
+
+                let (_top, mut lines_to_process) = self.delegate.get_lines(range_to_process);
+                if direction == -1 {
+                    lines_to_process.reverse();
+                }
+                for (line_idx, line) in lines_to_process.iter().enumerate() {
+                    let mut candidates: Vec<(usize, isize)> = line
+                        .visible_cells()
+                        .filter_map(|cell| {
+                            let cell_str = cell.str();
+                            if cell_str == cursor_bracket {
+                                Some((cell.cell_index(), direction))
+                            } else if cell_str == matching_bracket {
+                                Some((cell.cell_index(), -direction))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+
+                    if direction == -1 {
+                        candidates.reverse();
+                    }
+
+                    for (cell_idx, bracket_direction) in candidates {
+                        if line_idx != 0
+                            || direction * (cell_idx as isize - self.cursor.x as isize) > 0
+                        {
+                            balance += bracket_direction;
+                        }
+                        if balance == 0 {
+                            self.cursor.y += direction * line_idx as isize;
+                            self.cursor.x = cell_idx;
+                            self.select_to_cursor_pos();
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fn jump(&mut self, forward: bool, prev_char: bool) {
         self.pending_jump
             .replace(PendingJump { forward, prev_char });
@@ -1289,6 +1354,7 @@ impl Pane for CopyOverlay {
                     JumpBackward { prev_char } => render.jump(false, *prev_char),
                     JumpAgain => render.jump_again(false),
                     JumpReverse => render.jump_again(true),
+                    JumpToMatchingBracket => render.jump_to_matching_bracket(),
                 }
                 PerformAssignmentResult::Handled
             }
@@ -2005,6 +2071,16 @@ pub fn copy_key_table() -> KeyTable {
             WKeyCode::Char('t'),
             Modifiers::NONE,
             KeyAssignment::CopyMode(CopyModeAssignment::JumpForward { prev_char: true }),
+        ),
+        (
+            WKeyCode::Char('%'),
+            Modifiers::NONE,
+            KeyAssignment::CopyMode(CopyModeAssignment::JumpToMatchingBracket),
+        ),
+        (
+            WKeyCode::Char('%'),
+            Modifiers::SHIFT,
+            KeyAssignment::CopyMode(CopyModeAssignment::JumpToMatchingBracket),
         ),
         (
             WKeyCode::Home,


### PR DESCRIPTION
The KeyAssignment applies to the bracket pairs `{}`, `()`, `[]`

Resolves:
* Point 1 in https://github.com/wezterm/wezterm/issues/4471#issue-1955504704