### PR TITLE
feat(macos): add `MACOS_DISABLE_TITLEBAR_DRAG` decoration, normalized and refactored decorations

### DIFF
--- a/docs/config/lua/config/window_decorations.md
+++ b/docs/config/lua/config/window_decorations.md
@@ -49,6 +49,15 @@ The value is a set of flags:
       system titlebar background color to match the terminal background color
       defined by your configuration.  This option doesn't make sense to use
       without also including `TITLE|RESIZE` in the set of decorations.
+    * `MACOS_DISABLE_TITLEBAR_DRAG` — on macOS, **do not reserve the titlebar
+      region for dragging** when the title is hidden. This makes the top row of content
+      (e.g. the first line of the terminal) fully interactive for text selection and clicks.
+      
+      **Compatibility:**
+      - This flag is **ignored** when `TITLE` is present (a visible title implies a draggable area).
+      - This flag is **ignored** when `INTEGRATED_BUTTONS` is present (integrated buttons require a draggable area and a full-size content view).
+      
+      Combine it with `RESIZE` if you still want a resizable window.
 
 On X11 and Wayland, the windowing system may override the window decorations.
 
@@ -77,3 +86,16 @@ desktop environment to resize the window.  Windows users may wish to consider
 !!! tip
     You probably always want `RESIZE` to be listed in your `window_decorations`.
 
+!!! tip "macOS: enable system drag-by-gesture"
+    If you choose `MACOS_DISABLE_TITLEBAR_DRAG` to avoid reserving the titlebar area for
+    dragging, you can enable a system gesture to move any window (including wezterm) by holding
+    **Control + Command** and dragging anywhere in the window:
+    ```
+    defaults write -g NSWindowShouldDragOnGesture -bool true
+    ```
+    To revert:
+    ```
+    defaults delete -g NSWindowShouldDragOnGesture
+    ```
+    With this gesture enabled, removing the titlebar drag region lets you select text
+    starting from the very first line without accidental window drags.

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -2051,6 +2051,7 @@ bitflags! {
         const INTEGRATED_BUTTONS = 16;
         const MACOS_FORCE_SQUARE_CORNERS = 32;
         const MACOS_USE_BACKGROUND_COLOR_AS_TITLEBAR_COLOR = 64;
+        const MACOS_DISABLE_TITLEBAR_DRAG = 128;
     }
 }
 
