### PR TITLE
Treat SCTKWindowState::TILED as a maximized state

### DIFF
--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -1329,7 +1329,9 @@ impl WaylandState {
                 if configure.state.contains(SCTKWindowState::FULLSCREEN) {
                     state |= WindowState::FULL_SCREEN;
                 }
-                if configure.state.contains(SCTKWindowState::MAXIMIZED) {
+                if configure.state.contains(SCTKWindowState::MAXIMIZED)
+                    || configure.state.contains(SCTKWindowState::TILED)
+                {
                     state |= WindowState::MAXIMIZED;
                 }
 


### PR DESCRIPTION
I'm also encountering #7156. It looks like what happened is `SCTKWindowState::TILED` got added, and replaced the `SCTKWindowState::MAXIMIZED` in at least the tiling window manager case. Wezterm isn't handling this state, and so it was treating tiled windows as resizable, and then you end up rendering at the wrong size. There could be other problems, the full resizing logic is rather complex, but this seems more correct to me and fixes my usecase.