### PR TITLE
docs(linuxbrew install): formula flag

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -281,13 +281,13 @@ hide:
 
     ```console
     $ brew tap wezterm/wezterm-linuxbrew
-    $ brew install wezterm
+    $ brew install --formula wezterm
     ```
 
     If you'd like to use a nightly build you can perform a head install:
 
     ```console
-    $ brew install --HEAD wezterm
+    $ brew install --HEAD --formula wezterm
     ```
 
     to upgrade to a newer nightly, it is simplest to remove then
@@ -295,7 +295,7 @@ hide:
 
     ```console
     $ brew rm wezterm
-    $ brew install --HEAD wezterm
+    $ brew install --HEAD --formula wezterm
     ```
 === "Nix/NixOS"
 


### PR DESCRIPTION
`brew install wezterm` attempts to install the macOS package and fails with `Error: macOS is required for this software.` because it treats `wezterm` as a cask, as per the warning displayed before the error:

 Warning: Treating wezterm as a cask. For the formula, use wezterm/wezterm-linuxbrew/wezterm or specify the `--formula` flag. To silence this message, use the `--cask` flag.