### PR TITLE
Improve scroll handling: add gesture fan-out and precise scroll scale

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -203,6 +203,22 @@ pub struct Config {
     )]
     pub scrollback_lines: usize,
 
+    /// If true, convert large wheel deltas into multiple discrete ticks
+    /// when forwarding to TUI apps (tmux, vim, emacs, …).
+    /// Default: false
+    #[dynamic(
+    	default = "default_tui_scroll_gesture_support",
+    )]
+    pub tui_scroll_gesture_support: bool,
+
+    /// The divisor for precise scrolling devices (like trackpads / Magic Mouse).
+    /// Default: 15.0 (WezTerm’s current hard-coded value).
+    #[dynamic(
+    	default = "default_precise_scroll_scale",
+		validate = "validate_precise_scroll_scale"
+    )]
+    pub precise_scroll_scale: f64,
+
     /// If no `prog` is specified on the command line, use this
     /// instead of running the user's shell.
     /// For example, to have `wezterm` always run `top` by default,
@@ -1695,6 +1711,24 @@ fn validate_scrollback_lines(value: &usize) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn default_tui_scroll_gesture_support() -> bool {
+    false
+}
+
+fn default_precise_scroll_scale() -> f64 {
+    15.0
+}
+
+fn validate_precise_scroll_scale(value: &f64) -> Result<(), String> {
+    if *value <= 0.0 {
+        Err(format!(
+            "Illegal value {value} for precise_scroll_scale; it must be positive and greater than zero!"
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 fn default_initial_rows() -> u16 {

--- a/docs/config/lua/config/precise_scroll_scale.md
+++ b/docs/config/lua/config/precise_scroll_scale.md
@@ -1,0 +1,18 @@
+---
+tags:
+  - mouse
+---
+# `precise_scroll_scale = 15.0`
+
+{{since('2025xxxx-xxxxx-xxxxx')}}
+
+Some devices, such as the Apple Magic Mouse and trackpads, provide *precise*
+scrolling deltas measured in pixels. Since wezterm doesn’t know the exact pixel
+size of a terminal cell, it applies a scale factor to approximate a reasonable
+scroll speed.
+
+The `precise_scroll_scale` option controls this scale factor. Smaller values
+make scrolling faster and more sensitive, while larger values slow it down.
+
+The default value is `15.0`, which is tuned for typical font sizes and DPI
+settings.

--- a/docs/config/lua/config/tui_scroll_gesture_support.md
+++ b/docs/config/lua/config/tui_scroll_gesture_support.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - mouse
+---
+# `tui_scroll_gesture_support = true`
+
+{{since('2025xxxx-xxxxx-xxxxx')}}
+
+When using terminal user interface (TUI) applications such as `tmux`, `vim`,
+`nvim` or `emacs` that enable mouse reporting, wezterm forwards scroll wheel
+events to the application.
+
+Traditionally, mouse protocols understood only discrete wheel "ticks", without
+any concept of larger scroll deltas. On systems with touchpads or devices such
+as the Apple Magic Mouse, a single gesture can produce a large scroll delta.
+By default wezterm would forward this as a single wheel tick, which makes
+scrolling inside TUIs feel slow.
+
+When `tui_scroll_gesture_support` is enabled, wezterm will expand larger scroll
+deltas into multiple discrete wheel events before forwarding them to the
+application. This allows TUIs to experience accelerated scrolling, while still
+preserving single-step precision for small movements.
+
+The default value is `false`.

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -2376,10 +2376,16 @@ impl WindowView {
             // Devices with precise deltas report number of pixels scrolled.
             // At this layer we don't know how many pixels comprise a cell
             // in the terminal widget, and our abstraction doesn't allow being
-            // told what that amount should be, so we come up with a hard
-            // coded factor based on the likely default font size and dpi
-            // to make the scroll speed feel a bit better.
-            15.0
+            // told what that amount should be, so we let the user decide the
+            // factor to make the scroll speed feel right.
+            if let Some(myself) = Self::get_this(this) {
+	            let cfg_ref = myself.inner.borrow(); // immutable
+	            // Be defensive: avoid zero/negative scale
+	            let s = cfg_ref.config.precise_scroll_scale.max(0.1);
+	            s
+	        } else {
+	            15.0 // fallback default if we can't get the config
+	        }
         } else {
             // Whereas imprecise deltas report the number of lines scrolled,
             // so we want to report those lines here wholesale.


### PR DESCRIPTION
# Summary

This PR improves scroll handling in WezTerm by introducing support for gesture-based scrolling in TUI applications and by making the scale factor for precise devices configurable.

It addresses the long-standing issue where scroll gestures from devices like the Apple Magic Mouse or trackpads felt smooth in WezTerm’s own scrollback but sluggish inside TUIs (e.g. tmux, neovim, emacs, ...). The root cause is that traditional mouse protocols only define discrete wheel “ticks”, so large deltas were collapsed into a single tick when forwarded to applications.

---

# Rationale

* **Before**:
    * Scrolling in WezTerm’s own UI could use large deltas for smooth, accelerated movement.
    * Inside TUIs, the same gestures were forwarded as a single wheel event, effectively losing the acceleration. This made scrollback navigation in tmux, vim, etc. frustratingly slow.
    * On macOS, precise scrolling devices used a hard-coded divisor (15.0), which could not be tuned for different DPI or user preference.
* **After**:
    * Large wheel deltas are expanded into multiple discrete wheel events (fan-out) when forwarding to TUIs, restoring a natural scrolling feel.
    * This behavior is controlled by a new config option, `tui_scroll_gesture_support`, so users can enable/disable it as needed.
    * The divisor for precise scrolling devices is now configurable via `precise_scroll_scale`, allowing users to adjust sensitivity beyond the old hard-coded default.

---

# Changes

* **Config**
    * Added `tui_scroll_gesture_support` (default: false).
    * Added `precise_scroll_scale` (default: 15.0) with validation.
* **Mouse handling**
    * Refactored `mouse_event_terminal` to compute `mouse_reporting` once and reuse it.
    * Added fan-out logic for large deltas, gated by `tui_scroll_gesture_support`.
    * Fan-out capped at 256 discrete events per gesture.
* **macOS scroll\_wheel**
    * Replaced hard-coded `15.0` divisor with `precise_scroll_scale` from config.
    * Borrowing logic refactored to avoid conflicts when accessing config and mutable state.
* **Docs**
    * Added `docs/config/lua/config/tui_scroll_gesture_support.md`.
    * Added `docs/config/lua/config/precise_scroll_scale.md`.

---

# Impact

* Default behavior is unchanged (new options default to current values).
* Users on macOS with trackpads or Magic Mouse can now fine-tune scroll sensitivity.
* Users of TUIs (tmux, vim, emacs, etc.) can enable `tui_scroll_gesture_support` to get natural accelerated scrolling, matching the feel of WezTerm’s native scrollback.

---

# Next steps

* Consider whether `tui_scroll_gesture_support` should default to `true` in future versions.
