### PR TITLE
Revert "Fix crash on hidpi with wayland (#6508)"

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -921,8 +921,6 @@ impl WaylandWindowInner {
                         ) {
                             self.surface().attach(Some(buffer.wl_buffer()), 0, 0);
                             self.surface().set_buffer_scale(factor as i32);
-                            self.surface().commit();
-
                             self.surface_factor = factor;
                         }
                     }


### PR DESCRIPTION
Close #6645
Close #6998

This reverts commit d1684d38e83d31dcd28dfc7dcc36ac4ba9eb582c (PR https://github.com/wezterm/wezterm/pull/6508).
That commit caused a crash plaging a lot of nvidia users on Wayland (see #6645) as well as when using Fractional Scaling (see #6998), and probably in a few other cases as well..

That means #5406 will need to be re-opened & fixed differently :thinking: 