### PR TITLE
copy_mode: implement `MoveToBlankLine`

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -678,6 +678,12 @@ pub enum RotationDirection {
     CounterClockwise,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromDynamic, ToDynamic)]
+pub enum ScrollDirection {
+    Up,
+    Down,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, FromDynamic, ToDynamic)]
 pub enum CopyModeAssignment {
     MoveToViewportBottom,
@@ -693,6 +699,7 @@ pub enum CopyModeAssignment {
     MoveToStartOfNextLine,
     MoveToSelectionOtherEnd,
     MoveToSelectionOtherEndHoriz,
+    MoveToBlankLine(ScrollDirection),
     MoveBackwardWord,
     MoveForwardWord,
     MoveForwardWordEnd,

--- a/docs/config/lua/keyassignment/CopyMode/MoveToBlankLine.md
+++ b/docs/config/lua/keyassignment/CopyMode/MoveToBlankLine.md
@@ -1,0 +1,27 @@
+# CopyMode `MoveToBlankLine`
+
+Moves the CopyMode cursor position to the next blank line in the specified
+direction, or to the end of scrollback if no blank line is found.
+
+This is similar to `tmux`'s `previous-paragraph` and `next-paragraph` bindings.
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+
+return {
+  key_tables = {
+    copy_mode = {
+      {
+        key = "{",
+        action = act.CopyMode { MoveToBlankLine = "Up" },
+      },
+      {
+        key = "}",
+        action = act.CopyMode { MoveToBlankLine = "Down" },
+      },
+    },
+  },
+}
+```
+

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -160,6 +160,24 @@ impl LogicalLine {
         }
         (y - 1, x - idx + self.physical_lines.last().unwrap().len())
     }
+
+    /// Determine if this is a single empty line.
+    ///
+    /// To be visually empty, it must contain one physical line containing only whitespace.
+    /// [`Line`]s don't track which cells are empty, so we can't distinguish between
+    /// whitespace and empty cells, so we just look at whitespace. This is also how Wezterm
+    /// deals with whitespace when copying to the clipboard, so this should be fine.
+    pub fn is_visually_empty(&self) -> bool {
+        if self.physical_lines.len() != 1 {
+            false
+        } else {
+            let physical_line = &self.physical_lines[0];
+            physical_line
+                .columns_as_str(0..usize::MAX)
+                .trim_end()
+                .is_empty()
+        }
+    }
 }
 
 /// A Pane represents a view on a terminal

--- a/mux/src/renderable.rs
+++ b/mux/src/renderable.rs
@@ -2,6 +2,7 @@ use crate::pane::{ForEachPaneLogicalLine, WithPaneLines};
 use luahelper::impl_lua_conversion_dynamic;
 use rangeset::RangeSet;
 use serde::{Deserialize, Serialize};
+use std::convert::TryInto;
 use std::ops::Range;
 use termwiz::surface::SequenceNo;
 use wezterm_dynamic::{FromDynamic, ToDynamic};
@@ -46,6 +47,13 @@ pub struct RenderableDimensions {
     pub reverse_video: bool,
 }
 impl_lua_conversion_dynamic!(RenderableDimensions);
+
+impl RenderableDimensions {
+    pub fn scrollback_bottom(&self) -> StableRowIndex {
+        self.scrollback_top
+            .saturating_add(self.scrollback_rows.try_into().unwrap_or(isize::MAX))
+    }
+}
 
 /// Implements Pane::get_cursor_position for Terminal
 pub fn terminal_get_cursor_position(term: &mut Terminal) -> StableCursorPosition {

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -3,7 +3,7 @@ use crate::termwindow::keyevent::KeyTableArgs;
 use crate::termwindow::{TermWindow, TermWindowNotif};
 use config::keyassignment::{
     ClipboardCopyDestination, CopyModeAssignment, KeyAssignment, KeyTable, KeyTableEntry,
-    ScrollbackEraseMode, SelectionMode,
+    ScrollDirection, ScrollbackEraseMode, SelectionMode,
 };
 use mux::domain::DomainId;
 use mux::pane::{
@@ -822,6 +822,38 @@ impl CopyRenderable {
         }
     }
 
+    fn move_to_blank_line(&mut self, direction: ScrollDirection) {
+        let dimensions = self.delegate.get_dimensions();
+        let bottom = dimensions.scrollback_bottom();
+
+        let direction = match direction {
+            ScrollDirection::Up => -1,
+            ScrollDirection::Down => 1,
+        };
+        let mut line_index = self.cursor.y;
+
+        loop {
+            line_index += direction;
+
+            if line_index < dimensions.scrollback_top || line_index >= bottom {
+                break;
+            }
+
+            let lines = self.delegate.get_logical_lines(line_index..line_index + 1);
+
+            if lines.len() == 1 && lines[0].is_visually_empty() {
+                break;
+            }
+        }
+
+        // Note: We jump to the `line_index` even if we didn't find a blank line. This lets you use
+        // `move_to_blank_line` to navigate to the boundaries of the scrollback even if it doesn't
+        // end/start with blank lines.
+        self.cursor.x = 0;
+        self.cursor.y = line_index;
+        self.select_to_cursor_pos();
+    }
+
     fn move_backward_one_word(&mut self) {
         let y = if self.cursor.x == 0 && self.cursor.y > 0 {
             self.cursor.x = usize::max_value();
@@ -1260,6 +1292,7 @@ impl Pane for CopyOverlay {
                     MoveToStartOfNextLine => render.move_to_start_of_next_line(),
                     MoveToSelectionOtherEnd => render.move_to_selection_other_end(),
                     MoveToSelectionOtherEndHoriz => render.move_to_selection_other_end_horiz(),
+                    MoveToBlankLine(direction) => render.move_to_blank_line(*direction),
                     MoveBackwardWord => render.move_backward_one_word(),
                     MoveForwardWord => render.move_forward_one_word(),
                     MoveForwardWordEnd => render.move_to_end_of_word(),


### PR DESCRIPTION
This is equivalent to the `previous-paragraph` and `next-paragraph` bindings in `tmux`.

Closes #7079

If this looks good, let me know and I can write some tests and docs for it! I'm not sure if we want this to be a more general mechanism like jumping to a line that matches a pattern.

TODO:
- [x] Docs
- [ ] Tests

Usage:

```lua
local wezterm = require 'wezterm'
local act = wezterm.action

return {
  key_tables = {
    copy_mode = {
      {
        key = "{",
        action = act.CopyMode { MoveToBlankLine = "Up" },
      },
      {
        key = "}",
        action = act.CopyMode { MoveToBlankLine = "Down" },
      },
    },
  },
}
```