### PR TITLE
fix: hang when receiving WM_INPUTLANGCHANGEREQUEST message

### DIFF
--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2934,6 +2934,11 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
         WM_IME_SETCONTEXT => ime_set_context(hwnd, msg, wparam, lparam),
         WM_IME_COMPOSITION => ime_composition(hwnd, msg, wparam, lparam),
         WM_IME_ENDCOMPOSITION => ime_end_composition(hwnd, msg, wparam, lparam),
+        WM_INPUTLANGCHANGEREQUEST => {
+            let layout = lparam as HKL;
+            ActivateKeyboardLayout(layout, KLF_REPLACELANG);
+            Some(0)
+        },
         WM_MOUSEMOVE => mouse_move(hwnd, msg, wparam, lparam),
         WM_MOUSELEAVE => mouse_leave(hwnd, msg, wparam, lparam),
         WM_MOUSEHWHEEL | WM_MOUSEWHEEL => mouse_wheel(hwnd, msg, wparam, lparam),


### PR DESCRIPTION
## Problem
Wezterm hangs when switching input methods using tools like `im-select` that send `WM_INPUTLANGCHANGEREQUEST` messages via `PostMessage`. This happens because the message is not explicitly handled and falls through to `DefWindowProcW`, which can cause deadlocks. 

The link below might explain why #6787 #6817 happens:
https://marc.durdin.net/2012/08/waitforsingleobject-why-you-should-never-use-it/

## Solution
- Added explicit handling for `WM_INPUTLANGCHANGEREQUEST` in `do_wnd_proc`
- Call `ActivateKeyboardLayout` directly and return `Some(0)` to prevent the message from reaching `DefWindowProcW`
- This maintains input method switching functionality while avoiding the deadlock

## Testing
- [x] Tested with `im-select.exe` switching between English and Chinese input methods(cmd: im-select.exe 1033 or 2052)
- [x] Verified wezterm no longer hangs during input method switches
- [x] Confirmed input method switching still works correctly
- [x] Built and tested release version

## Changes
- Modified `window/src/os/windows/window.rs` to handle `WM_INPUTLANGCHANGEREQUEST`

Fixes: #6787 #6817