### PR TITLE
Change display order of `key` and `mode` in `show-keys --lua`

### DIFF
--- a/wezterm-gui/src/inputmap.rs
+++ b/wezterm-gui/src/inputmap.rs
@@ -499,7 +499,7 @@ impl InputMap {
 
     pub fn show_keys(&self) {
         if let Some((key, mods, duration)) = &self.leader {
-            println!("Leader: {key:?} {mods:?} {duration:?}");
+            println!("Leader: {mods:?} {key:?} {duration:?}");
         }
 
         section_header("Default key table");
@@ -775,7 +775,7 @@ fn lua_key(key: &KeyCode, mods: Modifiers, action: &KeyAssignment) -> String {
 
     let mods = format!("{mods:?}").replace(" ", "");
 
-    format!("{{ key = {key}, mods = '{mods}', action = {action} }}")
+    format!("{{ mods = '{mods}', key = {key}, action = {action} }}")
 }
 
 fn show_key_table(table: &config::keyassignment::KeyTable) {


### PR DESCRIPTION
Display order of keys in the output of `wezterm show-keys` is `Mods - Key - Action`. But it is `Key - Mods - Action` when the command is run with `--lua` switch. This PR is to make this output consistent. Specifically changed the order of mods and key in the output of `wezterm show-keys --lua`

Before:
```
return {
  keys = {
    { key = 'Tab', mods = 'CTRL', action = act.ActivateTabRelative(1) },
    { key = 'Tab', mods = 'SHIFT|CTRL', action = act.ActivateTabRelative(-1) },
    { key = 'Enter', mods = 'SUPER', action = act.ToggleFullScreen },
    ...
  }
}
```

After:
```
return {
  keys = {
    { mods = 'CTRL', key = 'Tab', action = act.ActivateTabRelative(1) },
    { mods = 'SHIFT|CTRL', key = 'Tab', action = act.ActivateTabRelative(-1) },
    { mods = 'SUPER', key = 'Enter', action = act.ToggleFullScreen },
    ...
  }
}
```