### PR TITLE
docs: fix typo in `quick_select_alphabet.md`

### DIFF
--- a/docs/config/lua/config/quick_select_alphabet.md
+++ b/docs/config/lua/config/quick_select_alphabet.md
@@ -23,5 +23,5 @@ accessible characters in a `qwerty` keyboard layout.
 |`colemak`      |`"arstqwfpzxcvneioluymdhgjbk"`|
 
 The suggested alphabet in the above table uses the left 4 fingers on the home row, top row, bottom
-row, then the right 4 fingers on the home raw, top row, bottom row, followed by the characters in
+row, then the right 4 fingers on the home row, top row, bottom row, followed by the characters in
 the middle of the keyboard that may be harder to reach.


### PR DESCRIPTION
Small typo fix. Love the project!