### PR TITLE
wayland: terminate key repetition after window is closed

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -125,6 +125,10 @@ impl KeyRepeatState {
                     };
 
                     let mut inner = handle.borrow_mut();
+                    if inner.window.is_none() {
+                        log::warn!("key repetition cancelled because window has been closed");
+                        return;
+                    }
 
                     if inner.key_repeat.as_ref().map(|(_, k)| Arc::as_ptr(k))
                         != Some(Arc::as_ptr(&state))


### PR DESCRIPTION
I went the easiest route – code in many other places check for window having been closed by looking at the inner window being Some/None. But from what I can tell there's still an effective leak with windows, the hashmap of windows is added to but never is removed from. Probably not a huge deal even for relatively long sessions, but one of the reasons why key repetition issue ended up surfacing.

Fixes #7230