### PR TITLE
Add function to percent encode string

### DIFF
--- a/docs/config/lua/wezterm.url/encode.md
+++ b/docs/config/lua/wezterm.url/encode.md
@@ -1,0 +1,8 @@
+# `wezterm.url.encode(string)`
+
+{{since('nightly')}}
+
+Returns the percent encoded version of the provided string.
+This is helpful to encode a string in order to be able to pass
+it as query string.
+

--- a/lua-api-crates/url-funcs/src/lib.rs
+++ b/lua-api-crates/url-funcs/src/lib.rs
@@ -1,7 +1,10 @@
 use crate::mlua::UserDataFields;
 use config::lua::get_or_create_sub_module;
 use config::lua::mlua::{self, Lua, MetaMethod, UserData, UserDataMethods};
-use percent_encoding::percent_decode;
+use percent_encoding::{percent_decode, utf8_percent_encode, AsciiSet, CONTROLS};
+
+/// https://url.spec.whatwg.org/#query-percent-encode-set
+const QUERY: &AsciiSet = &CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>');
 
 pub fn register(lua: &Lua) -> anyhow::Result<()> {
     let url_mod = get_or_create_sub_module(lua, "url")?;
@@ -13,6 +16,14 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
                 mlua::Error::external(format!("{err:#} while parsing {s} as URL"))
             })?;
             Ok(Url { url })
+        })?,
+    )?;
+
+    url_mod.set(
+        "encode",
+        lua.create_function(|_, s: String| {
+            let encoded = utf8_percent_encode(&s, QUERY).to_string();
+            Ok(encoded)
         })?,
     )?;
 


### PR DESCRIPTION
This is helpful to encode a string in order to be able to pass it as query string.

e.g. Using `InputSelector` to read a line and apply url encoding on the line and append it to a search engine's search url and open the resulting url 