@@ -2075,6 +2076,9 @@ impl Into<String> for &WindowDecorations {
             s.push("MACOS_FORCE_DISABLE_SHADOW");
         } else if self.contains(WindowDecorations::MACOS_FORCE_SQUARE_CORNERS) {
             s.push("MACOS_FORCE_SQUARE_CORNERS");
+        }
+        if self.contains(WindowDecorations::MACOS_DISABLE_TITLEBAR_DRAG) {
+            s.push("MACOS_DISABLE_TITLEBAR_DRAG");
         }
         if s.is_empty() {
             "NONE".to_string()
@@ -2104,6 +2108,8 @@ impl TryFrom<String> for WindowDecorations {
                 flags |= Self::MACOS_FORCE_ENABLE_SHADOW;
             } else if ele == "MACOS_FORCE_SQUARE_CORNERS" {
                 flags |= Self::MACOS_FORCE_SQUARE_CORNERS;
+            } else if ele == "MACOS_DISABLE_TITLEBAR_DRAG" {
+                flags |= Self::MACOS_DISABLE_TITLEBAR_DRAG;
             } else if ele == "INTEGRATED_BUTTONS" {
                 flags |= Self::INTEGRATED_BUTTONS;
             } else {


### PR DESCRIPTION
## Summary

This PR adds a new macOS window decoration flag and refactors the decoration logic for clarity and maintainability.

### New decoration flag

* **`MACOS_DISABLE_TITLEBAR_DRAG`** – when the title is hidden, do **not** reserve the titlebar area for window dragging. This makes the first line of content fully interactive (e.g. easier text selection in the top row).

### Refactor highlights

* Centralized normalization in `resolve_compatible_decorations()` with explicit invariants.
* Clear separation of concerns:
    * `resolve_compatible_decorations` — normalize & enforce invariants.
    * `from_normalized_decoration_to_mask` — build `NSWindowStyleMask` from normalized flags.
    * `apply_decorations_to_window` — apply mask and UI affordances (button visibility, title transparency) using normalized flags.
* Added defensive `debug_assert!` checks to catch misuse of non-normalized flags.
* Improved in-code comments (notably the “titled-by-default” rationale).

---

## Rationale for `MACOS_DISABLE_TITLEBAR_DRAG`

On macOS, hiding the title typically implies enabling `NSFullSizeContentViewWindowMask` so content extends into the titlebar region while AppKit uses that region for dragging. With `MACOS_DISABLE_TITLEBAR_DRAG`, WezTerm **intentionally omits** `NSFullSizeContentViewWindowMask` so that the top-most content becomes fully interactive (no implicit drag region). This is useful for workflows that prioritize selecting/clicking the very first line.

**Tip for users:** macOS supports a system gesture to drag windows from anywhere with **Control + Command + drag**:

```bash
defaults write -g NSWindowShouldDragOnGesture -bool true
# revert:
defaults delete -g NSWindowShouldDragOnGesture
```

With that gesture, it’s often preferable to disable the reserved drag region and keep the top row fully interactive. The same tip for users is provided in the updated documentation.

---

## Behavior & Invariants

After normalization (`resolve_compatible_decorations`), we guarantee:

* If `INTEGRATED_BUTTONS` is present, `MACOS_DISABLE_TITLEBAR_DRAG` is **absent**.
* If `TITLE` is present, `MACOS_DISABLE_TITLEBAR_DRAG` is **absent**.
* If `integrated_title_button_style != MacOsNative`, `INTEGRATED_BUTTONS` is **removed**.

Mask building (`from_normalized_decoration_to_mask`) then uses these invariants to:

* Keep **`NSTitledWindowMask`** as the basis (for consistent AppKit behavior), and later hide the title text/traffic lights when needed.
* Add **`NSResizableWindowMask`** only if `RESIZE` is set.
* Add **`NSFullSizeContentViewWindowMask`** when **either**
    * `TITLE` is hidden **or**
    * `INTEGRATED_BUTTONS` is set,  
        **and** `MACOS_DISABLE_TITLEBAR_DRAG` is **not** set.
* Preserve the prior special case for `MACOS_FORCE_SQUARE_CORNERS` (if only that flag is set), matching legacy behavior.

No behavior changes on Windows/X11/Wayland.

---

## Code Changes (key pieces)

* `resolve_compatible_decorations(...)` — enforce invariants & compatibility.
* `from_normalized_decoration_to_mask(...)` — build mask with clear, additive logic; includes `debug_assert!` sanity checks.
* `apply_decorations_to_window(...)` — normalize first with `resolve_compatible_decorations(...)`, compute mask once with `from_normalized_decoration_to_mask(...)`, then set:
    * standard window button visibility (only if a titlebar exists),
    * title visibility,
    * transparent titlebar rules.

---

## Documentation

* Add `MACOS_DISABLE_TITLEBAR_DRAG` to the **window\_decorations** docs (nightly).
* Document compatibility: ignored if `TITLE` or `INTEGRATED_BUTTONS` is present.
* Provide tip for users for dragging macOS windows using CTRL+Super key combination.

---

## Backwards Compatibility

* Existing configs are unaffected.
* The new flag is opt-in (nightly). If present alongside incompatible flags, normalization removes it (preserving previous behavior).
* Integrated buttons continue to set full-size content, unchanged.

---

## Testing Plan (manual)

**Configurations to verify on macOS:**

* `TITLE | RESIZE` (default)
    * Title visible, full-size content **off**; standard buttons visible; resizable.
* `RESIZE`
    * Title hidden; full-size content **on**; draggable by title area; resizable.
* `RESIZE | MACOS_DISABLE_TITLEBAR_DRAG`
    * Title hidden; full-size content **off**; **no** reserved drag region; resizable.
* `INTEGRATED_BUTTONS | RESIZE` (native style)
    * Integrated buttons visible (in tab bar); full-size content **on**; resizable.
* `TITLE | MACOS_DISABLE_TITLEBAR_DRAG`
    * The disable-drag flag is **ignored**; title visible; normal drag behavior.
* Non-native integrated button style
    * `INTEGRATED_BUTTONS` is removed; behavior matches `TITLE` or `RESIZE` per config.

---

## Follow-ups (optional)

* Unit tests for normalization (pure function): table-driven cases asserting invariant outputs.
* Consider gating or revisiting `MACOS_FORCE_SQUARE_CORNERS` behavior if still experimental (see https://github.com/wezterm/wezterm/pull/6587#issuecomment-3248533942)

---

**Thanks for reviewing the PR!**