### PR TITLE
Prevent shell integration from interfering with other terminal programs

### DIFF
--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -14,6 +14,11 @@
 # WEZTERM_SHELL_SKIP_USER_VARS - disable user vars that capture information
 #                                about running programs
 
+if [ "${TERM_PROGRAM}" != "WezTerm" ]
+then
+  return 0
+fi
+
 # shellcheck disable=SC2166
 if [ -z "${BASH_VERSION-}" -a -z "${ZSH_NAME-}" ] ; then
   # Only for bash or zsh


### PR DESCRIPTION
The following changes the wezterm.sh script so that it only runs if the terminal is WezTerm. Thus preventing from interfering with other terminal programs.

I tested this on my local system and did not run the rust and cargo tests since it is not a change to any of the rust code.

This should address #7090 