### PR TITLE
Implement get_semantic_zones() for ClientPane

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -34,7 +34,7 @@ use termwiz::image::{ImageData, TextureCoordinate};
 use termwiz::surface::{Line, SequenceNo};
 use thiserror::Error;
 use wezterm_term::color::ColorPalette;
-use wezterm_term::{Alert, ClipboardSelection, StableRowIndex, TerminalSize};
+use wezterm_term::{Alert, ClipboardSelection, SemanticZone, StableRowIndex, TerminalSize};
 
 #[derive(Error, Debug)]
 #[error("Corrupt Response: {0}")]
@@ -441,7 +441,7 @@ macro_rules! pdu {
 /// The overall version of the codec.
 /// This must be bumped when backwards incompatible changes
 /// are made to the types and protocol.
-pub const CODEC_VERSION: usize = 45;
+pub const CODEC_VERSION: usize = 46;
 
 // Defines the Pdu enum.
 // Each struct has an explicit identifying number.
@@ -502,6 +502,8 @@ pdu! {
     GetPaneDirection: 60,
     GetPaneDirectionResponse: 61,
     AdjustPaneSize: 62,
+    SemanticZonesRequest: 63,
+    SemanticZonesResponse: 64,
 }
 
 impl Pdu {
@@ -1113,6 +1115,16 @@ pub struct GetLinesResponse {
 pub struct EraseScrollbackRequest {
     pub pane_id: PaneId,
     pub erase_mode: ScrollbackEraseMode,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct SemanticZonesRequest {
+    pub pane_id: PaneId,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct SemanticZonesResponse {
+    pub results: Vec<SemanticZone>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/lua-api-crates/mux/src/pane.rs
+++ b/lua-api-crates/mux/src/pane.rs
@@ -302,23 +302,27 @@ impl UserData for MuxPane {
             Ok(())
         });
 
-        methods.add_method("get_semantic_zones", |lua, this, of_type: Value| {
-            let mux = get_mux()?;
-            let pane = this.resolve(&mux)?;
+        methods.add_async_method(
+            "get_semantic_zones",
+            |lua, this, of_type: Value| async move {
+                let mux = get_mux()?;
+                let pane = this.resolve(&mux)?;
 
-            let of_type: Option<SemanticType> = from_lua(of_type)?;
+                let of_type: Option<SemanticType> = from_lua(of_type)?;
 
-            let mut zones = pane
-                .get_semantic_zones()
-                .map_err(|e| mlua::Error::external(format!("{:#}", e)))?;
+                let mut zones = pane
+                    .get_semantic_zones()
+                    .await
+                    .map_err(|e| mlua::Error::external(format!("{:#}", e)))?;
 
-            if let Some(of_type) = of_type {
-                zones.retain(|zone| zone.semantic_type == of_type);
-            }
+                if let Some(of_type) = of_type {
+                    zones.retain(|zone| zone.semantic_type == of_type);
+                }
 
-            let zones = to_lua(lua, zones)?;
-            Ok(zones)
-        });
+                let zones = to_lua(lua, zones)?;
+                Ok(zones)
+            },
+        );
 
         methods.add_method(
             "get_semantic_zone_at",
@@ -326,7 +330,8 @@ impl UserData for MuxPane {
                 let mux = get_mux()?;
                 let pane = this.resolve(&mux)?;
 
-                let zones = pane.get_semantic_zones().unwrap_or_else(|_| vec![]);
+                let zones = smol::block_on(async { pane.get_semantic_zones().await })
+                    .unwrap_or_else(|_| vec![]);
 
                 fn find_zone(x: usize, y: StableRowIndex, zone: &SemanticZone) -> Ordering {
                     match zone.start_y.cmp(&y) {

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -638,7 +638,7 @@ impl Pane for LocalPane {
         }
     }
 
-    fn get_semantic_zones(&self) -> anyhow::Result<Vec<SemanticZone>> {
+    async fn get_semantic_zones(&self) -> anyhow::Result<Vec<SemanticZone>> {
         let mut term = self.terminal.lock();
         term.get_semantic_zones()
     }

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -309,7 +309,7 @@ pub trait Pane: Downcast + Send + Sync {
     }
 
     /// Retrieve the set of semantic zones
-    fn get_semantic_zones(&self) -> anyhow::Result<Vec<SemanticZone>> {
+    async fn get_semantic_zones(&self) -> anyhow::Result<Vec<SemanticZone>> {
         Ok(vec![])
     }
 

--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -1389,4 +1389,9 @@ impl Client {
         GetPaneDirectionResponse
     );
     rpc!(adjust_pane_size, AdjustPaneSize, UnitResponse);
+    rpc!(
+        get_semantic_zones,
+        SemanticZonesRequest,
+        SemanticZonesResponse
+    );
 }

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -27,8 +27,8 @@ use url::Url;
 use wezterm_dynamic::Value;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    Alert, Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, Progress, StableRowIndex,
-    TerminalConfiguration, TerminalSize,
+    Alert, Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, Progress, SemanticZone,
+    StableRowIndex, TerminalConfiguration, TerminalSize,
 };
 
 pub struct ClientPane {
@@ -423,6 +423,20 @@ impl Pane for ClientPane {
             inner.update_last_send();
         }
         Ok(())
+    }
+
+    async fn get_semantic_zones(&self) -> anyhow::Result<Vec<SemanticZone>> {
+        match self
+            .client
+            .client
+            .get_semantic_zones(SemanticZonesRequest {
+                pane_id: self.remote_pane_id,
+            })
+            .await
+        {
+            Ok(SemanticZonesResponse { results }) => Ok(results),
+            Err(e) => Err(e),
+        }
     }
 
     async fn search(

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -960,9 +960,7 @@ impl CopyRenderable {
             return;
         }
 
-        let zones = self
-            .delegate
-            .get_semantic_zones()
+        let zones = smol::block_on(async { self.delegate.get_semantic_zones().await })
             .unwrap_or_else(|_| vec![]);
         let mut idx = match zones.binary_search_by(|zone| {
             if zone.start_y == self.cursor.y {

--- a/wezterm-gui/src/selection.rs
+++ b/wezterm-gui/src/selection.rs
@@ -197,7 +197,7 @@ impl SelectionRange {
     }
 
     pub fn zone_around(start: SelectionCoordinate, pane: &dyn mux::pane::Pane) -> Self {
-        let zones = match pane.get_semantic_zones() {
+        let zones = match smol::block_on(async { pane.get_semantic_zones().await }) {
             Ok(z) => z,
             Err(_) => return Self { start, end: start },
         };

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2475,7 +2475,8 @@ impl TermWindow {
 
         let seqno = pane.get_current_seqno();
         if cache.seqno != seqno {
-            let zones = pane.get_semantic_zones().unwrap_or_else(|_| vec![]);
+            let zones = smol::block_on(async { pane.get_semantic_zones().await })
+                .unwrap_or_else(|_| vec![]);
             let mut zones: Vec<StableRowIndex> = zones
                 .into_iter()
                 .filter_map(|zone| {

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -508,7 +508,26 @@ impl SessionHandler {
                 })
                 .detach();
             }
+            Pdu::SemanticZonesRequest(SemanticZonesRequest { pane_id }) => {
+                async fn do_get_semantic_zones(pane_id: PaneId) -> anyhow::Result<Pdu> {
+                    let mux = Mux::get();
+                    let pane = mux
+                        .get_pane(pane_id)
+                        .ok_or_else(|| anyhow!("no such pane {}", pane_id))?;
+                    pane.get_semantic_zones().await.map(|results| {
+                        Pdu::SemanticZonesResponse(SemanticZonesResponse { results })
+                    })
+                }
 
+                spawn_into_main_thread(async move {
+                    promise::spawn::spawn(async move {
+                        let result = do_get_semantic_zones(pane_id).await;
+                        send_response(result);
+                    })
+                    .detach();
+                })
+                .detach();
+            }
             Pdu::SearchScrollbackRequest(SearchScrollbackRequest {
                 pane_id,
                 pattern,
@@ -1010,6 +1029,7 @@ impl SessionHandler {
             | Pdu::MovePaneToNewTabResponse { .. }
             | Pdu::TabAddedToWindow { .. }
             | Pdu::GetPaneRenderableDimensionsResponse { .. }
+            | Pdu::SemanticZonesResponse { .. }
             | Pdu::ErrorResponse { .. } => {
                 send_response(Err(anyhow!("expected a request, got {:?}", decoded.pdu)))
             }


### PR DESCRIPTION
By adding a new request and response we can query the remote terminal
for its semantic zones. Thus handy features like the ScrollToPrompt and
CopyMode actions work as expected in other domains than the local
domain.

Fixes #5141

---------------------------------------------------

I implemented this fairly quickly buy just basing it on the patterns in
surrouding code, and it seems to work exactly as I had hoped. Some
concerns/points:

- As far as I can tell the RPC stuff needs to be `async` functions while
  `get_semantic_zones()` from the `Pane` trait is not. I worked around this by
  using `smol::block_on()`. I see that is used many places in the code base but I'm
  not sure it's acceptable here. An alternative is to make the function `async`
  in the trait, but that seemed messy for other reasons.
- I couldn't find any places to add a test for this.
- There is no new documentation. Imo. that's justified as I am making an
  existing feature work in more contexts which the existing documentation did
  not clarify that it _didn't_ work.
