### PR TITLE
feat(terminal): Implement dynamic DECRQSS and DECRQM cursor queries

### DIFF
--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -20,9 +20,9 @@ use wezterm_cell::UnicodeVersion;
 use wezterm_escape_parser::csi::{
     Cursor, CursorStyle, DecPrivateMode, DecPrivateModeCode, Device, Edit, EraseInDisplay,
     EraseInLine, Mode, Sgr, TabulationClear, TerminalMode, TerminalModeCode, Window, XtSmGraphics,
-    XtSmGraphicsAction, XtSmGraphicsItem, XtSmGraphicsStatus, XtermKeyModifierResource,
+    XtSmGraphicsAction, XtSmGraphicsItem, XtSmGraphicsStatus, XtermKeyModifierResource
 };
-use wezterm_escape_parser::{OneBased, OperatingSystemCommand, CSI};
+use wezterm_escape_parser::{OneBased, OperatingSystemCommand, ShortDeviceControl, CSI};
 use wezterm_surface::{CursorShape, CursorVisibility, SequenceNo};
 
 mod image;
@@ -1431,17 +1431,52 @@ impl TerminalState {
 
     fn perform_csi_mode(&mut self, mode: Mode) {
         match mode {
-            Mode::SetDecPrivateMode(DecPrivateMode::Code(
-                DecPrivateModeCode::StartBlinkingCursor,
-            ))
-            | Mode::ResetDecPrivateMode(DecPrivateMode::Code(
-                DecPrivateModeCode::StartBlinkingCursor,
-            )) => {}
-            Mode::QueryDecPrivateMode(DecPrivateMode::Code(
-                DecPrivateModeCode::StartBlinkingCursor,
-            )) => {
-                self.decqrm_response(mode, true, false);
-            }
+			// --> START OF MODIFICATION <--
+	        Mode::SetDecPrivateMode(DecPrivateMode::Code(
+	            DecPrivateModeCode::StartBlinkingCursor,
+	        )) => {
+	            // An application is enabling blinking. Change the current shape to its
+	            // blinking variant.
+	            self.cursor.shape = match self.cursor.shape {
+	                CursorShape::SteadyBlock => CursorShape::BlinkingBlock,
+	                CursorShape::SteadyUnderline => CursorShape::BlinkingUnderline,
+	                CursorShape::SteadyBar => CursorShape::BlinkingBar,
+	                // If it's already blinking or default, do nothing
+	                _ => self.cursor.shape,
+	            };
+	        }
+
+	        Mode::ResetDecPrivateMode(DecPrivateMode::Code(
+	            DecPrivateModeCode::StartBlinkingCursor,
+	        )) => {
+	            // An application is disabling blinking. Change the current shape to its
+	            // steady variant.
+	            self.cursor.shape = match self.cursor.shape {
+	                CursorShape::BlinkingBlock | CursorShape::Default => CursorShape::SteadyBlock,
+	                CursorShape::BlinkingUnderline => CursorShape::SteadyUnderline,
+	                CursorShape::BlinkingBar => CursorShape::SteadyBar,
+	                // If it's already steady, do nothing
+	                _ => self.cursor.shape,
+	            };
+	        }
+
+	        Mode::QueryDecPrivateMode(DecPrivateMode::Code(
+	            DecPrivateModeCode::StartBlinkingCursor,
+	        )) => {
+	            // This part remains the same as our previous fix
+	            let shape = self.cursor.shape;
+	            // if shape == CursorShape::Default {
+                //     // Query the live configuration via the trait
+                //     shape = wezterm.config.default_cursor_style().into();
+                // }
+	            let is_blinking = matches!(
+	                shape,
+	                CursorShape::BlinkingBlock 
+	                | CursorShape::BlinkingUnderline 
+	                | CursorShape::BlinkingBar
+	            );
+	            self.decqrm_response(mode, true, is_blinking);
+	        }
 
             Mode::SetDecPrivateMode(DecPrivateMode::Code(DecPrivateModeCode::AutoRepeat))
             | Mode::ResetDecPrivateMode(DecPrivateMode::Code(DecPrivateModeCode::AutoRepeat)) => {
@@ -2593,6 +2628,69 @@ impl TerminalState {
                 log::debug!("Cursor shape is now {:?}", self.cursor.shape);
             }
         }
+    }
+
+    fn perform_decrqss(&mut self, s: &Box<ShortDeviceControl>) {
+        match s.data.as_slice() {
+            &[b'"', b'p'] => {
+                // DECSCL - select conformance level
+                write!(self.writer, "{}1$r65;1\"p{}", DCS, ST).ok();
+            }
+            &[b' ', b'q'] => {
+                // DECSCUSR - cursor style query (xterm extension)
+                let shape = self.cursor.shape;
+
+                // if shape == CursorShape::Default {
+                //     // Query the live configuration via the trait
+                //     shape = wezterm.config.default_cursor_style().into();
+                // }
+                
+                // 1. Map the internal CursorShape to the standard CSI CursorStyle enum
+	            let style_code = match shape {
+	                CursorShape::BlinkingBlock => CursorStyle::BlinkingBlock,
+	                CursorShape::SteadyBlock => CursorStyle::SteadyBlock,
+	                CursorShape::BlinkingUnderline => CursorStyle::BlinkingUnderline,
+	                CursorShape::SteadyUnderline => CursorStyle::SteadyUnderline,
+	                CursorShape::BlinkingBar => CursorStyle::BlinkingBar,
+	                CursorShape::SteadyBar => CursorStyle::SteadyBar,
+	                CursorShape::Default => CursorStyle::Default,
+	            };
+
+                write!(self.writer, "{}1$r{} q{}", DCS, style_code as u16, ST).ok();
+            }
+            &[b'r'] => {
+                // DECSTBM - top and bottom margins
+                let margins = self.top_and_bottom_margins.clone();
+                write!(
+                    self.writer,
+                    "{}1$r{};{}r{}",
+                    DCS,
+                    margins.start + 1,
+                    margins.end,
+                    ST
+                ).ok();
+            }
+            &[b's'] => {
+                // DECSLRM - left and right margins
+                let margins = self.left_and_right_margins.clone();
+                write!(
+                    self.writer,
+                    "{}1$r{};{}s{}",
+                    DCS,
+                    margins.start + 1,
+                    margins.end,
+                    ST
+                ).ok();
+            }
+            _ => {
+                if self.config.log_unknown_escape_sequences() {
+                    log::warn!("unhandled DECRQSS {:?}", s);
+                }
+                // Reply that the request is invalid
+                write!(self.writer, "{}0$r{}", DCS, ST).ok();
+            }
+        }
+        self.writer.flush().ok();
     }
 
     /// https://vt100.net/docs/vt510-rm/DECSC.html


### PR DESCRIPTION
**Description:**

This PR implements the correct handling for terminal cursor queries to ensure they reflect the true state of the cursor, including user-configured defaults and runtime changes.

Specifically, this addresses three issues:
1.  **DECRQSS Cursor Shape Query (`DCS $q "q" ST`)**: Previously, this was unrecognized and returned a failure. It is now correctly handled, reporting the cursor's current shape.
2.  **DECRQM Blinking Cursor Query (`CSI ?12$p`)**: Previously, this was hardcoded to always report "not blinking". It now correctly reports the cursor's actual blinking status.
3.  **DECSM Blinking Cursor Set/Reset (`CSI ?12h`/`l`)**: Adds support for applications to toggle the cursor between its blinking and steady variants at runtime, overriding the configured default for the current session.

The implementation follows the established architectural pattern of dispatching actions from the `Performer` to `perform_*` methods in `TerminalState` for clean separation of concerns.

**Follow-up Required:** The logic for resolving `CursorShape::Default` is currently commented out in both new query handlers. It needs to be connected to the main `wezterm_config` to dynamically query the user's `default_cursor_style`, especially to handle cases where the configuration is reloaded at runtime. A core developer with knowledge of the configuration-passing mechanism is best suited to complete this final step.