### PR TITLE
Fix disable ligatures snippet

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -408,5 +408,5 @@ If you prefer to disable ligatures you can instruct *harfbuzz*, the underlying
 font shaping software, to disable them by adding this to your configuration:
 
 ```lua
-config.harfbuzz_features = { calt = 0, clig = 0, liga = 0 }
+config.harfbuzz_features = { 'calt = 0', 'clig = 0', 'liga = 0' }
 ```


### PR DESCRIPTION
The [FAQ](https://wezterm.org/faq.html?h=ligature#how-do-i-disable-ligatures) has this snippet to disable ligatures:

```lua
config.harfbuzz_features = { calt = 0, clig = 0, liga = 0 }
```

I'm using version `20240203-110809-5046fc22` (and I tested in the latest nightly as well) and it returns the following error when I add that snippet to my configuration:

```
error converting Lua table to Config (Config::from_dynamic: Error processing
Config::harfbuzz_features: Cannot convert `Object` to `Vec`.
{
    "harfbuzz_features": {
        "calt": 0,
        "clig": 0,
        "liga": 0,
    },
})
stack traceback:
        [C]: in metamethod 'newindex'
        [string "/Users/phin/.wezterm.lua"]:18: in main chunk
```

Changing the snippet so each key/value pair is a string gets rid of the error and does seem to disable ligatures as expected:

```lua
config.harfbuzz_features = { 'calt = 0', 'clig = 0', 'liga = 0' }
```

So that's all this PR does, it updates that snippet to work.