### PR TITLE
Update linuxbrew installation instructions

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -281,7 +281,7 @@ hide:
 
     ```console
     $ brew tap wezterm/wezterm-linuxbrew
-    $ brew install wezterm
+    $ brew install wezterm/wezterm-linuxbrew/wezterm
     ```
 
     If you'd like to use a nightly build you can perform a head install:


### PR DESCRIPTION
There original instructions resulted in this error:

```
$ brew install wezterm
Warning: Treating wezterm as a cask. For the formula, use wezterm/wezterm-linuxbrew/wezterm or specify the `--formula` flag. To silence this message, use the `--cask` flag.
Error: macOS is required for this software.
```