### PR TITLE
Fix mermaid newlines in what-is-a-terminal.md

### DIFF
--- a/docs/what-is-a-terminal.md
+++ b/docs/what-is-a-terminal.md
@@ -57,13 +57,16 @@ kernel, which manages the actual communication with the terminal.
 flowchart LR
     subgraph Kernel
         direction LR
-        TTY["TTY device\n(e.g. /dev/tty/0)"] 
+        TTY["
+            TTY device
+            (e.g. /dev/tty/0)
+        "] 
     end
     
     subgraph Userspace
-    SHELL["Shell Program (e.g. zsh)"] <-- "input\noutput" --> TTY
+    SHELL["Shell Program (e.g. zsh)"] <-- "input/output" --> TTY
     end
-    TTY  <-- "input\noutput" -->  TE["Terminal Device"]:::td
+    TTY  <-- "input/output" -->  TE["Terminal Device"]:::td
     classDef td stroke:#00F,stroke-width:2px
 ```
 
@@ -137,13 +140,19 @@ an appropriate library to resolve the correct escape sequences.
 flowchart 
     subgraph Kernel
         direction TB
-        TTY["TTY device\n(e.g. /dev/tty/0)"] 
+        TTY["
+            TTY device
+            (e.g. /dev/tty/0)
+        "] 
     end
     
     subgraph Userspace
     SHELL["Shell Program (e.g. zsh)"] <-- input/output --> TTY
     SHELL -. "starts" .-> APP
-    APP["Application\n(e.g. vim)"] <-- input/output --> TTY
+    APP["
+        Application
+        (e.g. vim)
+    "] <-- input/output --> TTY
 
     end
     TTY  <-- input/output -->  TE["Terminal Device"]:::td
@@ -224,7 +233,10 @@ essentially just being the I/O stream.
 flowchart 
     subgraph Kernel
         direction TB
-        PTYC["PTY client\n(e.g. /dev/pts/0)"] 
+        PTYC["
+            PTY client
+            (e.g. /dev/pts/0)
+        "] 
         PTYM[PTY master]
         PTYC <--> PTYM
     end
@@ -232,8 +244,15 @@ flowchart
     subgraph Userspace
     SHELL["Shell Program (e.g. zsh)"] <-- input/output --> PTYC
     SHELL -. "starts" .-> APP
-    APP["Application\n(e.g. vim)"] <-- input/output --> PTYC
-    PTYM  <-- input/output -->  TE["Terminal Emulator\n(e.g. wezterm)"]:::wezterm
+    APP["
+        Application
+        (e.g. vim)
+    "] <-- input/output --> PTYC
+    PTYM  <-- input/output -->  TE
+    TE["
+        Terminal Emulator
+        (e.g. wezterm)
+    "]:::wezterm
     classDef wezterm stroke:#00F,stroke-width:2px
     end
 ```


### PR DESCRIPTION
Mermaid doesn't convert `\n` to newlines; you need to use literal new lines in the diagram. Fortunately, mermaid *does* ignore (some?) whitespace, so you don't have to ruin your lovely indentation.

For example, this is incorrect:
~~~
```mermaid
flowchart LR
    A["First line\nSecond line"]
```
~~~

```mermaid
flowchart LR
    A["First line\nSecond line"]
```

I have converted most cases of this to something more like the following:
~~~
```mermaid
flowchart LR
    A["
        First line
        Second line
    "]
```
~~~
```mermaid
flowchart LR
    A["
        First line
        Second line
    "]
```
The leading and trailing newlines, as well as the leading spaces, seem to be ignored by mermaid.

I did say "most" before; the exception is the `input\noutput` labels that I changed to `input/output` so they'd match the rest of the page.

There may be more instances of this across the documentation; I only noticed this one because I was looking at it.