### PR TITLE
fix(wezterm-gui): max tab title length

### DIFF
--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -465,7 +465,7 @@ impl TabBarState {
                 pane_info,
                 config,
                 hover,
-                tab_title_len,
+                tab_width_max,
             );
 
             let cell_attrs = if active {


### PR DESCRIPTION
Fixes the logic regarding tab title length.

This is a really weird detail that took a fair bit of debugging to find

The `format-tab-title` event currently receives an incorrect `max_width` parameter. Right now, `max_width` is basically the minimum title length possible. 

example config to reproduce: (it basically displays the max_width inside the tab title)

```lua
config.use_fancy_tab_bar = false
config.tab_max_width = 50
wezterm.on("format-tab-title", function(tab, tabs, panes, conf, hover, max_width)
    return {
        { Text = max_width .. tab.active_pane.title },
    }
end)
```

video:


https://github.com/user-attachments/assets/e0252da4-41e4-41b7-9092-e0c5bfbcd009

observe how the title for each tab is `5zsh`. The value of `tab.active_pane.title` was `" zsh "` (observe spaces on left/right for padding), which has a length of 5.

The expected tab title should be `50zsh`. this change fixes it.

Previously, the code was using the variable `tab_title_len`, which is the length of the previous tab title, while it should be using `tab_width_max`, which is the max width allowed for the tab title.

new video:

https://github.com/user-attachments/assets/936ed4e9-9f7a-47cb-adc5-2dd681f60e1a

