### PR TITLE
fancy tab bar: fix layout issues with macOS native traffic light buttons

### DIFF
--- a/window/src/os/parameters.rs
+++ b/window/src/os/parameters.rs
@@ -11,6 +11,10 @@ pub struct TitleBar {
     pub padding_right: ULength,
     pub height: Option<ULength>,
     pub font_and_size: Option<FontAndSize>,
+    /// Offset from the left edge of the window to the right edge of the
+    /// macOS traffic light buttons (close/minimize/zoom).
+    /// Value is in points (logical pixels).
+    pub macos_traffic_light_offset: Option<f32>,
 }
 
 #[derive(Default, Clone, Debug)]


### PR DESCRIPTION
fancy tab bar: fix layout issues with macOS native traffic light buttons
Fix layout issues when using `use_fancy_tab_bar = true` with
`window_decorations = "INTEGRATED_BUTTONS|RESIZE"` on macOS:

1. Traffic light buttons overlapped with left_status text
2. Excessive gap between left_status and tabs

Changes:
- Dynamically query the traffic light buttons width via NSWindow API
  instead of using a hardcoded pixel value
- Properly handle spacing for all combinations:
  - With/without left_status configured
  - Fullscreen/non-fullscreen mode
- Consolidate space reservation into a single placeholder element
  and remove duplicate padding from the tabs container

## With left_status, and not fullscreen:
before:
![img_v3_02un_c5208f5b-d2d3-4234-9d62-6e1e0ff08beg](https://github.com/user-attachments/assets/281434be-232c-4b0e-82fa-57b756b52898)


after:
![img_v3_02un_e891da34-08b3-4843-a467-c1865423e6cg](https://github.com/user-attachments/assets/bcf9764f-34d3-423c-b9c6-315168dc33ef)

## Without left_status, and not fullscreen:
before:
![img_v3_02un_505b38db-3bb6-40eb-a782-ce741f6d1d9g](https://github.com/user-attachments/assets/de8faba1-40c3-44a1-9c2a-8874d915e0cf)

after:
![img_v3_02un_684c642a-6f8e-4410-844b-6f0f3d0d8b6g](https://github.com/user-attachments/assets/4f5a7d25-acaf-44e6-957b-a33d266b35dd)


# Fullscreen mode is not affected.
with left_status:
![img_v3_02un_69e9c47e-60a4-4322-81da-94c2a2ce3edg](https://github.com/user-attachments/assets/433410c0-daaf-45db-9e63-653b23886c25)
without left_status:
![img_v3_02un_2694f16d-007a-4894-a561-5a0a4e7538dg](https://github.com/user-attachments/assets/ded9c3c1-c1ec-4264-b091-89a42e74cc65)