### PR TITLE
Update char_select_fg_color.md

### DIFF
--- a/docs/config/lua/config/char_select_fg_color.md
+++ b/docs/config/lua/config/char_select_fg_color.md
@@ -4,7 +4,7 @@ tags:
   - char_select
   - color
 ---
-# `char_select_fg_color = rgba(0.75, 0.75, 0.75, 1.0)`
+# `char_select_fg_color = "rgba(0.75, 0.75, 0.75, 1.0)"`
 
 {{since('20230712-072601-f4abf8fd')}}
 


### PR DESCRIPTION
While configuring WezTerm, I ran into the following issue:

```console
runtime error: $HOME/.config/wezterm/appearance.lua:32: attempt to
call a nil value (global 'rgba')
stack traceback:
        $HOME/.config/wezterm/appearance.lua:32: in function
'appearance.display'
        [string "$HOME/.config/wezterm/wezterm.lua"]:17: in main chunk
```

I had just copied the config [here](https://wezterm.org/config/lua/config/char_select_fg_color.html) which was:

```lua
config.char_select_fg_color = rgba(0.75, 0.75, 0.75, 1.0)
```

but I kept getting the same error regardless how I changed the value. I tried changing it to:

```lua
wezterm.config.char_select_fg_color = rgba(0.75, 0.75, 0.75, 1.0)
```

but it was still throwing the same error. I then tried wrapping it in quotes and it somehow worked:

```lua
config.char_select_fg_color = "rgba(0.75, 0.75, 0.75, 1.0)"
```

I have read the contributing guidelines and for a small fix I did not write any tests for it.