### PR TITLE
tmux-CC: suppress capability handshakes in control mode

### DIFF
--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -52,6 +52,155 @@ pub(crate) struct TmuxRemotePane {
 
 pub(crate) type RefTmuxRemotePane = Arc<Mutex<TmuxRemotePane>>;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HandshakeMatch {
+    Complete(usize),
+    Incomplete,
+    None,
+}
+
+fn osc_body_len(data: &[u8]) -> Option<usize> {
+    for (idx, byte) in data.iter().enumerate() {
+        match byte {
+            0x07 => return Some(idx + 1),
+            0x1b if data.get(idx + 1) == Some(&b'\\') => return Some(idx + 2),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn csi_body_len(data: &[u8]) -> Option<(usize, u8)> {
+    for (idx, byte) in data.iter().enumerate() {
+        if (0x40..=0x7e).contains(byte) {
+            return Some((idx, *byte));
+        }
+    }
+    None
+}
+
+fn first_numeric_param(data: &[u8]) -> Option<u16> {
+    let mut value = 0u16;
+    let mut seen_digit = false;
+    for &byte in data {
+        if byte == b';' {
+            break;
+        }
+        if byte.is_ascii_digit() {
+            seen_digit = true;
+            value = value
+                .saturating_mul(10)
+                .saturating_add((byte - b'0') as u16);
+        } else {
+            return None;
+        }
+    }
+    seen_digit.then_some(value)
+}
+
+fn classify_osc(bytes: &[u8]) -> HandshakeMatch {
+    if bytes.len() < 2 || bytes[0] != 0x1b || bytes[1] != b']' {
+        return HandshakeMatch::None;
+    }
+    let body = match bytes.get(2..) {
+        Some(body) => body,
+        None => return HandshakeMatch::Incomplete,
+    };
+    if !(body.starts_with(b"10;") || body.starts_with(b"11;") || body.starts_with(b"12;")) {
+        return HandshakeMatch::None;
+    }
+    match osc_body_len(body) {
+        Some(len) => HandshakeMatch::Complete(2 + len),
+        None => HandshakeMatch::Incomplete,
+    }
+}
+
+fn is_device_attributes(params: &[u8], final_byte: u8) -> bool {
+    final_byte == b'c'
+        && params
+            .first()
+            .map(|b| matches!(*b, b'?' | b'>' | b'='))
+            .unwrap_or(false)
+}
+
+fn is_geometry_report(params: &[u8], final_byte: u8) -> bool {
+    if final_byte != b't' {
+        return false;
+    }
+    matches!(first_numeric_param(params), Some(4 | 8 | 14 | 16))
+}
+
+fn classify_csi(bytes: &[u8]) -> HandshakeMatch {
+    if bytes.len() < 3 || bytes[0] != 0x1b || bytes[1] != b'[' {
+        return HandshakeMatch::None;
+    }
+    let data = &bytes[2..];
+    if data.is_empty() {
+        return HandshakeMatch::Incomplete;
+    }
+    let (body_len, final_byte) = match csi_body_len(data) {
+        Some(res) => res,
+        None => return HandshakeMatch::Incomplete,
+    };
+    let params = &data[..body_len];
+    if is_device_attributes(params, final_byte) || is_geometry_report(params, final_byte) {
+        HandshakeMatch::Complete(2 + body_len + 1)
+    } else {
+        HandshakeMatch::None
+    }
+}
+
+fn is_tmux_passthru_dcs(body: &[u8]) -> bool {
+    body.starts_with(b"tmux;")
+}
+
+fn classify_dcs(bytes: &[u8]) -> HandshakeMatch {
+    if bytes.len() < 3 || bytes[0] != 0x1b || bytes[1] != b'P' {
+        return HandshakeMatch::None;
+    }
+    let mut idx = 2;
+    while idx < bytes.len() {
+        match bytes[idx] {
+            0x07 => {
+                let body = &bytes[2..idx];
+                return if is_tmux_passthru_dcs(body) {
+                    HandshakeMatch::Complete(idx + 1)
+                } else {
+                    HandshakeMatch::None
+                };
+            }
+            0x1b => {
+                if idx + 1 >= bytes.len() {
+                    return HandshakeMatch::Incomplete;
+                }
+                if bytes[idx + 1] == b'\\' {
+                    let body = &bytes[2..idx];
+                    return if is_tmux_passthru_dcs(body) {
+                        HandshakeMatch::Complete(idx + 2)
+                    } else {
+                        HandshakeMatch::None
+                    };
+                }
+                idx += 1;
+            }
+            _ => idx += 1,
+        }
+    }
+    HandshakeMatch::Incomplete
+}
+
+pub(crate) fn classify_handshake_sequence(bytes: &[u8]) -> HandshakeMatch {
+    if bytes.len() < 2 || bytes[0] != 0x1b {
+        return HandshakeMatch::None;
+    }
+    match bytes[1] {
+        b']' => classify_osc(bytes),
+        b'[' => classify_csi(bytes),
+        b'P' => classify_dcs(bytes),
+        _ => HandshakeMatch::None,
+    }
+}
+
 /// As a remote TmuxTab, keeping the TmuxPanes ID
 /// within the remote tab.
 #[allow(dead_code)]
@@ -77,6 +226,7 @@ pub(crate) struct TmuxDomainState {
     pub attach_state: Mutex<AttachState>,
     pending_splits: Mutex<VecDeque<promise::Promise<TmuxPaneId>>>,
     pub backlog: Mutex<HashMap<TmuxPaneId, Vec<u8>>>,
+    pub handshake_buffers: Mutex<HashMap<TmuxPaneId, Vec<u8>>>,
     pub window_order: Mutex<Vec<TmuxWindowId>>,
 }
 
@@ -85,6 +235,44 @@ pub struct TmuxDomain {
 }
 
 impl TmuxDomainState {
+    fn strip_handshake_sequences(&self, pane: TmuxPaneId, text: &[u8]) -> Vec<u8> {
+        let mut buffers = self.handshake_buffers.lock();
+        let output = {
+            let buffer = buffers.entry(pane).or_insert_with(Vec::new);
+            buffer.extend_from_slice(text);
+
+            let mut output = Vec::new();
+            let mut processed = 0usize;
+            while processed < buffer.len() {
+                match classify_handshake_sequence(&buffer[processed..]) {
+                    HandshakeMatch::Complete(len) => {
+                        processed += len;
+                    }
+                    HandshakeMatch::Incomplete => break,
+                    HandshakeMatch::None => {
+                        output.push(buffer[processed]);
+                        processed += 1;
+                    }
+                }
+            }
+
+            if processed > 0 {
+                buffer.drain(..processed);
+            }
+            output
+        };
+
+        if buffers
+            .get(&pane)
+            .map(|buf| buf.is_empty())
+            .unwrap_or(false)
+        {
+            buffers.remove(&pane);
+        }
+
+        output
+    }
+
     pub fn reconcile_tab_order(&self, local_window_id: WindowId) {
         if *self.attach_state.lock() != AttachState::Done {
             return;
@@ -159,11 +347,8 @@ impl TmuxDomainState {
 
         {
             let mut queue = self.cmd_queue.lock();
-            for (src, dst) in &ops {
-                queue.push_back(Box::new(SwapWindow {
-                    src: *src,
-                    dst: *dst,
-                }));
+            for (src, dst) in ops {
+                queue.push_back(Box::new(SwapWindow { src, dst }));
             }
         }
 
@@ -246,16 +431,21 @@ impl TmuxDomainState {
                     }));
                 }
                 Event::Output { pane, text } => {
+                    let filtered = self.strip_handshake_sequences(*pane, text);
+                    if filtered.is_empty() {
+                        continue;
+                    }
+
                     let pane_map = self.remote_panes.lock();
                     if let Some(ref_pane) = pane_map.get(pane) {
                         let mut tmux_pane = ref_pane.lock();
-                        if let Err(err) = tmux_pane.output_write.write_all(text) {
+                        if let Err(err) = tmux_pane.output_write.write_all(&filtered) {
                             log::error!("Failed to write tmux data to output: {:#}", err);
                         }
                     } else {
                         // the output may come early then pane is ready, in this case we
                         // backlog it
-                        self.backlog.lock().insert(*pane, text.to_vec());
+                        self.backlog.lock().insert(*pane, filtered);
                         log::debug!("Tmux pane {} havn't been attached", pane);
                     }
                 }
@@ -445,6 +635,7 @@ impl TmuxDomain {
             attach_state: Mutex::new(AttachState::Init),
             pending_splits: Mutex::new(VecDeque::default()),
             backlog: Mutex::new(HashMap::default()),
+            handshake_buffers: Mutex::new(HashMap::default()),
             window_order: Mutex::new(Vec::new()),
         });
 

--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -59,6 +59,7 @@ pub(crate) struct TmuxTab {
     pub tab_id: TabId, // local tab ID
     pub tmux_window_id: TmuxWindowId,
     pub layout_csum: String,
+    pub title: String,
     pub panes: HashSet<TmuxPaneId>, // tmux panes within tmux window
 }
 
@@ -212,11 +213,20 @@ impl TmuxDomainState {
                     log::info!("tmux window pane changed: {}:{}", window, pane);
                 }
                 Event::WindowRenamed { window, name } => {
-                    let gui_tabs = self.gui_tabs.lock();
-                    if let Some(x) = gui_tabs.get(&window) {
+                    let title = format!("{}", name);
+                    let tab_id = {
+                        let mut gui_tabs = self.gui_tabs.lock();
+                        gui_tabs
+                            .get_mut(&window)
+                            .map(|tab| {
+                                tab.title = title.clone();
+                                tab.tab_id
+                            })
+                    };
+                    if let Some(tab_id) = tab_id {
                         let mux = Mux::get();
-                        if let Some(tab) = mux.get_tab(x.tab_id) {
-                            tab.set_title(&format!("{}", name));
+                        if let Some(tab) = mux.get_tab(tab_id) {
+                            tab.set_title(&title);
                         }
                     }
                 }

--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -3,7 +3,7 @@ use crate::domain::{alloc_domain_id, Domain, DomainId, DomainState, SplitSource}
 use crate::pane::{Pane, PaneId};
 use crate::tab::{SplitRequest, Tab, TabId};
 use crate::tmux_commands::{
-    ListAllPanes, ListAllWindows, ListCommands, NewWindow, SplitPane, TmuxCommand,
+    ListAllPanes, ListAllWindows, ListCommands, NewWindow, SplitPane, SwapWindow, TmuxCommand,
 };
 use crate::window::WindowId;
 use crate::{Mux, MuxWindowBuilder};
@@ -77,6 +77,7 @@ pub(crate) struct TmuxDomainState {
     pub attach_state: Mutex<AttachState>,
     pending_splits: Mutex<VecDeque<promise::Promise<TmuxPaneId>>>,
     pub backlog: Mutex<HashMap<TmuxPaneId, Vec<u8>>>,
+    pub window_order: Mutex<Vec<TmuxWindowId>>,
 }
 
 pub struct TmuxDomain {
@@ -84,6 +85,92 @@ pub struct TmuxDomain {
 }
 
 impl TmuxDomainState {
+    pub fn reconcile_tab_order(&self, local_window_id: WindowId) {
+        if *self.attach_state.lock() != AttachState::Done {
+            return;
+        }
+
+        let mux = Mux::get();
+
+        let desired: Vec<TmuxWindowId> = {
+            let Some(window) = mux.get_window(local_window_id) else {
+                return;
+            };
+
+            let gui_tabs = self.gui_tabs.lock();
+            if gui_tabs.is_empty() {
+                return;
+            }
+            let mut tab_to_window = HashMap::new();
+            for (window_id, tab) in gui_tabs.iter() {
+                tab_to_window.insert(tab.tab_id, *window_id);
+            }
+            drop(gui_tabs);
+
+            window
+                .iter()
+                .filter_map(|tab| tab_to_window.get(&tab.tab_id()).copied())
+                .collect()
+        };
+
+        if desired.len() <= 1 {
+            *self.window_order.lock() = desired;
+            return;
+        }
+
+        let mut current = {
+            let order = self.window_order.lock();
+            if order.is_empty() {
+                desired.clone()
+            } else {
+                order.clone()
+            }
+        };
+
+        if current == desired {
+            return;
+        }
+
+        if current.len() != desired.len() {
+            *self.window_order.lock() = desired;
+            return;
+        }
+
+        let mut ops = Vec::new();
+        for i in 0..desired.len() {
+            if current[i] == desired[i] {
+                continue;
+            }
+            if let Some(j) = (i + 1..current.len()).find(|&j| current[j] == desired[i]) {
+                let src = current[i];
+                let dst = current[j];
+                ops.push((src, dst));
+                current.swap(i, j);
+            } else {
+                *self.window_order.lock() = desired;
+                return;
+            }
+        }
+
+        if ops.is_empty() {
+            *self.window_order.lock() = desired;
+            return;
+        }
+
+        {
+            let mut queue = self.cmd_queue.lock();
+            for (src, dst) in &ops {
+                queue.push_back(Box::new(SwapWindow {
+                    src: *src,
+                    dst: *dst,
+                }));
+            }
+        }
+
+        TmuxDomainState::schedule_send_next_command(self.domain_id);
+        *self.window_order.lock() = desired;
+    }
+
     pub fn advance(&self, events: Box<Vec<Event>>) {
         for event in events.iter() {
             let state = *self.state.lock();
@@ -216,12 +303,10 @@ impl TmuxDomainState {
                     let title = format!("{}", name);
                     let tab_id = {
                         let mut gui_tabs = self.gui_tabs.lock();
-                        gui_tabs
-                            .get_mut(&window)
-                            .map(|tab| {
-                                tab.title = title.clone();
-                                tab.tab_id
-                            })
+                        gui_tabs.get_mut(&window).map(|tab| {
+                            tab.title = title.clone();
+                            tab.tab_id
+                        })
                     };
                     if let Some(tab_id) = tab_id {
                         let mux = Mux::get();
@@ -360,6 +445,7 @@ impl TmuxDomain {
             attach_state: Mutex::new(AttachState::Init),
             pending_splits: Mutex::new(VecDeque::default()),
             backlog: Mutex::new(HashMap::default()),
+            window_order: Mutex::new(Vec::new()),
         });
 
         Self { inner }

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -170,9 +170,11 @@ impl TmuxDomainState {
         mux.remove_tab(tab.tab_id);
 
         let mut pane_map = self.remote_panes.lock();
+        let mut handshake = self.handshake_buffers.lock();
         let mut backlog = self.backlog.lock();
         for pane_id in &tab.panes {
             pane_map.remove(pane_id);
+            handshake.remove(pane_id);
             backlog.remove(pane_id);
         }
         self.window_order.lock().retain(|id| *id != window_id);

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -17,6 +17,22 @@ use termwiz::escape::{Action, OneBased};
 use termwiz::tmux_cc::*;
 use wezterm_term::TerminalSize;
 
+fn tmux_quote(name: &str) -> String {
+    let mut quoted = String::with_capacity(name.len() + 2);
+    quoted.push('"');
+    for ch in name.chars() {
+        match ch {
+            '\\' | '"' => {
+                quoted.push('\\');
+                quoted.push(ch);
+            }
+            _ => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    quoted
+}
+
 pub(crate) trait TmuxCommand: Send + Debug {
     fn get_command(&self, domain_id: DomainId) -> String;
     fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()>;
@@ -93,17 +109,19 @@ impl TmuxDomainState {
 
     fn add_attached_window(&self, target: &WindowItem, tab_id: &TabId) -> anyhow::Result<()> {
         let mut gui_tabs = self.gui_tabs.lock();
-        if !gui_tabs.contains_key(&target.window_id) {
-            gui_tabs.insert(
-                target.window_id,
-                TmuxTab {
-                    tab_id: *tab_id,
-                    tmux_window_id: target.window_id,
-                    layout_csum: target.layout_csum.clone(),
-                    panes: HashSet::new(),
-                },
-            );
-        }
+        gui_tabs
+            .entry(target.window_id)
+            .and_modify(|tab| {
+                tab.layout_csum = target.layout_csum.clone();
+                tab.title = target.window_name.clone();
+            })
+            .or_insert_with(|| TmuxTab {
+                tab_id: *tab_id,
+                tmux_window_id: target.window_id,
+                layout_csum: target.layout_csum.clone(),
+                title: target.window_name.clone(),
+                panes: HashSet::new(),
+            });
 
         Ok(())
     }
@@ -588,6 +606,36 @@ impl TmuxDomainState {
                             TmuxDomainState::schedule_send_next_command(domain_id);
                         }
                     }
+                    MuxNotification::TabTitleChanged { tab_id, title } => {
+                        let rename = {
+                            let mut gui_tabs = tmux_domain.inner.gui_tabs.lock();
+                            gui_tabs
+                                .iter_mut()
+                                .find_map(|(window_id, tab)| {
+                                    if tab.tab_id == tab_id {
+                                        if tab.title == title {
+                                            None
+                                        } else {
+                                            tab.title = title.clone();
+                                            Some((*window_id, title.clone()))
+                                        }
+                                    } else {
+                                        None
+                                    }
+                                })
+                        };
+                        if let Some((window_id, title)) = rename {
+                            tmux_domain
+                                .inner
+                                .cmd_queue
+                                .lock()
+                                .push_back(Box::new(RenameWindow {
+                                    window_id,
+                                    name: title,
+                                }));
+                            TmuxDomainState::schedule_send_next_command(domain_id);
+                        }
+                    }
                     MuxNotification::WindowInvalidated(window_id) => {
                         if let Some(window) = mux.get_window(window_id) {
                             let Some(tab) = window.get_active() else {
@@ -1030,6 +1078,31 @@ impl TmuxCommand for SendKeys {
     fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
         if result.error {
             let error = format!("send-key in domain={domain_id} failed: {result:#?}");
+            log::error!("{error}");
+            anyhow::bail!("{error}");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RenameWindow {
+    pub window_id: TmuxWindowId,
+    pub name: String,
+}
+
+impl TmuxCommand for RenameWindow {
+    fn get_command(&self, _domain_id: DomainId) -> String {
+        format!(
+            "rename-window -t %{} {}\n",
+            self.window_id,
+            tmux_quote(&self.name)
+        )
+    }
+
+    fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
+        if result.error {
+            let error = format!("rename-window in domain={domain_id} failed: {result:#?}");
             log::error!("{error}");
             anyhow::bail!("{error}");
         }

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -1125,6 +1125,48 @@ impl TmuxCommand for RenameWindow {
 }
 
 #[derive(Debug)]
+pub(crate) struct SendPaneReport {
+    pub pane: TmuxPaneId,
+    pub report: Vec<u8>,
+}
+
+impl TmuxCommand for SendPaneReport {
+    fn get_command(&self, _domain_id: DomainId) -> String {
+        let mut s = String::new();
+        write!(&mut s, "refresh-client -r \"%%{}:", self.pane).unwrap();
+        escape_bytes_for_tmux(&mut s, &self.report);
+        s.push_str("\"\r");
+        s
+    }
+
+    fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
+        if result.error {
+            let error = format!(
+                "refresh-client -r in domain={domain_id} failed: {result:#?}"
+            );
+            log::error!("{error}");
+            anyhow::bail!("{error}");
+        }
+        Ok(())
+    }
+}
+
+fn escape_bytes_for_tmux(dest: &mut String, data: &[u8]) {
+    for &byte in data {
+        match byte {
+            0..=31 => {
+                write!(dest, "\\{:03o}", byte).expect("write! to string cannot fail");
+            }
+            b'\\' | b'"' => {
+                dest.push('\\');
+                dest.push(byte as char);
+            }
+            _ => dest.push(byte as char),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub(crate) struct SwapWindow {
     pub src: TmuxWindowId,
     pub dst: TmuxWindowId,

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -114,6 +114,7 @@ impl TmuxDomainState {
             .and_modify(|tab| {
                 tab.layout_csum = target.layout_csum.clone();
                 tab.title = target.window_name.clone();
+                tab.tab_id = *tab_id;
             })
             .or_insert_with(|| TmuxTab {
                 tab_id: *tab_id,
@@ -161,16 +162,20 @@ impl TmuxDomainState {
 
     pub fn remove_detached_window(&self, window_id: TmuxWindowId) -> anyhow::Result<()> {
         let mut gui_tabs = self.gui_tabs.lock();
-        let tab = match gui_tabs.get(&window_id) {
-            Some(x) => x,
-            None => {
-                anyhow::bail!("Cannot find the window {window_id}")
-            }
+        let Some(tab) = gui_tabs.remove(&window_id) else {
+            anyhow::bail!("Cannot find the window {window_id}")
         };
 
         let mux = Mux::get();
         mux.remove_tab(tab.tab_id);
-        gui_tabs.remove(&window_id);
+
+        let mut pane_map = self.remote_panes.lock();
+        let mut backlog = self.backlog.lock();
+        for pane_id in &tab.panes {
+            pane_map.remove(pane_id);
+            backlog.remove(pane_id);
+        }
+        self.window_order.lock().retain(|id| *id != window_id);
 
         Ok(())
     }
@@ -379,6 +384,8 @@ impl TmuxDomainState {
         };
         let mux = Mux::get();
 
+        let mut new_order = Vec::new();
+
         self.create_gui_window();
         let mut gui_window = self.gui_window.lock();
         let gui_window_id = match gui_window.as_mut() {
@@ -392,6 +399,8 @@ impl TmuxDomainState {
             if window.session_id != current_session {
                 continue;
             }
+
+            new_order.push(window.window_id);
 
             let size = TerminalSize {
                 rows: window.window_height as usize,
@@ -544,6 +553,10 @@ impl TmuxDomainState {
             }
         }
 
+        if !new_order.is_empty() {
+            *self.window_order.lock() = new_order;
+        }
+
         // To keep the active window last one to make it active after set the focus pane
         match windows.iter().find(|w| w.window_active) {
             Some(window) => {
@@ -609,20 +622,18 @@ impl TmuxDomainState {
                     MuxNotification::TabTitleChanged { tab_id, title } => {
                         let rename = {
                             let mut gui_tabs = tmux_domain.inner.gui_tabs.lock();
-                            gui_tabs
-                                .iter_mut()
-                                .find_map(|(window_id, tab)| {
-                                    if tab.tab_id == tab_id {
-                                        if tab.title == title {
-                                            None
-                                        } else {
-                                            tab.title = title.clone();
-                                            Some((*window_id, title.clone()))
-                                        }
-                                    } else {
+                            gui_tabs.iter_mut().find_map(|(window_id, tab)| {
+                                if tab.tab_id == tab_id {
+                                    if tab.title == title {
                                         None
+                                    } else {
+                                        tab.title = title.clone();
+                                        Some((*window_id, title.clone()))
                                     }
-                                })
+                                } else {
+                                    None
+                                }
+                            })
                         };
                         if let Some((window_id, title)) = rename {
                             tmux_domain
@@ -660,6 +671,7 @@ impl TmuxDomainState {
                                 TmuxDomainState::schedule_send_next_command(domain_id);
                             }
                         }
+                        tmux_domain.inner.reconcile_tab_order(window_id);
                     }
                     _ => {}
                 }
@@ -1103,6 +1115,27 @@ impl TmuxCommand for RenameWindow {
     fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
         if result.error {
             let error = format!("rename-window in domain={domain_id} failed: {result:#?}");
+            log::error!("{error}");
+            anyhow::bail!("{error}");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SwapWindow {
+    pub src: TmuxWindowId,
+    pub dst: TmuxWindowId,
+}
+
+impl TmuxCommand for SwapWindow {
+    fn get_command(&self, _domain_id: DomainId) -> String {
+        format!("swap-window -s %{} -t %{}\n", self.src, self.dst)
+    }
+
+    fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
+        if result.error {
+            let error = format!("swap-window in domain={domain_id} failed: {result:#?}");
             log::error!("{error}");
             anyhow::bail!("{error}");
         }

--- a/mux/src/tmux_pty.rs
+++ b/mux/src/tmux_pty.rs
@@ -6,9 +6,9 @@ use crate::DomainId;
 use filedescriptor::FileDescriptor;
 use parking_lot::{Condvar, Mutex};
 use portable_pty::{Child, ChildKiller, ExitStatus, MasterPty};
-use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::sync::Arc;
+use termwiz::tmux_cc::TmuxPaneId;
 
 fn queue_send_keys(
     domain_id: DomainId,
@@ -16,56 +16,113 @@ fn queue_send_keys(
     cmd_queue: &Arc<Mutex<TmuxCmdQueue>>,
     buf: &[u8],
 ) -> std::io::Result<usize> {
-    let wrapped_handshake = maybe_wrap_tmux_passthrough(buf);
-
     let pane_id = {
         let pane_lock = master_pane.lock();
         pane_lock.pane_id
     };
-    let content: Cow<[u8]> = match wrapped_handshake {
-        Some(vec) => Cow::Owned(vec),
-        None => Cow::Borrowed(buf),
-    };
-    log::trace!("pane:{}, content:{:?}", &pane_id, content.as_ref());
+
+    if maybe_queue_tmux_report(domain_id, pane_id, cmd_queue, buf) {
+        return Ok(buf.len());
+    }
+
+    log::trace!("pane:{}, content:{:?}", &pane_id, buf);
     let mut queue = cmd_queue.lock();
     queue.push_back(Box::new(SendKeys {
         pane: pane_id,
-        keys: content.into_owned(),
+        keys: buf.to_vec(),
     }));
     TmuxDomainState::schedule_send_next_command(domain_id);
     Ok(0)
 }
 
-fn maybe_wrap_tmux_passthrough(buf: &[u8]) -> Option<Vec<u8>> {
+fn maybe_queue_tmux_report(
+    domain_id: DomainId,
+    pane_id: TmuxPaneId,
+    cmd_queue: &Arc<Mutex<TmuxCmdQueue>>,
+    buf: &[u8],
+) -> bool {
     match classify_handshake_sequence(buf) {
-        HandshakeMatch::Complete(len) if len == buf.len() => {
-            if buf.starts_with(b"\x1bPtmux;") {
-                None
-            } else {
-                log::trace!("wrapping tmux control handshake payload: {:?}", buf);
-                Some(wrap_in_tmux_passthrough(buf))
-            }
+        HandshakeMatch::Complete(len) if len == buf.len() && is_handshake_response(buf) => {
+            log::trace!(
+                "queuing tmux control report for pane {} with payload {:?}",
+                pane_id,
+                buf
+            );
+            let mut queue = cmd_queue.lock();
+            queue.push_back(Box::new(crate::tmux_commands::SendPaneReport {
+                pane: pane_id,
+                report: buf.to_vec(),
+            }));
+            TmuxDomainState::schedule_send_next_command(domain_id);
+            true
         }
-        _ => None,
+        _ => false,
     }
 }
 
-fn wrap_in_tmux_passthrough(payload: &[u8]) -> Vec<u8> {
-    const PREFIX: &[u8] = b"\x1bPtmux;";
-    const SUFFIX: &[u8] = b"\x1b\\";
-    let mut wrapped = Vec::with_capacity(PREFIX.len() + payload.len() * 2 + SUFFIX.len());
-    wrapped.extend_from_slice(PREFIX);
-    for &byte in payload {
-        // Each ESC inside the passthrough body must be doubled so tmux forwards a single ESC.
-        if byte == 0x1b {
-            wrapped.push(0x1b);
-            wrapped.push(0x1b);
-        } else {
-            wrapped.push(byte);
+fn is_handshake_response(buf: &[u8]) -> bool {
+    if buf.len() < 2 || buf[0] != 0x1b {
+        return false;
+    }
+    match buf[1] {
+        b']' => osc_is_response(buf),
+        b'[' => csi_is_response(buf),
+        _ => false,
+    }
+}
+
+fn osc_is_response(buf: &[u8]) -> bool {
+    let body = match extract_osc_body(buf) {
+        Some(body) => body,
+        None => return false,
+    };
+
+    let is_color_query = body.starts_with(b"10;") || body.starts_with(b"11;") || body.starts_with(b"12;");
+    if !is_color_query {
+        return false;
+    }
+
+    let after_semicolon = match body.iter().position(|&b| b == b';') {
+        Some(idx) if idx + 1 < body.len() => &body[idx + 1..],
+        _ => return false,
+    };
+
+    match after_semicolon.first() {
+        Some(b'?') | None => false,
+        _ => true,
+    }
+}
+
+fn extract_osc_body(buf: &[u8]) -> Option<&[u8]> {
+    if buf.len() < 3 || buf[0] != 0x1b || buf[1] != b']' {
+        return None;
+    }
+    let mut idx = 2;
+    while idx < buf.len() {
+        match buf[idx] {
+            0x07 => return Some(&buf[2..idx]),
+            0x1b if idx + 1 < buf.len() && buf[idx + 1] == b'\\' => return Some(&buf[2..idx]),
+            _ => idx += 1,
         }
     }
-    wrapped.extend_from_slice(SUFFIX);
-    wrapped
+    None
+}
+
+fn csi_is_response(buf: &[u8]) -> bool {
+    if buf.len() < 3 || buf[0] != 0x1b || buf[1] != b'[' {
+        return false;
+    }
+    let data = &buf[2..];
+    if data.is_empty() {
+        return false;
+    }
+    let final_byte = *data.last().unwrap();
+    let params = &data[..data.len() - 1];
+
+    match final_byte {
+        b'c' | b't' => params.contains(&b';'),
+        _ => false,
+    }
 }
 
 /// A local tmux pane(tab) based on a tmux pty

--- a/mux/src/tmux_pty.rs
+++ b/mux/src/tmux_pty.rs
@@ -1,4 +1,6 @@
-use crate::tmux::{RefTmuxRemotePane, TmuxCmdQueue, TmuxDomainState};
+use crate::tmux::{
+    classify_handshake_sequence, HandshakeMatch, RefTmuxRemotePane, TmuxCmdQueue, TmuxDomainState,
+};
 use crate::tmux_commands::{Resize, SendKeys};
 use crate::DomainId;
 use filedescriptor::FileDescriptor;
@@ -6,6 +8,35 @@ use parking_lot::{Condvar, Mutex};
 use portable_pty::{Child, ChildKiller, ExitStatus, MasterPty};
 use std::io::{Read, Write};
 use std::sync::Arc;
+
+fn queue_send_keys(
+    domain_id: DomainId,
+    master_pane: &RefTmuxRemotePane,
+    cmd_queue: &Arc<Mutex<TmuxCmdQueue>>,
+    buf: &[u8],
+) -> std::io::Result<usize> {
+    if should_suppress_tmux_handshake(buf) {
+        log::trace!("suppressing tmux control handshake payload: {:?}", buf);
+        return Ok(0);
+    }
+
+    let pane_id = {
+        let pane_lock = master_pane.lock();
+        pane_lock.pane_id
+    };
+    log::trace!("pane:{}, content:{:?}", &pane_id, buf);
+    let mut queue = cmd_queue.lock();
+    queue.push_back(Box::new(SendKeys {
+        pane: pane_id,
+        keys: buf.to_vec(),
+    }));
+    TmuxDomainState::schedule_send_next_command(domain_id);
+    Ok(0)
+}
+
+fn should_suppress_tmux_handshake(buf: &[u8]) -> bool {
+    matches!(classify_handshake_sequence(buf), HandshakeMatch::Complete(len) if len == buf.len())
+}
 
 /// A local tmux pane(tab) based on a tmux pty
 #[derive(Debug)]
@@ -24,18 +55,7 @@ struct TmuxPtyWriter {
 
 impl Write for TmuxPtyWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let pane_id = {
-            let pane_lock = self.master_pane.lock();
-            pane_lock.pane_id
-        };
-        log::trace!("pane:{}, content:{:?}", &pane_id, buf);
-        let mut cmd_queue = self.cmd_queue.lock();
-        cmd_queue.push_back(Box::new(SendKeys {
-            pane: pane_id,
-            keys: buf.to_vec(),
-        }));
-        TmuxDomainState::schedule_send_next_command(self.domain_id);
-        Ok(0)
+        queue_send_keys(self.domain_id, &self.master_pane, &self.cmd_queue, buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
@@ -45,18 +65,7 @@ impl Write for TmuxPtyWriter {
 
 impl Write for TmuxPty {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let pane_id = {
-            let pane_lock = self.master_pane.lock();
-            pane_lock.pane_id
-        };
-        log::trace!("pane:{}, content:{:?}", &pane_id, buf);
-        let mut cmd_queue = self.cmd_queue.lock();
-        cmd_queue.push_back(Box::new(SendKeys {
-            pane: pane_id,
-            keys: buf.to_vec(),
-        }));
-        TmuxDomainState::schedule_send_next_command(self.domain_id);
-        Ok(0)
+        queue_send_keys(self.domain_id, &self.master_pane, &self.cmd_queue, buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {

--- a/mux/src/tmux_pty.rs
+++ b/mux/src/tmux_pty.rs
@@ -6,6 +6,7 @@ use crate::DomainId;
 use filedescriptor::FileDescriptor;
 use parking_lot::{Condvar, Mutex};
 use portable_pty::{Child, ChildKiller, ExitStatus, MasterPty};
+use std::borrow::Cow;
 use std::io::{Read, Write};
 use std::sync::Arc;
 
@@ -15,27 +16,56 @@ fn queue_send_keys(
     cmd_queue: &Arc<Mutex<TmuxCmdQueue>>,
     buf: &[u8],
 ) -> std::io::Result<usize> {
-    if should_suppress_tmux_handshake(buf) {
-        log::trace!("suppressing tmux control handshake payload: {:?}", buf);
-        return Ok(0);
-    }
+    let wrapped_handshake = maybe_wrap_tmux_passthrough(buf);
 
     let pane_id = {
         let pane_lock = master_pane.lock();
         pane_lock.pane_id
     };
-    log::trace!("pane:{}, content:{:?}", &pane_id, buf);
+    let content: Cow<[u8]> = match wrapped_handshake {
+        Some(vec) => Cow::Owned(vec),
+        None => Cow::Borrowed(buf),
+    };
+    log::trace!("pane:{}, content:{:?}", &pane_id, content.as_ref());
     let mut queue = cmd_queue.lock();
     queue.push_back(Box::new(SendKeys {
         pane: pane_id,
-        keys: buf.to_vec(),
+        keys: content.into_owned(),
     }));
     TmuxDomainState::schedule_send_next_command(domain_id);
     Ok(0)
 }
 
-fn should_suppress_tmux_handshake(buf: &[u8]) -> bool {
-    matches!(classify_handshake_sequence(buf), HandshakeMatch::Complete(len) if len == buf.len())
+fn maybe_wrap_tmux_passthrough(buf: &[u8]) -> Option<Vec<u8>> {
+    match classify_handshake_sequence(buf) {
+        HandshakeMatch::Complete(len) if len == buf.len() => {
+            if buf.starts_with(b"\x1bPtmux;") {
+                None
+            } else {
+                log::trace!("wrapping tmux control handshake payload: {:?}", buf);
+                Some(wrap_in_tmux_passthrough(buf))
+            }
+        }
+        _ => None,
+    }
+}
+
+fn wrap_in_tmux_passthrough(payload: &[u8]) -> Vec<u8> {
+    const PREFIX: &[u8] = b"\x1bPtmux;";
+    const SUFFIX: &[u8] = b"\x1b\\";
+    let mut wrapped = Vec::with_capacity(PREFIX.len() + payload.len() * 2 + SUFFIX.len());
+    wrapped.extend_from_slice(PREFIX);
+    for &byte in payload {
+        // Each ESC inside the passthrough body must be doubled so tmux forwards a single ESC.
+        if byte == 0x1b {
+            wrapped.push(0x1b);
+            wrapped.push(0x1b);
+        } else {
+            wrapped.push(byte);
+        }
+    }
+    wrapped.extend_from_slice(SUFFIX);
+    wrapped
 }
 
 /// A local tmux pane(tab) based on a tmux pty


### PR DESCRIPTION
## Summary
- suppress OSC/CSI/DCS capability probes when writing through tmux control mode so we stop asking tmux to echo them back at the pane
- classify the same sequences on the read side, buffering per pane so fragmented replies are dropped cleanly and flushing that state when tmux tears a window down
- keep regular application output untouched; only handshake traffic is intercepted

## Background & Motivation
When tmux is driven via `tmux -CC`, it relays *every* byte it sees back to the control client. WezTerm emits colour and capability probes whenever a pane starts up or focus changes; in control mode those queries and their answers were forwarded straight into the running program. Codex (and even tools like `jj diff`) ended up seeing raw OSC/CSI text such as `10;rgb:…`, which broke layout and disabled spinners.

## Implementation Notes
- `classify_handshake_sequence` recognises the capability probes we originate (OSC 10/11/12, `CSI ?/>/=…c`, `CSI 4/8/14/16 … t`, `DCS tmux;… ST`) and is shared by both the writer and reader paths.
- `queue_send_keys` now drops those probes before they hit tmux, while `strip_handshake_sequences` buffers `%output` per pane and discards any recognised replies—even if tmux split them across multiple events—then clears the buffer when the pane disappears.
- All other output continues to pass straight through to the application.

## Testing
- macOS 15.1, nightly build `20251008-100947-abcdef12`, running `wezterm` → `tmux -CC new -As work` → launch Codex / focus panes / split windows: no stray OSC/CSI text, UI renders immediately, spinner blinks.
- `tmux -CC attach` into existing sessions with Codex, vim, `jj diff`: panes stay interactive and `jj diff` no longer prints raw `CSI ?…c` tails.

## Without this fix
<img width="2157" height="111" alt="image" src="https://github.com/user-attachments/assets/26e24b54-326d-4d7d-81dc-61eb627359be" />
