### PR TITLE
fix: save the wayland selection offer to every CopyAndPaste

### DIFF
--- a/window/src/os/wayland/copy_and_paste.rs
+++ b/window/src/os/wayland/copy_and_paste.rs
@@ -99,15 +99,6 @@ impl CopyAndPaste {
     }
 }
 
-impl WaylandState {
-    pub(super) fn resolve_copy_and_paste(&mut self) -> Option<Arc<Mutex<CopyAndPaste>>> {
-        let active_surface_id = self.active_surface_id.borrow();
-        let active_surface_id = active_surface_id.as_ref()?;
-        let pending = self.surface_to_pending.get(&active_surface_id)?;
-        Some(Arc::clone(&pending.lock().unwrap().copy_and_paste))
-    }
-}
-
 pub(super) fn write_selection_to_pipe(fd: WritePipe, text: &str) {
     if let Err(e) = write_pipe_with_timeout(fd, text.as_bytes()) {
         log::error!("while sending primary selection to pipe: {}", e);

--- a/window/src/os/wayland/data_device.rs
+++ b/window/src/os/wayland/data_device.rs
@@ -112,8 +112,9 @@ impl DataDeviceHandler for WaylandState {
                 return;
             }
 
-            if let Some(copy_and_paste) = self.resolve_copy_and_paste() {
-                copy_and_paste.lock().unwrap().confirm_selection(offer);
+            for pending_mouse in self.surface_to_pending.values() {
+                let copy_and_paste = &pending_mouse.lock().unwrap().copy_and_paste;
+                copy_and_paste.lock().unwrap().confirm_selection(offer.clone());
             }
         }
     }


### PR DESCRIPTION
I use the niri compositor, and I'm affected by #6685. This patch fixes the issue for me.

I'm not very familiar with how WezTerm is structured, so I don't understand why WezTerm has a separate `CopyAndPaste` per window, but it makes sense to me that when something is copied, it should be able to be pasted in all windows, not just the one that was the active_surface_id at the time when the clipboard was filled.

I've tested this in niri, but not in other compositors.