### PR TITLE
Fix `mismatched_lifetime_syntaxes` warnings

### DIFF
--- a/async_ossl/src/lib.rs
+++ b/async_ossl/src/lib.rs
@@ -21,7 +21,7 @@ impl AsyncSslStream {
 
 #[cfg(unix)]
 impl std::os::fd::AsFd for AsyncSslStream {
-    fn as_fd(&self) -> std::os::fd::BorrowedFd {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
         self.s.get_ref().as_fd()
     }
 }

--- a/bintree/src/lib.rs
+++ b/bintree/src/lib.rs
@@ -271,7 +271,7 @@ impl<L, N> Cursor<L, N> {
     /// Return an iterator that will visit the chain of nodes leading
     /// to the root from the current position and yield their node
     /// data at each step of iteration.
-    pub fn path_to_root(&self) -> ParentIterator<L, N> {
+    pub fn path_to_root(&self) -> ParentIterator<'_, L, N> {
         ParentIterator { path: &*self.path }
     }
 

--- a/config/derive/src/attr.rs
+++ b/config/derive/src/attr.rs
@@ -130,7 +130,7 @@ impl<'a> FieldInfo<'a> {
     }
 }
 
-pub fn field_info(field: &Field) -> Result<FieldInfo> {
+pub fn field_info(field: &Field) -> Result<FieldInfo<'_>> {
     let mut name = field.ident.as_ref().unwrap().to_string();
     let mut skip = false;
     let mut flatten = false;

--- a/filedescriptor/src/unix.rs
+++ b/filedescriptor/src/unix.rs
@@ -62,7 +62,7 @@ impl Drop for OwnedHandle {
 }
 
 impl std::os::fd::AsFd for OwnedHandle {
-    fn as_fd(&self) -> std::os::fd::BorrowedFd {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
         unsafe { std::os::fd::BorrowedFd::borrow_raw(self.handle) }
     }
 }
@@ -231,7 +231,7 @@ impl std::io::Write for FileDescriptor {
 }
 
 impl std::os::fd::AsFd for FileDescriptor {
-    fn as_fd(&self) -> std::os::fd::BorrowedFd {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
         self.handle.as_fd()
     }
 }

--- a/lua-api-crates/plugin/src/lib.rs
+++ b/lua-api-crates/plugin/src/lib.rs
@@ -41,7 +41,7 @@ fn compute_repo_dir(url: &str) -> String {
     dir
 }
 
-fn get_remote(repo: &Repository) -> anyhow::Result<Option<Remote>> {
+fn get_remote(repo: &Repository) -> anyhow::Result<Option<Remote<'_>>> {
     let remotes = repo.remotes()?;
     for remote in remotes.iter() {
         if let Some(name) = remote {
@@ -184,7 +184,7 @@ impl RepoSpec {
     }
 }
 
-fn require_plugin(lua: &Lua, url: String) -> anyhow::Result<Value> {
+fn require_plugin(lua: &Lua, url: String) -> anyhow::Result<Value<'_>> {
     let spec = RepoSpec::parse(url)?;
 
     if !spec.is_checked_out() {

--- a/lua-api-crates/serde-funcs/src/lib.rs
+++ b/lua-api-crates/serde-funcs/src/lib.rs
@@ -62,19 +62,19 @@ fn toml_encode_pretty(_: &Lua, value: LuaValue) -> mlua::Result<String> {
     toml::to_string_pretty(&json).map_err(|err| mlua::Error::external(format!("{err:#}")))
 }
 
-fn json_decode(lua: &Lua, text: String) -> mlua::Result<LuaValue> {
+fn json_decode(lua: &Lua, text: String) -> mlua::Result<LuaValue<'_>> {
     let value =
         serde_json::from_str(&text).map_err(|err| mlua::Error::external(format!("{err:#}")))?;
     json_value_to_lua_value(lua, value)
 }
 
-fn yaml_decode(lua: &Lua, text: String) -> mlua::Result<LuaValue> {
+fn yaml_decode(lua: &Lua, text: String) -> mlua::Result<LuaValue<'_>> {
     let value: JValue =
         serde_yaml::from_str(&text).map_err(|err| mlua::Error::external(format!("{err:#}")))?;
     json_value_to_lua_value(lua, value)
 }
 
-fn toml_decode(lua: &Lua, text: String) -> mlua::Result<LuaValue> {
+fn toml_decode(lua: &Lua, text: String) -> mlua::Result<LuaValue<'_>> {
     let value: JValue =
         toml::from_str(&text).map_err(|err| mlua::Error::external(format!("{err:#}")))?;
     json_value_to_lua_value(lua, value)

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -951,7 +951,7 @@ impl Mux {
         self.prune_dead_windows();
     }
 
-    pub fn get_window(&self, window_id: WindowId) -> Option<MappedRwLockReadGuard<Window>> {
+    pub fn get_window(&self, window_id: WindowId) -> Option<MappedRwLockReadGuard<'_, Window>> {
         if !self.windows.read().contains_key(&window_id) {
             return None;
         }
@@ -960,7 +960,10 @@ impl Mux {
         }))
     }
 
-    pub fn get_window_mut(&self, window_id: WindowId) -> Option<MappedRwLockWriteGuard<Window>> {
+    pub fn get_window_mut(
+        &self,
+        window_id: WindowId,
+    ) -> Option<MappedRwLockWriteGuard<'_, Window>> {
         if !self.windows.read().contains_key(&window_id) {
             return None;
         }

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -425,7 +425,7 @@ impl Pane for LocalPane {
         Ok(())
     }
 
-    fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+    fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
         Mux::get().record_input_for_current_identity();
         MutexGuard::map(self.writer.lock(), |writer| {
             let w: &mut dyn std::io::Write = writer;
@@ -1067,7 +1067,10 @@ impl LocalPane {
         None
     }
 
-    fn divine_process_list(&self, policy: CachePolicy) -> Option<MappedMutexGuard<CachedProcInfo>> {
+    fn divine_process_list(
+        &self,
+        policy: CachePolicy,
+    ) -> Option<MappedMutexGuard<'_, CachedProcInfo>> {
         if let ProcessState::Running { pid: Some(pid), .. } = &*self.process.lock() {
             let mut proc_list = self.proc_list.lock();
 

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -237,7 +237,7 @@ pub trait Pane: Downcast + Send + Sync {
     }
     fn send_paste(&self, text: &str) -> anyhow::Result<()>;
     fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>>;
-    fn writer(&self) -> MappedMutexGuard<dyn std::io::Write>;
+    fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write>;
     fn resize(&self, size: TerminalSize) -> anyhow::Result<()>;
     /// Called as a hint that the pane is being resized as part of
     /// a zoom-to-fill-all-the-tab-space operation.
@@ -627,7 +627,7 @@ mod test {
         fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
             Ok(None)
         }
-        fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+        fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
             unimplemented!()
         }
         fn resize(&self, _: TerminalSize) -> anyhow::Result<()> {
@@ -685,7 +685,7 @@ mod test {
         physical_lines
     }
 
-    fn summarize_logical_lines(lines: &[LogicalLine]) -> Vec<(StableRowIndex, Cow<str>)> {
+    fn summarize_logical_lines(lines: &[LogicalLine]) -> Vec<(StableRowIndex, Cow<'_, str>)> {
         lines
             .iter()
             .map(|l| (l.first_row, l.logical.as_str()))
@@ -698,7 +698,7 @@ mod test {
         let width = 20;
         let physical_lines = physical_lines_from_text(text, width);
 
-        fn text_from_lines(lines: &[Line]) -> Vec<Cow<str>> {
+        fn text_from_lines(lines: &[Line]) -> Vec<Cow<'_, str>> {
             lines.iter().map(|l| l.as_str()).collect::<Vec<_>>()
         }
 

--- a/mux/src/termwiztermtab.rs
+++ b/mux/src/termwiztermtab.rs
@@ -192,7 +192,7 @@ impl Pane for TermWizTerminalPane {
         Ok(Some(Box::new(self.render_rx.try_clone()?)))
     }
 
-    fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+    fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
         MutexGuard::map(self.writer.lock(), |writer| {
             let w: &mut dyn std::io::Write = writer;
             w

--- a/termwiz/src/lineedit/history.rs
+++ b/termwiz/src/lineedit/history.rs
@@ -9,7 +9,7 @@ pub type HistoryIndex = usize;
 /// Defines the history interface for the line editor.
 pub trait History {
     /// Lookup the line corresponding to an index.
-    fn get(&self, idx: HistoryIndex) -> Option<Cow<str>>;
+    fn get(&self, idx: HistoryIndex) -> Option<Cow<'_, str>>;
     /// Return the index for the most recently added entry.
     fn last(&self) -> Option<HistoryIndex>;
     /// Add an entry.
@@ -24,7 +24,7 @@ pub trait History {
         style: SearchStyle,
         direction: SearchDirection,
         pattern: &str,
-    ) -> Option<SearchResult>;
+    ) -> Option<SearchResult<'_>>;
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -85,7 +85,7 @@ pub struct BasicHistory {
 }
 
 impl History for BasicHistory {
-    fn get(&self, idx: HistoryIndex) -> Option<Cow<str>> {
+    fn get(&self, idx: HistoryIndex) -> Option<Cow<'_, str>> {
         self.entries.get(idx).map(|s| Cow::Borrowed(s.as_str()))
     }
 
@@ -111,7 +111,7 @@ impl History for BasicHistory {
         style: SearchStyle,
         direction: SearchDirection,
         pattern: &str,
-    ) -> Option<SearchResult> {
+    ) -> Option<SearchResult<'_>> {
         let mut idx = idx;
 
         loop {

--- a/termwiz/src/terminal/mod.rs
+++ b/termwiz/src/terminal/mod.rs
@@ -71,7 +71,7 @@ pub trait Terminal {
 
     /// Returns a capability probing helper that will use escape
     /// sequences to attempt to probe information from the terminal
-    fn probe_capabilities(&mut self) -> Option<ProbeCapabilities> {
+    fn probe_capabilities(&mut self) -> Option<ProbeCapabilities<'_>> {
         None
     }
 

--- a/termwiz/src/terminal/unix.rs
+++ b/termwiz/src/terminal/unix.rs
@@ -386,7 +386,7 @@ impl Terminal for UnixTerminal {
         })
     }
 
-    fn probe_capabilities(&mut self) -> Option<ProbeCapabilities> {
+    fn probe_capabilities(&mut self) -> Option<ProbeCapabilities<'_>> {
         Some(ProbeCapabilities::new(&mut self.read, &mut self.write))
     }
 

--- a/wezterm-cell/src/image.rs
+++ b/wezterm-cell/src/image.rs
@@ -578,7 +578,7 @@ impl ImageData {
         }
     }
 
-    pub fn data(&self) -> MutexGuard<ImageDataType> {
+    pub fn data(&self) -> MutexGuard<'_, ImageDataType> {
         self.data.lock().unwrap()
     }
 

--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -557,7 +557,7 @@ impl std::fmt::Debug for SshStream {
 
 #[cfg(unix)]
 impl AsFd for SshStream {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.stdout.as_fd()
     }
 }

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -357,7 +357,7 @@ impl Pane for ClientPane {
         Ok(None)
     }
 
-    fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+    fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
         MutexGuard::map(self.writer.lock(), |writer| {
             let w: &mut dyn std::io::Write = writer;
             w

--- a/wezterm-dynamic/derive/src/attr.rs
+++ b/wezterm-dynamic/derive/src/attr.rs
@@ -280,7 +280,7 @@ impl<'a> FieldInfo<'a> {
     }
 }
 
-pub fn field_info(field: &Field) -> Result<FieldInfo> {
+pub fn field_info(field: &Field) -> Result<FieldInfo<'_>> {
     let mut name = field.ident.as_ref().unwrap().to_string();
     let mut skip = false;
     let mut flatten = false;

--- a/wezterm-font/src/locator/mod.rs
+++ b/wezterm-font/src/locator/mod.rs
@@ -45,7 +45,7 @@ pub enum FontDataSource {
 }
 
 impl FontDataSource {
-    pub fn name_or_path_str(&self) -> Cow<str> {
+    pub fn name_or_path_str(&self) -> Cow<'_, str> {
         match self {
             Self::OnDisk(path) => path.to_string_lossy(),
             Self::BuiltIn { name, .. } => Cow::Borrowed(name),
@@ -53,7 +53,7 @@ impl FontDataSource {
         }
     }
 
-    pub fn path_str(&self) -> Option<Cow<str>> {
+    pub fn path_str(&self) -> Option<Cow<'_, str>> {
         match self {
             Self::OnDisk(path) => Some(path.to_string_lossy()),
             Self::BuiltIn { .. } => None,
@@ -165,11 +165,11 @@ impl Ord for FontDataHandle {
 }
 
 impl FontDataHandle {
-    pub fn name_or_path_str(&self) -> Cow<str> {
+    pub fn name_or_path_str(&self) -> Cow<'_, str> {
         self.source.name_or_path_str()
     }
 
-    pub fn path_str(&self) -> Option<Cow<str>> {
+    pub fn path_str(&self) -> Option<Cow<'_, str>> {
         self.source.path_str()
     }
 

--- a/wezterm-font/src/shaper/harfbuzz.rs
+++ b/wezterm-font/src/shaper/harfbuzz.rs
@@ -146,7 +146,7 @@ impl HarfbuzzShaper {
         &self,
         font_idx: FallbackIdx,
         dpi: u32,
-    ) -> anyhow::Result<Option<RefMut<FontPair>>> {
+    ) -> anyhow::Result<Option<RefMut<'_, FontPair>>> {
         if font_idx >= self.handles.len() {
             return Ok(None);
         }

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -1121,7 +1121,7 @@ impl Pane for CopyOverlay {
         Ok(None)
     }
 
-    fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+    fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
         MutexGuard::map(self.writer.lock(), |writer| {
             let w: &mut dyn std::io::Write = writer;
             w

--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -334,7 +334,7 @@ impl Pane for QuickSelectOverlay {
         Ok(None)
     }
 
-    fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+    fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
         self.delegate.writer()
     }
 

--- a/wezterm-gui/src/quad.rs
+++ b/wezterm-gui/src/quad.rs
@@ -208,12 +208,12 @@ impl<'a> QuadTrait for Quad<'a> {
 }
 
 pub trait QuadAllocator {
-    fn allocate(&mut self) -> anyhow::Result<QuadImpl>;
+    fn allocate(&mut self) -> anyhow::Result<QuadImpl<'_>>;
     fn extend_with(&mut self, vertices: &[Vertex]);
 }
 
 pub trait TripleLayerQuadAllocatorTrait {
-    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl>;
+    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl<'_>>;
     fn extend_with(&mut self, layer_num: usize, vertices: &[Vertex]);
 }
 
@@ -335,7 +335,7 @@ impl HeapQuadAllocator {
 }
 
 impl TripleLayerQuadAllocatorTrait for HeapQuadAllocator {
-    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl> {
+    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl<'_>> {
         let quads = match layer_num {
             0 => &mut self.layer0,
             1 => &mut self.layer1,
@@ -380,7 +380,7 @@ pub enum TripleLayerQuadAllocator<'a> {
 }
 
 impl<'a> TripleLayerQuadAllocatorTrait for TripleLayerQuadAllocator<'a> {
-    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl> {
+    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl<'_>> {
         match self {
             Self::Gpu(b) => b.allocate(layer_num),
             Self::Heap(h) => h.allocate(layer_num),

--- a/wezterm-gui/src/renderstate.rs
+++ b/wezterm-gui/src/renderstate.rs
@@ -397,7 +397,7 @@ impl TripleVertexBuffer {
         (num_quads * VERTICES_PER_CELL, num_quads * INDICES_PER_CELL)
     }
 
-    pub fn map(&self) -> MappedQuads {
+    pub fn map(&self) -> MappedQuads<'_> {
         let mut bufs = self.current_vb_mut();
 
         // To map the vertex buffer, we need to hold a mutable reference to
@@ -476,7 +476,7 @@ impl RenderLayer {
         }
     }
 
-    pub fn quad_allocator(&self) -> TripleLayerQuadAllocator {
+    pub fn quad_allocator(&self) -> TripleLayerQuadAllocator<'_> {
         // We're creating a self-referential struct here to manage the lifetimes
         // of these related items.  The transmutes are safe because we're only
         // transmuting the lifetimes (not the types), and we're keeping hold
@@ -559,7 +559,7 @@ pub struct BorrowedLayers {
 }
 
 impl TripleLayerQuadAllocatorTrait for BorrowedLayers {
-    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl> {
+    fn allocate(&mut self, layer_num: usize) -> anyhow::Result<QuadImpl<'_>> {
         self.layers[layer_num].allocate()
     }
 

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -696,7 +696,7 @@ impl Modal for CharSelector {
     fn computed_element(
         &self,
         term_window: &mut TermWindow,
-    ) -> anyhow::Result<Ref<[ComputedElement]>> {
+    ) -> anyhow::Result<Ref<'_, [ComputedElement]>> {
         let selection = self.selection.borrow();
         let selection = selection.as_str();
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3275,13 +3275,13 @@ impl TermWindow {
         }
     }
 
-    pub fn pane_state(&self, pane_id: PaneId) -> RefMut<PaneState> {
+    pub fn pane_state(&self, pane_id: PaneId) -> RefMut<'_, PaneState> {
         RefMut::map(self.pane_state.borrow_mut(), |state| {
             state.entry(pane_id).or_insert_with(PaneState::default)
         })
     }
 
-    pub fn tab_state(&self, tab_id: TabId) -> RefMut<TabState> {
+    pub fn tab_state(&self, tab_id: TabId) -> RefMut<'_, TabState> {
         RefMut::map(self.tab_state.borrow_mut(), |state| {
             state.entry(tab_id).or_insert_with(TabState::default)
         })

--- a/wezterm-gui/src/termwindow/modal.rs
+++ b/wezterm-gui/src/termwindow/modal.rs
@@ -23,7 +23,7 @@ pub trait Modal: Downcast {
     fn computed_element(
         &self,
         term_window: &mut TermWindow,
-    ) -> anyhow::Result<Ref<[ComputedElement]>>;
+    ) -> anyhow::Result<Ref<'_, [ComputedElement]>>;
     fn reconfigure(&self, term_window: &mut TermWindow);
 }
 impl_downcast!(Modal);

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -651,7 +651,7 @@ impl Modal for CommandPalette {
     fn computed_element(
         &self,
         term_window: &mut TermWindow,
-    ) -> anyhow::Result<Ref<[ComputedElement]>> {
+    ) -> anyhow::Result<Ref<'_, [ComputedElement]>> {
         let selection = self.selection.borrow();
         let selection = selection.as_str();
 

--- a/wezterm-gui/src/termwindow/paneselect.rs
+++ b/wezterm-gui/src/termwindow/paneselect.rs
@@ -278,7 +278,7 @@ impl Modal for PaneSelector {
     fn computed_element(
         &self,
         term_window: &mut TermWindow,
-    ) -> anyhow::Result<Ref<[ComputedElement]>> {
+    ) -> anyhow::Result<Ref<'_, [ComputedElement]>> {
         if self.element.borrow().is_none() {
             let (element, labels) = Self::compute(term_window, &self.alphabet, self.show_pane_ids)?;
             self.element.borrow_mut().replace(element);

--- a/wezterm-gui/src/termwindow/selection.rs
+++ b/wezterm-gui/src/termwindow/selection.rs
@@ -7,7 +7,7 @@ use termwiz::surface::Line;
 use wezterm_term::StableRowIndex;
 
 impl super::TermWindow {
-    pub fn selection(&self, pane_id: PaneId) -> RefMut<Selection> {
+    pub fn selection(&self, pane_id: PaneId) -> RefMut<'_, Selection> {
         RefMut::map(self.pane_state(pane_id), |state| &mut state.selection)
     }
 

--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -52,13 +52,13 @@ impl RawHandlePair {
 }
 
 impl HasWindowHandle for RawHandlePair {
-    fn window_handle(&self) -> Result<WindowHandle, HandleError> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
         unsafe { Ok(WindowHandle::borrow_raw(self.window)) }
     }
 }
 
 impl HasDisplayHandle for RawHandlePair {
-    fn display_handle(&self) -> Result<DisplayHandle, HandleError> {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
         unsafe { Ok(DisplayHandle::borrow_raw(self.display)) }
     }
 }

--- a/wezterm-surface/src/hyperlink.rs
+++ b/wezterm-surface/src/hyperlink.rs
@@ -139,7 +139,7 @@ impl<'t> Match<'t> {
         c0.start()..c0.end()
     }
 
-    fn highlight(&self) -> Option<fancy_regex::Match> {
+    fn highlight(&self) -> Option<fancy_regex::Match<'_>> {
         self.captures.get(self.rule.highlight)
     }
 

--- a/wezterm-surface/src/lib.rs
+++ b/wezterm-surface/src/lib.rs
@@ -524,7 +524,7 @@ impl Surface {
         lines
     }
 
-    pub fn screen_lines(&self) -> Vec<Cow<Line>> {
+    pub fn screen_lines(&self) -> Vec<Cow<'_, Line>> {
         self.lines.iter().map(|line| Cow::Borrowed(line)).collect()
     }
 
@@ -539,7 +539,7 @@ impl Surface {
     /// of `Change` entries that will update the display accordingly.
     /// The worst case is that this function will fabricate a sequence
     /// of Change entries to paint the screen from scratch.
-    pub fn get_changes(&self, seq: SequenceNo) -> (SequenceNo, Cow<[Change]>) {
+    pub fn get_changes(&self, seq: SequenceNo) -> (SequenceNo, Cow<'_, [Change]>) {
         // Do we have continuity in the sequence numbering?
         let first = self.seqno.saturating_sub(self.changes.len());
         if seq == 0 || first > seq || self.seqno == 0 {

--- a/wezterm-surface/src/line/clusterline.rs
+++ b/wezterm-surface/src/line/clusterline.rs
@@ -168,7 +168,7 @@ impl ClusteredLine {
         }
     }
 
-    pub fn iter(&self) -> ClusterLineCellIter {
+    pub fn iter(&self) -> ClusterLineCellIter<'_> {
         let mut clusters = self.clusters.iter();
         let cluster = clusters.next();
         ClusterLineCellIter {

--- a/wezterm-surface/src/line/line.rs
+++ b/wezterm-surface/src/line/line.rs
@@ -628,7 +628,7 @@ impl Line {
     }
 
     /// Recompose line into the corresponding utf8 string.
-    pub fn as_str(&self) -> Cow<str> {
+    pub fn as_str(&self) -> Cow<'_, str> {
         match &self.cells {
             CellStorage::V(_) => {
                 let mut s = String::new();
@@ -1035,7 +1035,7 @@ impl Line {
         }
     }
 
-    pub fn get_cell(&self, cell_index: usize) -> Option<CellRef> {
+    pub fn get_cell(&self, cell_index: usize) -> Option<CellRef<'_>> {
         self.visible_cells()
             .find(|cell| cell.cell_index() == cell_index)
     }

--- a/wezterm-uds/src/lib.rs
+++ b/wezterm-uds/src/lib.rs
@@ -32,7 +32,7 @@ pub struct UnixStream(StreamImpl);
 
 #[cfg(unix)]
 impl AsFd for UnixStream {
-    fn as_fd(&self) -> BorrowedFd {
+    fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()
     }
 }

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -667,7 +667,7 @@ impl Window {
 }
 
 impl HasDisplayHandle for Window {
-    fn display_handle(&self) -> Result<DisplayHandle, HandleError> {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
         unsafe {
             Ok(DisplayHandle::borrow_raw(RawDisplayHandle::AppKit(
                 AppKitDisplayHandle::new(),
@@ -677,7 +677,7 @@ impl HasDisplayHandle for Window {
 }
 
 impl HasWindowHandle for Window {
-    fn window_handle(&self) -> Result<WindowHandle, HandleError> {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
         let handle =
             AppKitWindowHandle::new(NonNull::new(self.ns_view as *mut _).expect("non-null"));
         unsafe { Ok(WindowHandle::borrow_raw(RawWindowHandle::AppKit(handle))) }


### PR DESCRIPTION
Fixes a bunch of warnings like this:

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> window/src/os/macos/window.rs:670:23
    |
670 |     fn display_handle(&self) -> Result<DisplayHandle, HandleError> {
    |                       ^^^^^            ------------- the same lifetime is hidden here
    |                       |
    |                       the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
670 |     fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
    |                                                     ++++
```

This lint was added in Rust 1.89: https://github.com/rust-lang/rust/issues/141787