### PR TITLE
Remove deprecated `NSWindowFullScreenButton`

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1385,7 +1385,6 @@ fn apply_decorations_to_window(
         };
 
         for titlebar_button in &[
-            appkit::NSWindowButton::NSWindowFullScreenButton,
             appkit::NSWindowButton::NSWindowMiniaturizeButton,
             appkit::NSWindowButton::NSWindowCloseButton,
             appkit::NSWindowButton::NSWindowZoomButton,


### PR DESCRIPTION
Fixes #7080 to prevent null pointer dereference (and crash in debug mode) on macOS.

`NSWindowFullScreenButton`
[is deprecated](https://developer.apple.com/documentation/appkit/nswindow/buttontype/fullscreenbutton?changes=__6_5&language=objc). Removing it prevents a null pointer from being dereferenced and doesn't otherwise impact behavior.

Confirmed that `window_decorations = "RESIZE"` sill works [with rounded corners](https://github.com/wezterm/wezterm/issues/1034).