### PR TITLE
Fix: left status bar overlaps with window buttons (#7197)

### DIFF
--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -10,6 +10,7 @@ use termwiz::escape::{Action, ControlCode, CSI};
 use termwiz::surface::SEQ_ZERO;
 use termwiz_funcs::{format_as_escapes, FormatColor, FormatItem};
 use wezterm_term::{Line, Progress};
+use window::parameters::Parameters;
 use window::{IntegratedTitleButton, IntegratedTitleButtonAlignment, IntegratedTitleButtonStyle};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -339,6 +340,8 @@ impl TabBarState {
         config: &ConfigHandle,
         left_status: &str,
         right_status: &str,
+        cell_width: f32,
+        os_parameters: Option<&Parameters>,
     ) -> Self {
         let colors = colors.cloned().unwrap_or_else(TabBarColors::default);
 
@@ -424,10 +427,29 @@ impl TabBarState {
 
         if use_integrated_title_buttons
             && config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
-            && config.use_fancy_tab_bar == false
-            && config.tab_bar_at_bottom == false
+            && !config.use_fancy_tab_bar
+            && !config.tab_bar_at_bottom
         {
-            for _ in 0..10 as usize {
+            // 1. Get the main margin in pixels from the OS parameters
+            let left_pixel_margin = os_parameters
+                .map(|p| p.title_bar.padding_left.get() as f32)
+                .unwrap_or(0.0);
+
+            // 2. Calculate the extra half-cell of padding in pixels
+            let extra_padding_in_pixels = 0.5 * cell_width;
+
+            // 3. Add the two pixel values together for a total margin
+            let total_pixel_margin = left_pixel_margin + extra_padding_in_pixels;
+
+            // 4. Convert the total pixel margin into a number of character cells
+            let num_padding_cells = if cell_width > 0.0 {
+                (total_pixel_margin / cell_width).ceil() as usize
+            } else {
+                10 // Fallback to a safe number of cells
+            };
+
+            // 5. Add the calculated number of padding cells
+            for _ in 0..num_padding_cells {
                 line.insert_cell(0, black_cell.clone(), title_width, SEQ_ZERO);
                 x += 1;
             }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2001,6 +2001,8 @@ impl TermWindow {
             &self.config,
             &self.left_status,
             &self.right_status,
+            self.render_metrics.cell_size.width as f32,
+            self.os_parameters.as_ref(),
         );
         if new_tab_bar != self.tab_bar {
             self.tab_bar = new_tab_bar;

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -315,9 +315,25 @@ impl crate::TermWindow {
             && self.config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
             && !self.window_state.contains(window::WindowState::FULL_SCREEN)
         {
+            // 1. Get the main margin in pixels (already done)
+            let left_margin = self
+                .os_parameters
+                .as_ref()
+                .map(|p| p.title_bar.padding_left.get() as f32)
+                .unwrap_or(0.0);
+
+            // 2. Get the width of a single cell in pixels
+            let cell_width = self.render_metrics.cell_size.width as f32;
+
+            // 3. Calculate the extra padding in pixels
+            let extra_padding_in_pixels = 0.5 * cell_width;
+
+            // 4. Add the two pixel values together
+            let total_left_margin = left_margin + extra_padding_in_pixels;
+
             left_status.push(
                 Element::new(&font, ElementContent::Text("".to_string())).margin(BoxDimension {
-                    left: Dimension::Cells(4.0), // FIXME: determine exact width of macos ... buttons
+                    left: Dimension::Pixels(total_left_margin),
                     right: Dimension::Cells(0.),
                     top: Dimension::Cells(0.),
                     bottom: Dimension::Cells(0.),
@@ -378,11 +394,7 @@ impl crate::TermWindow {
         let left_padding = if window_buttons_at_left {
             if self.config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
             {
-                if !self.window_state.contains(window::WindowState::FULL_SCREEN) {
-                    Dimension::Pixels(70.0)
-                } else {
-                    Dimension::Cells(0.5)
-                }
+                Dimension::Cells(0.5)
             } else {
                 Dimension::Pixels(0.0)
             }

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -19,7 +19,7 @@ use cocoa::appkit::{
     self, CGFloat, NSApplication, NSApplicationActivateIgnoringOtherApps,
     NSApplicationPresentationOptions, NSBackingStoreBuffered, NSEvent, NSEventModifierFlags,
     NSOpenGLContext, NSOpenGLPixelFormat, NSPasteboard, NSRunningApplication, NSScreen, NSView,
-    NSViewHeightSizable, NSViewWidthSizable, NSWindow, NSWindowStyleMask,
+    NSViewHeightSizable, NSViewWidthSizable, NSWindow, NSWindowButton, NSWindowStyleMask,
 };
 use cocoa::base::*;
 use cocoa::foundation::{
@@ -920,9 +920,47 @@ impl WindowOps for Window {
             None
         };
 
+        let title_bar_padding_left = if config
+            .window_decorations
+            .contains(WindowDecorations::INTEGRATED_BUTTONS)
+        {
+            // This unsafe block calls the native macOS APIs
+            unsafe {
+                let window_id: id = self.ns_window;
+
+                // 1. Get each of the three "traffic light" buttons
+                let close_button: id =
+                    msg_send![window_id, standardWindowButton: NSWindowButton::NSWindowCloseButton];
+                let zoom_button: id =
+                    msg_send![window_id, standardWindowButton: NSWindowButton::NSWindowZoomButton];
+
+                // 2. If we can't find the buttons (eg: fullscreen), fall back to a safe value.
+                if close_button == nil || zoom_button == nil {
+                    64.0 // Fallback value
+                } else {
+                    // 3. Get the frame (position and size) of the leftmost and rightmost buttons.
+                    let zoom_frame: NSRect = msg_send![zoom_button, frame];
+
+                    // 4. The total padding needed (in logical POINTS) is the coordinate
+                    // of the right edge of the rightmost button.
+                    let total_width_in_points = zoom_frame.origin.x + zoom_frame.size.width;
+
+                    // 5. Get the DPI scale factor (e.g., 2.0 for Retina)
+                    let scale_factor: CGFloat = msg_send![window_id, backingScaleFactor];
+
+                    // 6. Convert points to physical PIXELS
+                    let total_width_in_pixels = total_width_in_points * scale_factor;
+
+                    total_width_in_pixels
+                }
+            }
+        } else {
+            0.0
+        };
+
         Ok(Some(Parameters {
             title_bar: TitleBar {
-                padding_left: ULength::new(0),
+                padding_left: ULength::new(title_bar_padding_left as usize),
                 padding_right: ULength::new(0),
                 height: None,
                 font_and_size: None,


### PR DESCRIPTION
### fix(macos): Dynamically size tab bar margin for integrated buttons

### Description

#### Problem

On macOS, the left status bar content would render underneath the OS "traffic light" window controls when using integrated title bar buttons (`window_decorations = "INTEGRATED_BUTTONS"`).

This issue affected both the fancy and classic (text-based) tab bars, which relied on incorrect, hardcoded margins (`FIXME`s in the code) that were insufficient to clear the button area.

This bug is related to issue #7197, which this PR completely resolves.

#### Solution

This PR resolves the issue by replacing the hardcoded values with a robust, dynamic calculation of the button area's width. The fix is applied consistently to both tab bar renderers.

The changes are broken down as follows:

**1. Dynamic Width Calculation in the Windowing Layer**
* The `get_os_parameters` function for macOS now uses FFI to call native AppKit APIs (`standardWindowButton:`).
* It queries the `frame` of the native window buttons to compute the exact physical pixel width required for padding, correctly handling Retina (high-DPI) displays.
* This logic is now centralized in the windowing layer, providing a clean abstraction for the UI layer to consume.

**2. Refactored Fancy Tab Bar Renderer (`use_fancy_tab_bar = true`)**
* The fancy tab bar renderer now consumes the dynamic pixel value from `os_parameters`.
* It uses `Dimension::Pixels` to create a correctly sized spacer element, avoiding a "double scaling" issue and ensuring pixel-perfect alignment.
* Redundant hardcoded padding was removed to establish a single source of truth for the margin.

**3. Updated Classic Tab Bar Renderer (`use_fancy_tab_bar = false`)**
* The classic (text-based) tab bar renderer was also updated to use the dynamic pixel value.
* It now calculates the correct number of padding *cells* by dividing the required pixel width by the width of a single character cell.
* This makes the padding for the classic bar fully dynamic and accurate, adapting correctly to different font sizes.

The final result is a clean, pixel-perfect alignment of the tab bar content for both tab bar styles.


#### How to Test

**Test Case 1: Fancy Tab Bar**
1. On a macOS system, configure `wezterm.lua` with:
   ```lua
   config.use_fancy_tab_bar = true
   config.window_decorations = "INTEGRATED_BUTTONS"
   ```
2. Add a left status bar element using the `update-status` event.
   ```lua
   wezterm.on("update-status", function(window, pane)
    window:set_left_status(wezterm.format {
      { Text = 'My status bar text' },
    })
   end)
   ```
4. Launch WezTerm and confirm the left status text is positioned correctly.
5. Enter and exit fullscreen to confirm the layout remains correct.

**Test Case 2: Classic Tab Bar**
1. On a macOS system, configure `wezterm.lua` with:
   ```lua
   config.use_fancy_tab_bar = false
   config.window_decorations = "INTEGRATED_BUTTONS"
   ```
2. Add a left status bar element using the `update-status` event.
3. Launch WezTerm and confirm the left status text is positioned correctly.
4. Enter and exit fullscreen to confirm the layout remains correct.