### PR TITLE
Implement hide window operation for x11 windows

### DIFF
--- a/window/src/os/x11/connection.rs
+++ b/window/src/os/x11/connection.rs
@@ -96,6 +96,7 @@ pub struct XConnection {
     pub atom_net_supported: Atom,
     pub atom_net_supporting_wm_check: Atom,
     pub atom_net_active_window: Atom,
+    pub atom_wm_change_state: Atom,
     pub(crate) xrm: RefCell<HashMap<String, String>>,
     pub(crate) windows: RefCell<HashMap<xcb::x::Window, Arc<Mutex<XWindowInner>>>>,
     pub(crate) child_to_parent_id: RefCell<HashMap<xcb::x::Window, xcb::x::Window>>,
@@ -714,6 +715,7 @@ impl XConnection {
         let atom_net_supported = Self::intern_atom(&conn, "_NET_SUPPORTED")?;
         let atom_net_supporting_wm_check = Self::intern_atom(&conn, "_NET_SUPPORTING_WM_CHECK")?;
         let atom_net_active_window = Self::intern_atom(&conn, "_NET_ACTIVE_WINDOW")?;
+        let atom_wm_change_state = Self::intern_atom(&conn, "WM_CHANGE_STATE")?;
 
         let has_randr = conn.active_extensions().any(|e| e == xcb::Extension::RandR);
 
@@ -851,6 +853,7 @@ impl XConnection {
             atom_net_supporting_wm_check,
             atom_net_active_window,
             atom_net_wm_icon,
+            atom_wm_change_state,
             keyboard,
             kbd_ev,
             atom_utf8_string,

--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -1631,7 +1631,28 @@ impl XWindowInner {
         log::trace!("clear out self.window_id");
         self.window_id = xcb::x::Window::none();
     }
-    fn hide(&mut self) {}
+
+    fn hide(&mut self) {
+        const WM_STATE_ICONIC: u32 = 3;
+
+        let conn = self.conn();
+        conn.send_request_no_reply_log(&xcb::x::SendEvent {
+            propagate: true,
+            destination: xcb::x::SendEventDest::Window(conn.root),
+            event_mask: xcb::x::EventMask::SUBSTRUCTURE_REDIRECT
+                | xcb::x::EventMask::SUBSTRUCTURE_NOTIFY,
+            event: &xcb::x::ClientMessageEvent::new(
+                self.window_id,
+                conn.atom_wm_change_state,
+                xcb::x::ClientMessageData::Data32([WM_STATE_ICONIC, 0, 0, 0, 0]),
+            ),
+        });
+
+        if let Err(err) = conn.flush() {
+            log::error!("Error flushing: {err:#}");
+        }
+    }
+
     fn show(&mut self) {
         self.conn().send_request_no_reply_log(&xcb::x::MapWindow {
             window: self.window_id,


### PR DESCRIPTION
Demo:

https://github.com/user-attachments/assets/c63094e7-05d7-406a-b2a1-2a8fff014c56

The window is hidden by sending a WM_CHANGE_STATE client message to set the window into the iconic state, as per https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.4.

Tested on Linux Mint 22.2 Cinnamon (X11 Mutter).

Fixes #6086 