### PR TITLE
fix omitted color params in sixel parser

### DIFF
--- a/wezterm-escape-parser/src/parser/sixel.rs
+++ b/wezterm-escape-parser/src/parser/sixel.rs
@@ -97,11 +97,15 @@ impl SixelBuilder {
         match self.current_command {
             b'#' if self.param_no >= 4 => {
                 // Define a color
-                let color_number = self.params[0] as u16;
-                let system = self.params[1] as u16;
-                let a = self.params[2] as u16;
-                let b = self.params[3] as u8;
-                let c = self.params[4] as u8;
+                let param = |i| match self.params.get(i).copied().unwrap_or(-1) {
+                    -1 => 0,
+                    v => v.max(0),
+                };
+                let color_number = param(0) as u16;
+                let system = param(1) as u16;
+                let a = param(2) as u16;
+                let b = param(3) as u8;
+                let c = param(4) as u8;
 
                 if system == 1 {
                     self.sixel.data.push(SixelData::DefineColorMapHSL {


### PR DESCRIPTION
Fixes #7344

Omitted parameters in color definition sequences (e.g. `#1;2;;50;`) were incorrectly treated as 100 due to -1 sentinel values wrapping during type conversion. The DEC Sixel specification states that any missing parameter between semicolons must default to 0.

This change normalizes unset parameters to 0 when interpreting both RGB and HLS color definitions, matching the behavior of other terminals and the Sixel standard.