### PR TITLE
Add config option for debounce when searching

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -444,6 +444,9 @@ pub struct Config {
     #[dynamic(default)]
     pub quick_select_remove_styling: bool,
 
+    #[dynamic(default = "default_search_debounce_ms")]
+    pub search_debounce_ms: u64,
+
     #[dynamic(default)]
     pub mouse_bindings: Vec<Mouse>,
     #[dynamic(default)]
@@ -1661,6 +1664,10 @@ fn default_swallow_mouse_click_on_window_focus() -> bool {
 
 fn default_mux_output_parser_coalesce_delay_ms() -> u64 {
     3
+}
+
+fn default_search_debounce_ms() -> u64 {
+    350
 }
 
 fn default_mux_output_parser_buffer_size() -> usize {

--- a/docs/config/lua/config/search_debounce_ms.md
+++ b/docs/config/lua/config/search_debounce_ms.md
@@ -1,0 +1,16 @@
+---
+tags:
+  - tuning
+---
+
+# `search_debounce_ms = 350`
+
+{{since('nightly')}}
+
+Specifies the debounce duration in milliseconds for search updates after a key press.
+This avoids performance issues when the first few characters of a search string result in 
+a large number of matches. A value of `0` will disable the delay. The default is `350`.
+
+```lua
+config.search_debounce_ms = 0
+```

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -278,9 +278,12 @@ impl CopyRenderable {
 
         let window = self.window.clone();
         let pane_id = self.delegate.pane_id();
+        let debounce_ms = config::configuration().search_debounce_ms;
 
         promise::spawn::spawn(async move {
-            smol::Timer::after(Duration::from_millis(350)).await;
+            if debounce_ms > 0 {
+                smol::Timer::after(Duration::from_millis(debounce_ms)).await;
+            }
             window.notify(TermWindowNotif::Apply(Box::new(move |term_window| {
                 let state = term_window.pane_state(pane_id);
                 if let Some(overlay) = state.overlay.as_ref() {


### PR DESCRIPTION
When searching the terminal, there is a debounce that addresses this issue: https://github.com/wezterm/wezterm/issues/1569. 
At least for me, the 350ms delay after typing characters makes searching feel a bit sluggish, so I wanted to make it a configurable option. 