### PR TITLE
Add vertical tab bar support (Left/Right positioning)

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -476,6 +476,21 @@ pub struct Config {
     #[dynamic(default)]
     pub tab_bar_at_bottom: bool,
 
+    /// Controls the position of the tab bar: Top, Bottom, Left, or Right.
+    /// When set to a non-default value, this takes precedence over tab_bar_at_bottom.
+    /// Left and Right positions require use_fancy_tab_bar = true (the default).
+    #[dynamic(default)]
+    pub tab_bar_position: TabBarPosition,
+
+    /// The width of the tab bar when positioned on the left or right side.
+    /// Ignored when the tab bar is at the top or bottom.
+    /// Defaults to 200 pixels.
+    #[dynamic(
+        try_from = "crate::units::PixelUnit",
+        default = "default_tab_bar_width"
+    )]
+    pub tab_bar_width: Dimension,
+
     #[dynamic(default = "default_true")]
     pub mouse_wheel_scrolls_tabs: bool,
 
@@ -915,6 +930,17 @@ impl Default for Config {
 }
 
 impl Config {
+    /// Returns the effective tab bar position, resolving the precedence
+    /// between `tab_bar_position` and the legacy `tab_bar_at_bottom` option.
+    /// If `tab_bar_position` is set to a non-default value, it takes precedence.
+    /// Otherwise, `tab_bar_at_bottom = true` maps to `Bottom`.
+    pub fn resolved_tab_bar_position(&self) -> TabBarPosition {
+        match self.tab_bar_position {
+            TabBarPosition::Top if self.tab_bar_at_bottom => TabBarPosition::Bottom,
+            pos => pos,
+        }
+    }
+
     pub fn load() -> LoadedConfig {
         Self::load_with_overrides(&wezterm_dynamic::Value::default())
     }
@@ -1868,6 +1894,10 @@ fn default_tab_max_width() -> usize {
     16
 }
 
+fn default_tab_bar_width() -> Dimension {
+    Dimension::Pixels(200.0)
+}
+
 fn default_update_interval() -> u64 {
     86400
 }
@@ -2010,6 +2040,22 @@ impl PathPossibility {
             path,
             is_required: false,
         }
+    }
+}
+
+/// Controls the position of the tab bar within the window
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TabBarPosition {
+    #[default]
+    Top,
+    Bottom,
+    Left,
+    Right,
+}
+
+impl TabBarPosition {
+    pub fn is_vertical(self) -> bool {
+        matches!(self, TabBarPosition::Left | TabBarPosition::Right)
     }
 }
 
@@ -2192,4 +2238,73 @@ fn default_macos_forward_mods() -> Modifiers {
 
 fn default_colr_rasterizer() -> FontRasterizerSelection {
     FontRasterizerSelection::Harfbuzz
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wezterm_dynamic::{FromDynamic, FromDynamicOptions, Value};
+
+    #[test]
+    fn tab_bar_position_from_dynamic() {
+        let opts = FromDynamicOptions::default();
+        assert_eq!(
+            TabBarPosition::from_dynamic(&Value::String("Top".into()), opts).unwrap(),
+            TabBarPosition::Top
+        );
+        assert_eq!(
+            TabBarPosition::from_dynamic(&Value::String("Bottom".into()), opts).unwrap(),
+            TabBarPosition::Bottom
+        );
+        assert_eq!(
+            TabBarPosition::from_dynamic(&Value::String("Left".into()), opts).unwrap(),
+            TabBarPosition::Left
+        );
+        assert_eq!(
+            TabBarPosition::from_dynamic(&Value::String("Right".into()), opts).unwrap(),
+            TabBarPosition::Right
+        );
+    }
+
+    #[test]
+    fn tab_bar_position_default() {
+        assert_eq!(TabBarPosition::default(), TabBarPosition::Top);
+    }
+
+    #[test]
+    fn tab_bar_position_is_vertical() {
+        assert!(!TabBarPosition::Top.is_vertical());
+        assert!(!TabBarPosition::Bottom.is_vertical());
+        assert!(TabBarPosition::Left.is_vertical());
+        assert!(TabBarPosition::Right.is_vertical());
+    }
+
+    #[test]
+    fn resolved_tab_bar_position_defaults_to_top() {
+        let config = Config::default();
+        assert_eq!(config.resolved_tab_bar_position(), TabBarPosition::Top);
+    }
+
+    #[test]
+    fn resolved_tab_bar_position_respects_tab_bar_at_bottom() {
+        let mut config = Config::default();
+        config.tab_bar_at_bottom = true;
+        assert_eq!(config.resolved_tab_bar_position(), TabBarPosition::Bottom);
+    }
+
+    #[test]
+    fn resolved_tab_bar_position_explicit_overrides_at_bottom() {
+        let mut config = Config::default();
+        config.tab_bar_at_bottom = true;
+        config.tab_bar_position = TabBarPosition::Left;
+        assert_eq!(config.resolved_tab_bar_position(), TabBarPosition::Left);
+    }
+
+    #[test]
+    fn resolved_tab_bar_position_explicit_bottom_ignores_at_bottom() {
+        let mut config = Config::default();
+        config.tab_bar_at_bottom = false;
+        config.tab_bar_position = TabBarPosition::Right;
+        assert_eq!(config.resolved_tab_bar_position(), TabBarPosition::Right);
+    }
 }

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -281,6 +281,10 @@ details.
   causes the tab bar to be hidden when there is only a single tab.
 * [tab_bar_at_bottom](lua/config/tab_bar_at_bottom.md) places the tab
   bar at the bottom of the window instead of the top
+* [tab_bar_position](lua/config/tab_bar_position.md) controls where the tab bar
+  is rendered: `"Top"`, `"Bottom"`, `"Left"`, or `"Right"`
+* [tab_bar_width](lua/config/tab_bar_width.md) sets the width of the tab bar
+  when using a vertical (left/right) tab bar position
 * [tab_max_width](lua/config/tab_max_width.md) sets the maximum width, measured in cells,
   of a given tab when using retro tab mode.
 

--- a/docs/config/lua/config/tab_bar_at_bottom.md
+++ b/docs/config/lua/config/tab_bar_at_bottom.md
@@ -11,3 +11,8 @@ the window rather than the top of the window.
 
 The default is `false`.
 
+**Note:** The [tab_bar_position](tab_bar_position.md) option provides more
+flexibility, supporting `"Top"`, `"Bottom"`, `"Left"`, and `"Right"` positions.
+When `tab_bar_position` is set to a non-default value, it takes precedence over
+this option.
+

--- a/docs/config/lua/config/tab_bar_position.md
+++ b/docs/config/lua/config/tab_bar_position.md
@@ -1,0 +1,37 @@
+---
+tags:
+  - tab_bar
+---
+# `tab_bar_position = "Top"`
+
+Controls where the tab bar is rendered within the window.
+
+Possible values are:
+
+* `"Top"` - tab bar at the top of the window (default)
+* `"Bottom"` - tab bar at the bottom of the window
+* `"Left"` - tab bar on the left side of the window (vertical tabs)
+* `"Right"` - tab bar on the right side of the window (vertical tabs)
+
+When set to `"Left"` or `"Right"`, the [fancy tab
+bar](use_fancy_tab_bar.md) is always used, regardless of the
+`use_fancy_tab_bar` setting. The width of the vertical tab bar
+can be controlled with [tab_bar_width](tab_bar_width.md).
+
+This option takes precedence over the legacy
+[tab_bar_at_bottom](tab_bar_at_bottom.md) option. If
+`tab_bar_position` is left at its default value of `"Top"` and
+`tab_bar_at_bottom = true`, the tab bar will be placed at the
+bottom for backward compatibility.
+
+```lua
+local wezterm = require 'wezterm'
+
+local config = wezterm.config_builder()
+
+-- Place the tab bar on the left side with a 250px width
+config.tab_bar_position = 'Left'
+config.tab_bar_width = '250px'
+
+return config
+```

--- a/docs/config/lua/config/tab_bar_width.md
+++ b/docs/config/lua/config/tab_bar_width.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - tab_bar
+---
+# `tab_bar_width = "200px"`
+
+Controls the width of the tab bar when [tab_bar_position](tab_bar_position.md)
+is set to `"Left"` or `"Right"`.
+
+The value accepts pixel units (e.g., `"200px"`) and defaults to `"200px"`.
+
+This option has no effect when the tab bar is in horizontal mode
+(`"Top"` or `"Bottom"`).
+
+```lua
+local wezterm = require 'wezterm'
+
+local config = wezterm.config_builder()
+
+config.tab_bar_position = 'Left'
+config.tab_bar_width = '250px'
+
+return config
+```

--- a/wezterm-gui/src/resize_increment_calculator.rs
+++ b/wezterm-gui/src/resize_increment_calculator.rs
@@ -10,6 +10,7 @@ pub struct ResizeIncrementCalculator {
     pub padding_bottom: usize,
     pub border: Border,
     pub tab_bar_height: usize,
+    pub tab_bar_width: usize,
 }
 
 impl Into<ResizeIncrement> for ResizeIncrementCalculator {
@@ -19,7 +20,8 @@ impl Into<ResizeIncrement> for ResizeIncrementCalculator {
             y: self.y,
             base_width: (self.padding_left
                 + self.padding_right
-                + (self.border.left + self.border.right).get()) as u16,
+                + (self.border.left + self.border.right).get()
+                + self.tab_bar_width) as u16,
             base_height: (self.padding_top
                 + self.padding_bottom
                 + (self.border.top + self.border.bottom).get()

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -1,5 +1,5 @@
 use crate::termwindow::{PaneInformation, TabInformation, UIItem, UIItemType};
-use config::{ConfigHandle, TabBarColors};
+use config::{ConfigHandle, TabBarColors, TabBarPosition};
 use finl_unicode::grapheme_clusters::Graphemes;
 use mlua::FromLua;
 use termwiz::cell::{unicode_column_width, Cell, CellAttributes};
@@ -425,7 +425,7 @@ impl TabBarState {
         if use_integrated_title_buttons
             && config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
             && config.use_fancy_tab_bar == false
-            && config.tab_bar_at_bottom == false
+            && config.resolved_tab_bar_position() == TabBarPosition::Top
         {
             for _ in 0..10 as usize {
                 line.insert_cell(0, black_cell.clone(), title_width, SEQ_ZERO);

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -153,7 +153,11 @@ fn compute_tab_title(
                     tab.tab_title.clone()
                 };
 
-                let classic_spacing = if config.use_fancy_tab_bar { "" } else { " " };
+                let classic_spacing = if effective_use_fancy_tab_bar(config) {
+                    ""
+                } else {
+                    " "
+                };
                 if config.show_tab_index_in_tab_bar {
                     let index = format!(
                         "{classic_spacing}{}: ",
@@ -193,7 +197,7 @@ fn compute_tab_title(
                 // easier to click on tab titles, but we'll still go below
                 // this if there are too many tabs to fit the window at
                 // this width.
-                if !config.use_fancy_tab_bar {
+                if !effective_use_fancy_tab_bar(config) {
                     while len + unicode_column_width(&title, None) < 5 {
                         title.push(' ');
                     }
@@ -216,6 +220,10 @@ fn is_tab_hover(mouse_x: Option<usize>, x: usize, tab_title_len: usize) -> bool 
     return mouse_x
         .map(|mouse_x| mouse_x >= x && mouse_x < x + tab_title_len)
         .unwrap_or(false);
+}
+
+fn effective_use_fancy_tab_bar(config: &ConfigHandle) -> bool {
+    config.use_fancy_tab_bar || config.resolved_tab_bar_position().is_vertical()
 }
 
 impl TabBarState {
@@ -247,13 +255,13 @@ impl TabBarState {
         line: &mut Line,
         colors: &TabBarColors,
     ) {
-        let default_cell = if config.use_fancy_tab_bar {
+        let default_cell = if effective_use_fancy_tab_bar(config) {
             CellAttributes::default()
         } else {
             colors.new_tab().as_cell_attributes()
         };
 
-        let default_cell_hover = if config.use_fancy_tab_bar {
+        let default_cell_hover = if effective_use_fancy_tab_bar(config) {
             CellAttributes::default()
         } else {
             colors.new_tab_hover().as_cell_attributes()
@@ -350,7 +358,7 @@ impl TabBarState {
 
         let new_tab = parse_status_text(
             &config.tab_bar_style.new_tab,
-            if config.use_fancy_tab_bar {
+            if effective_use_fancy_tab_bar(config) {
                 CellAttributes::default()
             } else {
                 new_tab_attrs.clone()
@@ -358,7 +366,7 @@ impl TabBarState {
         );
         let new_tab_hover = parse_status_text(
             &config.tab_bar_style.new_tab_hover,
-            if config.use_fancy_tab_bar {
+            if effective_use_fancy_tab_bar(config) {
                 CellAttributes::default()
             } else {
                 new_tab_hover_attrs.clone()
@@ -402,7 +410,8 @@ impl TabBarState {
 
         let available_cells =
             title_width.saturating_sub(number_of_tabs.saturating_sub(1) + new_tab.len());
-        let tab_width_max = if config.use_fancy_tab_bar || available_cells >= titles_len {
+        let tab_width_max = if effective_use_fancy_tab_bar(config) || available_cells >= titles_len
+        {
             // We can render each title with its full width
             usize::max_value()
         } else {
@@ -424,7 +433,7 @@ impl TabBarState {
 
         if use_integrated_title_buttons
             && config.integrated_title_button_style == IntegratedTitleButtonStyle::MacOsNative
-            && config.use_fancy_tab_bar == false
+            && !effective_use_fancy_tab_bar(config)
             && config.resolved_tab_bar_position() == TabBarPosition::Top
         {
             for _ in 0..10 as usize {
@@ -481,7 +490,7 @@ impl TabBarState {
             let esc = format_as_escapes(tab_title.items.clone()).expect("already parsed ok above");
             let mut tab_line = parse_status_text(
                 &esc,
-                if config.use_fancy_tab_bar {
+                if effective_use_fancy_tab_bar(config) {
                     CellAttributes::default()
                 } else {
                     cell_attrs.clone()

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -392,8 +392,15 @@ impl CharSelector {
             .expect("to resolve char selection font");
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
 
-        let top_bar_height = if term_window.show_tab_bar && !term_window.config.tab_bar_at_bottom {
+        let tab_pos = term_window.resolved_tab_bar_position();
+        let top_bar_height = if term_window.show_tab_bar && tab_pos == config::TabBarPosition::Top {
             term_window.tab_bar_pixel_height().unwrap()
+        } else {
+            0.
+        };
+        let left_bar_width = if term_window.show_tab_bar && tab_pos == config::TabBarPosition::Left
+        {
+            term_window.tab_bar_pixel_width()
         } else {
             0.
         };
@@ -532,7 +539,7 @@ impl CharSelector {
                     pixel_cell: metrics.cell_size.width as f32,
                 },
                 bounds: euclid::rect(
-                    padding_left,
+                    padding_left + left_bar_width,
                     top_pixel_y,
                     size.cols as f32 * term_window.render_metrics.cell_size.width as f32,
                     size.rows as f32 * term_window.render_metrics.cell_size.height as f32,

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -604,7 +604,8 @@ impl TermWindow {
         // Initially we have only a single tab, so take that into account
         // for the tab bar state.
         let show_tab_bar = config.enable_tab_bar && !config.hide_tab_bar_if_only_one_tab;
-        let tab_bar_height = if show_tab_bar {
+        let is_vertical_tab_bar = config.resolved_tab_bar_position().is_vertical();
+        let tab_bar_height = if show_tab_bar && !is_vertical_tab_bar {
             Self::tab_bar_pixel_height_impl(&config, &fontconfig, &render_metrics)? as usize
         } else {
             0
@@ -650,8 +651,24 @@ impl TermWindow {
         let padding_top = config.window_padding.top.evaluate_as_pixels(v_context) as usize;
         let padding_bottom = config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
 
-        let mut dimensions = Dimensions {
+        // For vertical tab bar, we need a temporary Dimensions to compute the tab bar width.
+        // The tab_bar_pixel_width_impl needs dimensions for DPI.
+        let temp_dims = Dimensions {
             pixel_width: (terminal_size.pixel_width + padding_left + padding_right) as usize,
+            pixel_height: ((terminal_size.rows * render_metrics.cell_size.height as usize)
+                + padding_top
+                + padding_bottom) as usize,
+            dpi,
+        };
+        let tab_bar_width = if show_tab_bar && is_vertical_tab_bar {
+            Self::tab_bar_pixel_width_impl(&config, &render_metrics, &temp_dims) as usize
+        } else {
+            0
+        };
+
+        let mut dimensions = Dimensions {
+            pixel_width: (terminal_size.pixel_width + padding_left + padding_right) as usize
+                + tab_bar_width,
             pixel_height: ((terminal_size.rows * render_metrics.cell_size.height as usize)
                 + padding_top
                 + padding_bottom) as usize
@@ -869,6 +886,7 @@ impl TermWindow {
                         padding_bottom: padding_bottom,
                         border: border,
                         tab_bar_height: tab_bar_height,
+                        tab_bar_width: tab_bar_width,
                     }
                     .into(),
                 );
@@ -1970,26 +1988,45 @@ impl TermWindow {
         let active_pane = panes.iter().find(|p| p.is_active).cloned();
 
         let border = self.get_os_border();
+        let tab_pos = self.resolved_tab_bar_position();
         let tab_bar_height = self.tab_bar_pixel_height().unwrap_or(0.);
-        let tab_bar_y = if self.config.tab_bar_at_bottom {
-            ((self.dimensions.pixel_height as f32) - (tab_bar_height + border.bottom.get() as f32))
-                .max(0.)
-        } else {
-            border.top.get() as f32
-        };
-
-        let tab_bar_height = self.tab_bar_pixel_height().unwrap_or(0.);
+        let tab_bar_width = self.tab_bar_pixel_width();
 
         let hovering_in_tab_bar = match &self.current_mouse_event {
             Some(event) => {
-                let mouse_y = event.coords.y as f32;
-                mouse_y >= tab_bar_y as f32 && mouse_y < tab_bar_y as f32 + tab_bar_height
+                if tab_pos.is_vertical() {
+                    let mouse_x = event.coords.x as f32;
+                    let tab_bar_x = if tab_pos == config::TabBarPosition::Left {
+                        border.left.get() as f32
+                    } else {
+                        (self.dimensions.pixel_width as f32)
+                            - tab_bar_width
+                            - border.right.get() as f32
+                    };
+                    mouse_x >= tab_bar_x && mouse_x < tab_bar_x + tab_bar_width
+                } else {
+                    let mouse_y = event.coords.y as f32;
+                    let tab_bar_y = if tab_pos == config::TabBarPosition::Bottom {
+                        ((self.dimensions.pixel_height as f32)
+                            - (tab_bar_height + border.bottom.get() as f32))
+                            .max(0.)
+                    } else {
+                        border.top.get() as f32
+                    };
+                    mouse_y >= tab_bar_y && mouse_y < tab_bar_y + tab_bar_height
+                }
             }
             None => false,
         };
 
+        let tab_bar_cols = if tab_pos.is_vertical() {
+            (tab_bar_width as usize) / self.render_metrics.cell_size.width as usize
+        } else {
+            self.dimensions.pixel_width / self.render_metrics.cell_size.width as usize
+        };
+
         let new_tab_bar = TabBarState::new(
-            self.dimensions.pixel_width / self.render_metrics.cell_size.width as usize,
+            tab_bar_cols,
             if hovering_in_tab_bar {
                 Some(self.last_mouse_coords.0)
             } else {
@@ -2113,8 +2150,14 @@ impl TermWindow {
         if let Some(win) = self.window.as_ref() {
             let cursor = pos.pane.get_cursor_position();
             let top = pos.pane.get_dimensions().physical_top;
-            let tab_bar_height = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
+            let tab_pos = self.resolved_tab_bar_position();
+            let tab_bar_height = if self.show_tab_bar && tab_pos == config::TabBarPosition::Top {
                 self.tab_bar_pixel_height().unwrap()
+            } else {
+                0.0
+            };
+            let left_bar_width = if self.show_tab_bar && tab_pos == config::TabBarPosition::Left {
+                self.tab_bar_pixel_width()
             } else {
                 0.0
             };
@@ -2123,7 +2166,8 @@ impl TermWindow {
             let r = Rect::new(
                 Point::new(
                     (((cursor.x + pos.left) as isize).max(0) * self.render_metrics.cell_size.width)
-                        .add(padding_left as isize),
+                        .add(padding_left as isize)
+                        .add(left_bar_width as isize),
                     ((cursor.y + pos.top as isize - top).max(0)
                         * self.render_metrics.cell_size.height)
                         .add(tab_bar_height as isize)

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -68,12 +68,19 @@ impl super::TermWindow {
         self.current_mouse_event.replace(event.clone());
 
         let border = self.get_os_border();
+        let tab_pos = self.resolved_tab_bar_position();
 
-        let first_line_offset = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
+        let first_line_offset = if self.show_tab_bar && tab_pos == config::TabBarPosition::Top {
             self.tab_bar_pixel_height().unwrap_or(0.) as isize
         } else {
             0
         } + border.top.get() as isize;
+
+        let left_bar_offset = if self.show_tab_bar && tab_pos == config::TabBarPosition::Left {
+            self.tab_bar_pixel_width() as isize
+        } else {
+            0
+        };
 
         let (padding_left, padding_top) = self.padding_left_top();
 
@@ -88,6 +95,7 @@ impl super::TermWindow {
         let x = (event
             .coords
             .x
+            .sub(left_bar_offset)
             .sub((padding_left + border.left.get() as f32) as isize)
             .max(0) as f32)
             / self.render_metrics.cell_size.width as f32;
@@ -112,6 +120,7 @@ impl super::TermWindow {
         let mut x_pixel_offset = event
             .coords
             .x
+            .sub(left_bar_offset)
             .sub((padding_left + border.left.get() as f32) as isize);
         if x > 0 {
             x_pixel_offset = x_pixel_offset.max(0) % self.render_metrics.cell_size.width;
@@ -295,15 +304,16 @@ impl super::TermWindow {
         let dims = pane.get_dimensions();
         let current_viewport = self.get_viewport(pane.pane_id());
 
-        let tab_bar_height = if self.show_tab_bar {
+        let scroll_tab_pos = self.resolved_tab_bar_position();
+        let tab_bar_height = if self.show_tab_bar && !scroll_tab_pos.is_vertical() {
             self.tab_bar_pixel_height().unwrap_or(0.)
         } else {
             0.
         };
-        let (top_bar_height, bottom_bar_height) = if self.config.tab_bar_at_bottom {
-            (0.0, tab_bar_height)
-        } else {
-            (tab_bar_height, 0.0)
+        let (top_bar_height, bottom_bar_height) = match scroll_tab_pos {
+            config::TabBarPosition::Bottom => (0.0, tab_bar_height),
+            config::TabBarPosition::Top => (tab_bar_height, 0.0),
+            _ => (0.0, 0.0),
         };
 
         let border = self.get_os_border();

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -260,8 +260,15 @@ impl CommandPalette {
             .expect("to resolve command palette font");
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
 
-        let top_bar_height = if term_window.show_tab_bar && !term_window.config.tab_bar_at_bottom {
+        let tab_pos = term_window.resolved_tab_bar_position();
+        let top_bar_height = if term_window.show_tab_bar && tab_pos == config::TabBarPosition::Top {
             term_window.tab_bar_pixel_height().unwrap()
+        } else {
+            0.
+        };
+        let left_bar_width = if term_window.show_tab_bar && tab_pos == config::TabBarPosition::Left
+        {
+            term_window.tab_bar_pixel_width()
         } else {
             0.
         };
@@ -509,7 +516,8 @@ impl CommandPalette {
             }))
             .min_width(Some(Dimension::Pixels(desired_pixel_width)));
 
-        let x_adjust = ((avail_pixel_width - padding_left) - desired_pixel_width) / 2.;
+        let x_adjust =
+            ((avail_pixel_width - padding_left - left_bar_width) - desired_pixel_width) / 2.;
 
         let computed = term_window.compute_element(
             &LayoutContext {
@@ -524,7 +532,7 @@ impl CommandPalette {
                     pixel_cell: metrics.cell_size.width as f32,
                 },
                 bounds: euclid::rect(
-                    padding_left + x_adjust,
+                    padding_left + left_bar_width + x_adjust,
                     top_pixel_y,
                     desired_pixel_width,
                     size.rows as f32 * term_window.render_metrics.cell_size.height as f32,

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -516,8 +516,7 @@ impl CommandPalette {
             }))
             .min_width(Some(Dimension::Pixels(desired_pixel_width)));
 
-        let x_adjust =
-            ((avail_pixel_width - padding_left - left_bar_width) - desired_pixel_width) / 2.;
+        let x_adjust = ((avail_pixel_width - padding_left) - desired_pixel_width) / 2.;
 
         let computed = term_window.compute_element(
             &LayoutContext {

--- a/wezterm-gui/src/termwindow/paneselect.rs
+++ b/wezterm-gui/src/termwindow/paneselect.rs
@@ -61,8 +61,15 @@ impl PaneSelector {
             .expect("to resolve pane selection font");
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
 
-        let top_bar_height = if term_window.show_tab_bar && !term_window.config.tab_bar_at_bottom {
+        let tab_pos = term_window.resolved_tab_bar_position();
+        let top_bar_height = if term_window.show_tab_bar && tab_pos == config::TabBarPosition::Top {
             term_window.tab_bar_pixel_height().unwrap()
+        } else {
+            0.
+        };
+        let left_bar_width = if term_window.show_tab_bar && tab_pos == config::TabBarPosition::Left
+        {
+            term_window.tab_bar_pixel_width()
         } else {
             0.
         };
@@ -136,6 +143,7 @@ impl PaneSelector {
                     },
                     bounds: euclid::rect(
                         padding_left
+                            + left_bar_width
                             + ((pos.left as f32 + pane_dims.cols as f32 / 2.)
                                 * term_window.render_metrics.cell_size.width as f32),
                         top_pixel_y

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -6,7 +6,7 @@ use crate::termwindow::render::corners::*;
 use crate::termwindow::render::window_buttons::window_button_element;
 use crate::termwindow::{UIItem, UIItemType};
 use crate::utilsprites::RenderMetrics;
-use config::{Dimension, DimensionContext, TabBarColors};
+use config::{Dimension, DimensionContext, TabBarColors, TabBarPosition};
 use std::rc::Rc;
 use wezterm_font::LoadedFont;
 use wezterm_term::color::{ColorAttribute, ColorPalette};
@@ -56,6 +56,21 @@ impl crate::TermWindow {
     }
 
     pub fn build_fancy_tab_bar(&self, palette: &ColorPalette) -> anyhow::Result<ComputedElement> {
+        let pos = self.resolved_tab_bar_position();
+        if pos.is_vertical() {
+            self.build_vertical_fancy_tab_bar(palette, pos)
+        } else {
+            self.build_horizontal_fancy_tab_bar(palette, pos)
+        }
+    }
+
+    /// Build the horizontal fancy tab bar (Top/Bottom positions).
+    /// This is the original build_fancy_tab_bar logic.
+    fn build_horizontal_fancy_tab_bar(
+        &self,
+        palette: &ColorPalette,
+        pos: TabBarPosition,
+    ) -> anyhow::Result<ComputedElement> {
         let tab_bar_height = self.tab_bar_pixel_height()?;
         let font = self.fonts.title_font()?;
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
@@ -71,229 +86,10 @@ impl crate::TermWindow {
         let mut left_status = vec![];
         let mut left_eles = vec![];
         let mut right_eles = vec![];
-        let bar_colors = ElementColors {
-            border: BorderColor::default(),
-            bg: if self.focused.is_some() {
-                self.config.window_frame.active_titlebar_bg
-            } else {
-                self.config.window_frame.inactive_titlebar_bg
-            }
-            .to_linear()
-            .into(),
-            text: if self.focused.is_some() {
-                self.config.window_frame.active_titlebar_fg
-            } else {
-                self.config.window_frame.inactive_titlebar_fg
-            }
-            .to_linear()
-            .into(),
-        };
+        let bar_colors = self.tab_bar_colors();
 
         let item_to_elem = |item: &TabEntry| -> Element {
-            let element = Element::with_line(&font, &item.title, palette);
-
-            let bg_color = item
-                .title
-                .get_cell(0)
-                .and_then(|c| match c.attrs().background() {
-                    ColorAttribute::Default => None,
-                    col => Some(palette.resolve_bg(col)),
-                });
-            let fg_color = item
-                .title
-                .get_cell(0)
-                .and_then(|c| match c.attrs().foreground() {
-                    ColorAttribute::Default => None,
-                    col => Some(palette.resolve_fg(col)),
-                });
-
-            let new_tab = colors.new_tab();
-            let new_tab_hover = colors.new_tab_hover();
-            let active_tab = colors.active_tab();
-
-            match item.item {
-                TabBarItem::RightStatus | TabBarItem::LeftStatus | TabBarItem::None => element
-                    .item_type(UIItemType::TabBar(TabBarItem::None))
-                    .line_height(Some(1.75))
-                    .margin(BoxDimension {
-                        left: Dimension::Cells(0.),
-                        right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.0),
-                        bottom: Dimension::Cells(0.),
-                    })
-                    .padding(BoxDimension {
-                        left: Dimension::Cells(0.5),
-                        right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.),
-                        bottom: Dimension::Cells(0.),
-                    })
-                    .border(BoxDimension::new(Dimension::Pixels(0.)))
-                    .colors(bar_colors.clone()),
-                TabBarItem::NewTabButton => Element::new(
-                    &font,
-                    ElementContent::Poly {
-                        line_width: metrics.underline_height.max(2),
-                        poly: SizedPoly {
-                            poly: PLUS_BUTTON,
-                            width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
-                            height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
-                        },
-                    },
-                )
-                .vertical_align(VerticalAlign::Middle)
-                .item_type(UIItemType::TabBar(item.item.clone()))
-                .margin(BoxDimension {
-                    left: Dimension::Cells(0.5),
-                    right: Dimension::Cells(0.),
-                    top: Dimension::Cells(0.2),
-                    bottom: Dimension::Cells(0.),
-                })
-                .padding(BoxDimension {
-                    left: Dimension::Cells(0.5),
-                    right: Dimension::Cells(0.5),
-                    top: Dimension::Cells(0.2),
-                    bottom: Dimension::Cells(0.25),
-                })
-                .border(BoxDimension::new(Dimension::Pixels(1.)))
-                .colors(ElementColors {
-                    border: BorderColor::default(),
-                    bg: new_tab.bg_color.to_linear().into(),
-                    text: new_tab.fg_color.to_linear().into(),
-                })
-                .hover_colors(Some(ElementColors {
-                    border: BorderColor::default(),
-                    bg: new_tab_hover.bg_color.to_linear().into(),
-                    text: new_tab_hover.fg_color.to_linear().into(),
-                })),
-                TabBarItem::Tab { active, .. } if active => element
-                    .vertical_align(VerticalAlign::Bottom)
-                    .item_type(UIItemType::TabBar(item.item.clone()))
-                    .margin(BoxDimension {
-                        left: Dimension::Cells(0.),
-                        right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.),
-                    })
-                    .padding(BoxDimension {
-                        left: Dimension::Cells(0.5),
-                        right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.25),
-                    })
-                    .border(BoxDimension::new(Dimension::Pixels(1.)))
-                    .border_corners(Some(Corners {
-                        top_left: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_LEFT_ROUNDED_CORNER,
-                        },
-                        top_right: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_RIGHT_ROUNDED_CORNER,
-                        },
-                        bottom_left: SizedPoly::none(),
-                        bottom_right: SizedPoly::none(),
-                    }))
-                    .colors(ElementColors {
-                        border: BorderColor::new(
-                            bg_color
-                                .unwrap_or_else(|| active_tab.bg_color.into())
-                                .to_linear(),
-                        ),
-                        bg: bg_color
-                            .unwrap_or_else(|| active_tab.bg_color.into())
-                            .to_linear()
-                            .into(),
-                        text: fg_color
-                            .unwrap_or_else(|| active_tab.fg_color.into())
-                            .to_linear()
-                            .into(),
-                    }),
-                TabBarItem::Tab { .. } => element
-                    .vertical_align(VerticalAlign::Bottom)
-                    .item_type(UIItemType::TabBar(item.item.clone()))
-                    .margin(BoxDimension {
-                        left: Dimension::Cells(0.),
-                        right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.),
-                    })
-                    .padding(BoxDimension {
-                        left: Dimension::Cells(0.5),
-                        right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.25),
-                    })
-                    .border(BoxDimension::new(Dimension::Pixels(1.)))
-                    .border_corners(Some(Corners {
-                        top_left: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_LEFT_ROUNDED_CORNER,
-                        },
-                        top_right: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_RIGHT_ROUNDED_CORNER,
-                        },
-                        bottom_left: SizedPoly {
-                            width: Dimension::Cells(0.),
-                            height: Dimension::Cells(0.33),
-                            poly: &[],
-                        },
-                        bottom_right: SizedPoly {
-                            width: Dimension::Cells(0.),
-                            height: Dimension::Cells(0.33),
-                            poly: &[],
-                        },
-                    }))
-                    .colors({
-                        let inactive_tab = colors.inactive_tab();
-                        let bg = bg_color
-                            .unwrap_or_else(|| inactive_tab.bg_color.into())
-                            .to_linear();
-                        let edge = colors.inactive_tab_edge().to_linear();
-                        ElementColors {
-                            border: BorderColor {
-                                left: bg,
-                                right: edge,
-                                top: bg,
-                                bottom: bg,
-                            },
-                            bg: bg.into(),
-                            text: fg_color
-                                .unwrap_or_else(|| inactive_tab.fg_color.into())
-                                .to_linear()
-                                .into(),
-                        }
-                    })
-                    .hover_colors({
-                        let inactive_tab_hover = colors.inactive_tab_hover();
-                        Some(ElementColors {
-                            border: BorderColor::new(
-                                bg_color
-                                    .unwrap_or_else(|| inactive_tab_hover.bg_color.into())
-                                    .to_linear(),
-                            ),
-                            bg: bg_color
-                                .unwrap_or_else(|| inactive_tab_hover.bg_color.into())
-                                .to_linear()
-                                .into(),
-                            text: fg_color
-                                .unwrap_or_else(|| inactive_tab_hover.fg_color.into())
-                                .to_linear()
-                                .into(),
-                        })
-                    }),
-                TabBarItem::WindowButton(button) => window_button_element(
-                    button,
-                    self.window_state.contains(window::WindowState::MAXIMIZED),
-                    &font,
-                    &metrics,
-                    &self.config,
-                ),
-            }
+            self.tab_item_to_element(item, &font, &metrics, palette, &colors, &bar_colors, false)
         };
 
         let num_tabs: f32 = items
@@ -447,7 +243,7 @@ impl crate::TermWindow {
 
         computed.translate(euclid::vec2(
             0.,
-            if self.config.tab_bar_at_bottom {
+            if pos == TabBarPosition::Bottom {
                 self.dimensions.pixel_height as f32
                     - (computed.bounds.height() + border.bottom.get() as f32)
             } else {
@@ -456,6 +252,410 @@ impl crate::TermWindow {
         ));
 
         Ok(computed)
+    }
+
+    /// Build the vertical fancy tab bar (Left/Right positions).
+    /// Tabs are stacked vertically in a column with configurable width.
+    fn build_vertical_fancy_tab_bar(
+        &self,
+        palette: &ColorPalette,
+        pos: TabBarPosition,
+    ) -> anyhow::Result<ComputedElement> {
+        let tab_bar_width = self.tab_bar_pixel_width();
+        let font = self.fonts.title_font()?;
+        let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+        let items = self.tab_bar.items();
+        let colors = self
+            .config
+            .colors
+            .as_ref()
+            .and_then(|c| c.tab_bar.as_ref())
+            .cloned()
+            .unwrap_or_else(TabBarColors::default);
+
+        let bar_colors = self.tab_bar_colors();
+
+        // For vertical layout, each tab is a Block element stacked vertically.
+        // Important: we override vertical_align to Top for all children because
+        // the parent container has min_height = window_height. With Bottom or Middle
+        // alignment, all children would be translated to overlap at the bottom/middle
+        // of the window instead of stacking from the top.
+        let mut tab_eles = vec![];
+
+        for item in items {
+            match item.item {
+                TabBarItem::LeftStatus | TabBarItem::RightStatus | TabBarItem::None => {
+                    let mut elem = self.tab_item_to_element(
+                        item,
+                        &font,
+                        &metrics,
+                        palette,
+                        &colors,
+                        &bar_colors,
+                        true,
+                    );
+                    elem.display = DisplayType::Block;
+                    elem.vertical_align = VerticalAlign::Top;
+                    elem.min_width = Some(Dimension::Pixels(tab_bar_width));
+                    elem.max_width = Some(Dimension::Pixels(tab_bar_width));
+                    tab_eles.push(elem);
+                }
+                TabBarItem::WindowButton(_) => {
+                    // Skip window buttons in vertical mode
+                }
+                TabBarItem::Tab { tab_idx, active } => {
+                    let mut elem = self.tab_item_to_element(
+                        item,
+                        &font,
+                        &metrics,
+                        palette,
+                        &colors,
+                        &bar_colors,
+                        true,
+                    );
+                    // In vertical mode, tabs fill the full bar width and stack
+                    elem.display = DisplayType::Block;
+                    elem.vertical_align = VerticalAlign::Top;
+                    elem.min_width = Some(Dimension::Pixels(tab_bar_width));
+                    elem.max_width = Some(Dimension::Pixels(tab_bar_width));
+                    // Round all four corners equally for vertical tabs
+                    elem.border_corners = Some(Corners {
+                        top_left: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.5),
+                            poly: TOP_LEFT_ROUNDED_CORNER,
+                        },
+                        top_right: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.5),
+                            poly: TOP_RIGHT_ROUNDED_CORNER,
+                        },
+                        bottom_left: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.5),
+                            poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                        },
+                        bottom_right: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.5),
+                            poly: BOTTOM_RIGHT_ROUNDED_CORNER,
+                        },
+                    });
+                    elem.content = match elem.content {
+                        ElementContent::Text(_) => unreachable!(),
+                        ElementContent::Poly { .. } => unreachable!(),
+                        ElementContent::Children(mut kids) => {
+                            if self.config.show_close_tab_button_in_tabs {
+                                kids.push(make_x_button(&font, &metrics, &colors, tab_idx, active));
+                            }
+                            ElementContent::Children(kids)
+                        }
+                    };
+                    tab_eles.push(elem);
+                }
+                TabBarItem::NewTabButton => {
+                    let mut elem = self.tab_item_to_element(
+                        item,
+                        &font,
+                        &metrics,
+                        palette,
+                        &colors,
+                        &bar_colors,
+                        true,
+                    );
+                    elem.display = DisplayType::Block;
+                    elem.vertical_align = VerticalAlign::Top;
+                    elem.min_width = Some(Dimension::Pixels(tab_bar_width));
+                    elem.max_width = Some(Dimension::Pixels(tab_bar_width));
+                    tab_eles.push(elem);
+                }
+            }
+        }
+
+        let content = ElementContent::Children(tab_eles);
+
+        let tabs = Element::new(&font, content)
+            .display(DisplayType::Block)
+            .item_type(UIItemType::TabBar(TabBarItem::None))
+            .min_width(Some(Dimension::Pixels(tab_bar_width)))
+            .min_height(Some(Dimension::Pixels(self.dimensions.pixel_height as f32)))
+            .colors(bar_colors);
+
+        let border = self.get_os_border();
+
+        let mut computed = self.compute_element(
+            &LayoutContext {
+                height: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: self.dimensions.pixel_height as f32,
+                    pixel_cell: metrics.cell_size.height as f32,
+                },
+                width: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: tab_bar_width,
+                    pixel_cell: metrics.cell_size.width as f32,
+                },
+                bounds: euclid::rect(
+                    0.,
+                    border.top.get() as f32,
+                    tab_bar_width,
+                    self.dimensions.pixel_height as f32 - (border.top + border.bottom).get() as f32,
+                ),
+                metrics: &metrics,
+                gl_state: self.render_state.as_ref().unwrap(),
+                zindex: 10,
+            },
+            &tabs,
+        )?;
+
+        // Position the tab bar on the correct side
+        let translate_x = if pos == TabBarPosition::Right {
+            self.dimensions.pixel_width as f32 - tab_bar_width - border.right.get() as f32
+        } else {
+            // Left
+            border.left.get() as f32
+        };
+        computed.translate(euclid::vec2(translate_x, 0.));
+
+        Ok(computed)
+    }
+
+    /// Compute the bar background colors based on focus state.
+    fn tab_bar_colors(&self) -> ElementColors {
+        ElementColors {
+            border: BorderColor::default(),
+            bg: if self.focused.is_some() {
+                self.config.window_frame.active_titlebar_bg
+            } else {
+                self.config.window_frame.inactive_titlebar_bg
+            }
+            .to_linear()
+            .into(),
+            text: if self.focused.is_some() {
+                self.config.window_frame.active_titlebar_fg
+            } else {
+                self.config.window_frame.inactive_titlebar_fg
+            }
+            .to_linear()
+            .into(),
+        }
+    }
+
+    /// Convert a TabEntry into an Element, used for both horizontal and vertical tab bars.
+    fn tab_item_to_element(
+        &self,
+        item: &TabEntry,
+        font: &Rc<LoadedFont>,
+        metrics: &RenderMetrics,
+        palette: &ColorPalette,
+        colors: &TabBarColors,
+        bar_colors: &ElementColors,
+        _vertical: bool,
+    ) -> Element {
+        let element = Element::with_line(font, &item.title, palette);
+
+        let bg_color = item
+            .title
+            .get_cell(0)
+            .and_then(|c| match c.attrs().background() {
+                ColorAttribute::Default => None,
+                col => Some(palette.resolve_bg(col)),
+            });
+        let fg_color = item
+            .title
+            .get_cell(0)
+            .and_then(|c| match c.attrs().foreground() {
+                ColorAttribute::Default => None,
+                col => Some(palette.resolve_fg(col)),
+            });
+
+        let new_tab = colors.new_tab();
+        let new_tab_hover = colors.new_tab_hover();
+        let active_tab = colors.active_tab();
+
+        match item.item {
+            TabBarItem::RightStatus | TabBarItem::LeftStatus | TabBarItem::None => element
+                .item_type(UIItemType::TabBar(TabBarItem::None))
+                .line_height(Some(1.75))
+                .margin(BoxDimension {
+                    left: Dimension::Cells(0.),
+                    right: Dimension::Cells(0.),
+                    top: Dimension::Cells(0.0),
+                    bottom: Dimension::Cells(0.),
+                })
+                .padding(BoxDimension {
+                    left: Dimension::Cells(0.5),
+                    right: Dimension::Cells(0.),
+                    top: Dimension::Cells(0.),
+                    bottom: Dimension::Cells(0.),
+                })
+                .border(BoxDimension::new(Dimension::Pixels(0.)))
+                .colors(bar_colors.clone()),
+            TabBarItem::NewTabButton => Element::new(
+                font,
+                ElementContent::Poly {
+                    line_width: metrics.underline_height.max(2),
+                    poly: SizedPoly {
+                        poly: PLUS_BUTTON,
+                        width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+                        height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+                    },
+                },
+            )
+            .vertical_align(VerticalAlign::Middle)
+            .item_type(UIItemType::TabBar(item.item.clone()))
+            .margin(BoxDimension {
+                left: Dimension::Cells(0.5),
+                right: Dimension::Cells(0.),
+                top: Dimension::Cells(0.2),
+                bottom: Dimension::Cells(0.),
+            })
+            .padding(BoxDimension {
+                left: Dimension::Cells(0.5),
+                right: Dimension::Cells(0.5),
+                top: Dimension::Cells(0.2),
+                bottom: Dimension::Cells(0.25),
+            })
+            .border(BoxDimension::new(Dimension::Pixels(1.)))
+            .colors(ElementColors {
+                border: BorderColor::default(),
+                bg: new_tab.bg_color.to_linear().into(),
+                text: new_tab.fg_color.to_linear().into(),
+            })
+            .hover_colors(Some(ElementColors {
+                border: BorderColor::default(),
+                bg: new_tab_hover.bg_color.to_linear().into(),
+                text: new_tab_hover.fg_color.to_linear().into(),
+            })),
+            TabBarItem::Tab { active, .. } if active => element
+                .vertical_align(VerticalAlign::Bottom)
+                .item_type(UIItemType::TabBar(item.item.clone()))
+                .margin(BoxDimension {
+                    left: Dimension::Cells(0.),
+                    right: Dimension::Cells(0.),
+                    top: Dimension::Cells(0.2),
+                    bottom: Dimension::Cells(0.),
+                })
+                .padding(BoxDimension {
+                    left: Dimension::Cells(0.5),
+                    right: Dimension::Cells(0.5),
+                    top: Dimension::Cells(0.2),
+                    bottom: Dimension::Cells(0.25),
+                })
+                .border(BoxDimension::new(Dimension::Pixels(1.)))
+                .border_corners(Some(Corners {
+                    top_left: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: TOP_LEFT_ROUNDED_CORNER,
+                    },
+                    top_right: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: TOP_RIGHT_ROUNDED_CORNER,
+                    },
+                    bottom_left: SizedPoly::none(),
+                    bottom_right: SizedPoly::none(),
+                }))
+                .colors(ElementColors {
+                    border: BorderColor::new(
+                        bg_color
+                            .unwrap_or_else(|| active_tab.bg_color.into())
+                            .to_linear(),
+                    ),
+                    bg: bg_color
+                        .unwrap_or_else(|| active_tab.bg_color.into())
+                        .to_linear()
+                        .into(),
+                    text: fg_color
+                        .unwrap_or_else(|| active_tab.fg_color.into())
+                        .to_linear()
+                        .into(),
+                }),
+            TabBarItem::Tab { .. } => element
+                .vertical_align(VerticalAlign::Bottom)
+                .item_type(UIItemType::TabBar(item.item.clone()))
+                .margin(BoxDimension {
+                    left: Dimension::Cells(0.),
+                    right: Dimension::Cells(0.),
+                    top: Dimension::Cells(0.2),
+                    bottom: Dimension::Cells(0.),
+                })
+                .padding(BoxDimension {
+                    left: Dimension::Cells(0.5),
+                    right: Dimension::Cells(0.5),
+                    top: Dimension::Cells(0.2),
+                    bottom: Dimension::Cells(0.25),
+                })
+                .border(BoxDimension::new(Dimension::Pixels(1.)))
+                .border_corners(Some(Corners {
+                    top_left: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: TOP_LEFT_ROUNDED_CORNER,
+                    },
+                    top_right: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: TOP_RIGHT_ROUNDED_CORNER,
+                    },
+                    bottom_left: SizedPoly {
+                        width: Dimension::Cells(0.),
+                        height: Dimension::Cells(0.33),
+                        poly: &[],
+                    },
+                    bottom_right: SizedPoly {
+                        width: Dimension::Cells(0.),
+                        height: Dimension::Cells(0.33),
+                        poly: &[],
+                    },
+                }))
+                .colors({
+                    let inactive_tab = colors.inactive_tab();
+                    let bg = bg_color
+                        .unwrap_or_else(|| inactive_tab.bg_color.into())
+                        .to_linear();
+                    let edge = colors.inactive_tab_edge().to_linear();
+                    ElementColors {
+                        border: BorderColor {
+                            left: bg,
+                            right: edge,
+                            top: bg,
+                            bottom: bg,
+                        },
+                        bg: bg.into(),
+                        text: fg_color
+                            .unwrap_or_else(|| inactive_tab.fg_color.into())
+                            .to_linear()
+                            .into(),
+                    }
+                })
+                .hover_colors({
+                    let inactive_tab_hover = colors.inactive_tab_hover();
+                    Some(ElementColors {
+                        border: BorderColor::new(
+                            bg_color
+                                .unwrap_or_else(|| inactive_tab_hover.bg_color.into())
+                                .to_linear(),
+                        ),
+                        bg: bg_color
+                            .unwrap_or_else(|| inactive_tab_hover.bg_color.into())
+                            .to_linear()
+                            .into(),
+                        text: fg_color
+                            .unwrap_or_else(|| inactive_tab_hover.fg_color.into())
+                            .to_linear()
+                            .into(),
+                    })
+                }),
+            TabBarItem::WindowButton(button) => window_button_element(
+                button,
+                self.window_state.contains(window::WindowState::MAXIMIZED),
+                font,
+                metrics,
+                &self.config,
+            ),
+        }
     }
 
     pub fn paint_fancy_tab_bar(&self) -> anyhow::Result<Vec<UIItem>> {
@@ -479,7 +679,7 @@ fn make_x_button(
     active: bool,
 ) -> Element {
     Element::new(
-        &font,
+        font,
         ElementContent::Poly {
             line_width: metrics.underline_height.max(2),
             poly: SizedPoly {

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -62,16 +62,26 @@ impl crate::TermWindow {
 
         let (padding_left, padding_top) = self.padding_left_top();
 
-        let tab_bar_height = if self.show_tab_bar {
+        let tab_pos = self.resolved_tab_bar_position();
+        let tab_bar_height = if self.show_tab_bar && !tab_pos.is_vertical() {
             self.tab_bar_pixel_height()
                 .context("tab_bar_pixel_height")?
         } else {
             0.
         };
-        let (top_bar_height, bottom_bar_height) = if self.config.tab_bar_at_bottom {
-            (0.0, tab_bar_height)
+        let tab_bar_width = if self.show_tab_bar {
+            self.tab_bar_pixel_width()
         } else {
-            (tab_bar_height, 0.0)
+            0.
+        };
+        let (top_bar_height, bottom_bar_height) = match tab_pos {
+            config::TabBarPosition::Bottom => (0.0, tab_bar_height),
+            config::TabBarPosition::Top => (tab_bar_height, 0.0),
+            _ => (0.0, 0.0),
+        };
+        let left_bar_width = match tab_pos {
+            config::TabBarPosition::Left => tab_bar_width,
+            _ => 0.0,
         };
 
         let border = self.get_os_border();
@@ -111,12 +121,12 @@ impl crate::TermWindow {
             // We want to fill out to the edges of the splits
             let (x, width_delta) = if pos.left == 0 {
                 (
-                    0.,
+                    left_bar_width,
                     padding_left + border.left.get() as f32 + (cell_width / 2.0),
                 )
             } else {
                 (
-                    padding_left + border.left.get() as f32 - (cell_width / 2.0)
+                    left_bar_width + padding_left + border.left.get() as f32 - (cell_width / 2.0)
                         + (pos.left as f32 * cell_width),
                     cell_width,
                 )
@@ -337,7 +347,8 @@ impl crate::TermWindow {
                 error: Option<anyhow::Error>,
             }
 
-            let left_pixel_x = padding_left
+            let left_pixel_x = left_bar_width
+                + padding_left
                 + border.left.get() as f32
                 + (pos.left as f32 * self.render_metrics.cell_size.width as f32);
 
@@ -588,15 +599,25 @@ impl crate::TermWindow {
         let cell_width = self.render_metrics.cell_size.width as f32;
         let cell_height = self.render_metrics.cell_size.height as f32;
         let (padding_left, padding_top) = self.padding_left_top();
-        let tab_bar_height = if self.show_tab_bar {
+        let bp = self.resolved_tab_bar_position();
+        let tab_bar_height = if self.show_tab_bar && !bp.is_vertical() {
             self.tab_bar_pixel_height()?
         } else {
             0.
         };
-        let (top_bar_height, _bottom_bar_height) = if self.config.tab_bar_at_bottom {
-            (0.0, tab_bar_height)
+        let tab_bar_width = if self.show_tab_bar {
+            self.tab_bar_pixel_width()
         } else {
-            (tab_bar_height, 0.0)
+            0.
+        };
+        let (top_bar_height, _bottom_bar_height) = match bp {
+            config::TabBarPosition::Bottom => (0.0, tab_bar_height),
+            config::TabBarPosition::Top => (tab_bar_height, 0.0),
+            _ => (0.0, 0.0),
+        };
+        let left_bar_width2 = match bp {
+            config::TabBarPosition::Left => tab_bar_width,
+            _ => 0.0,
         };
 
         let border = self.get_os_border();
@@ -605,12 +626,12 @@ impl crate::TermWindow {
         // We want to fill out to the edges of the splits
         let (x, width_delta) = if pos.left == 0 {
             (
-                0.,
+                left_bar_width2,
                 padding_left + border.left.get() as f32 + (cell_width / 2.0),
             )
         } else {
             (
-                padding_left + border.left.get() as f32 - (cell_width / 2.0)
+                left_bar_width2 + padding_left + border.left.get() as f32 - (cell_width / 2.0)
                     + (pos.left as f32 * cell_width),
                 cell_width,
             )
@@ -647,7 +668,7 @@ impl crate::TermWindow {
 
         // Bounds for the terminal cells
         let content_rect = euclid::rect(
-            padding_left + border.left.get() as f32 - (cell_width / 2.0)
+            left_bar_width2 + padding_left + border.left.get() as f32 - (cell_width / 2.0)
                 + (pos.left as f32 * cell_width),
             top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),
             pos.width as f32 * cell_width,

--- a/wezterm-gui/src/termwindow/render/split.rs
+++ b/wezterm-gui/src/termwindow/render/split.rs
@@ -53,6 +53,7 @@ impl crate::TermWindow {
             self.ui_items.push(UIItem {
                 x: border.left.get() as usize
                     + padding_left as usize
+                    + left_bar_offset as usize
                     + (split.left * cell_width as usize),
                 width: cell_width as usize,
                 y: padding_top as usize
@@ -76,6 +77,7 @@ impl crate::TermWindow {
             self.ui_items.push(UIItem {
                 x: border.left.get() as usize
                     + padding_left as usize
+                    + left_bar_offset as usize
                     + (split.left * cell_width as usize),
                 width: split.size * cell_width as usize,
                 y: padding_top as usize

--- a/wezterm-gui/src/termwindow/render/split.rs
+++ b/wezterm-gui/src/termwindow/render/split.rs
@@ -17,16 +17,26 @@ impl crate::TermWindow {
         let cell_height = self.render_metrics.cell_size.height as f32;
 
         let border = self.get_os_border();
-        let first_row_offset = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
+        let tab_pos = self.resolved_tab_bar_position();
+        let first_row_offset = if self.show_tab_bar && tab_pos == config::TabBarPosition::Top {
             self.tab_bar_pixel_height()?
         } else {
             0.
         } + border.top.get() as f32;
 
+        let left_bar_offset = if self.show_tab_bar && tab_pos == config::TabBarPosition::Left {
+            self.tab_bar_pixel_width()
+        } else {
+            0.
+        };
+
         let (padding_left, padding_top) = self.padding_left_top();
 
         let pos_y = split.top as f32 * cell_height + first_row_offset + padding_top;
-        let pos_x = split.left as f32 * cell_width + padding_left + border.left.get() as f32;
+        let pos_x = split.left as f32 * cell_width
+            + padding_left
+            + border.left.get() as f32
+            + left_bar_offset;
 
         if split.direction == SplitDirection::Horizontal {
             self.filled_rectangle(

--- a/wezterm-gui/src/termwindow/render/tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/tab_bar.rs
@@ -1,14 +1,35 @@
 use crate::quad::TripleLayerQuadAllocator;
 use crate::termwindow::render::RenderScreenLineParams;
 use crate::utilsprites::RenderMetrics;
-use config::ConfigHandle;
+use config::{ConfigHandle, DimensionContext, TabBarPosition};
 use mux::renderable::RenderableDimensions;
 use wezterm_term::color::ColorAttribute;
 use window::color::LinearRgba;
 
 impl crate::TermWindow {
+    /// Returns the effective tab bar position, taking into account both
+    /// `tab_bar_position` and the legacy `tab_bar_at_bottom` config option.
+    pub fn resolved_tab_bar_position(&self) -> TabBarPosition {
+        self.config.resolved_tab_bar_position()
+    }
+
+    /// Returns true if the tab bar is positioned vertically (Left or Right).
+    pub fn is_tab_bar_vertical(&self) -> bool {
+        self.resolved_tab_bar_position().is_vertical()
+    }
+
+    /// Returns the effective use_fancy_tab_bar setting.
+    /// Vertical tab bar positions require fancy mode, so we force it on.
+    pub fn effective_use_fancy_tab_bar(&self) -> bool {
+        if self.is_tab_bar_vertical() {
+            true
+        } else {
+            self.config.use_fancy_tab_bar
+        }
+    }
+
     pub fn paint_tab_bar(&mut self, layers: &mut TripleLayerQuadAllocator) -> anyhow::Result<()> {
-        if self.config.use_fancy_tab_bar {
+        if self.effective_use_fancy_tab_bar() {
             if self.fancy_tab_bar.is_none() {
                 let palette = self.palette().clone();
                 let tab_bar = self.build_fancy_tab_bar(&palette)?;
@@ -19,11 +40,13 @@ impl crate::TermWindow {
             return Ok(());
         }
 
+        // Classic (retro) tab bar rendering — only for Top/Bottom positions
         let border = self.get_os_border();
+        let pos = self.resolved_tab_bar_position();
 
         let palette = self.palette().clone();
         let tab_bar_height = self.tab_bar_pixel_height()?;
-        let tab_bar_y = if self.config.tab_bar_at_bottom {
+        let tab_bar_y = if pos == TabBarPosition::Bottom {
             ((self.dimensions.pixel_height as f32) - (tab_bar_height + border.bottom.get() as f32))
                 .max(0.)
         } else {
@@ -105,7 +128,7 @@ impl crate::TermWindow {
         fontconfig: &wezterm_font::FontConfiguration,
         render_metrics: &RenderMetrics,
     ) -> anyhow::Result<f32> {
-        if config.use_fancy_tab_bar {
+        if config.use_fancy_tab_bar || config.resolved_tab_bar_position().is_vertical() {
             let font = fontconfig.title_font()?;
             Ok((font.metrics().cell_height.get() as f32 * 1.75).ceil())
         } else {
@@ -115,5 +138,28 @@ impl crate::TermWindow {
 
     pub fn tab_bar_pixel_height(&self) -> anyhow::Result<f32> {
         Self::tab_bar_pixel_height_impl(&self.config, &self.fonts, &self.render_metrics)
+    }
+
+    /// Returns the pixel width of the tab bar when positioned vertically (Left/Right).
+    /// Returns 0.0 for horizontal (Top/Bottom) positions.
+    pub fn tab_bar_pixel_width_impl(
+        config: &ConfigHandle,
+        render_metrics: &RenderMetrics,
+        dimensions: &::window::Dimensions,
+    ) -> f32 {
+        if config.resolved_tab_bar_position().is_vertical() {
+            let context = DimensionContext {
+                dpi: dimensions.dpi as f32,
+                pixel_max: dimensions.pixel_width as f32,
+                pixel_cell: render_metrics.cell_size.width as f32,
+            };
+            config.tab_bar_width.evaluate_as_pixels(context)
+        } else {
+            0.0
+        }
+    }
+
+    pub fn tab_bar_pixel_width(&self) -> f32 {
+        Self::tab_bar_pixel_width_impl(&self.config, &self.render_metrics, &self.dimensions)
     }
 }

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -163,8 +163,13 @@ impl super::TermWindow {
 
         let config = &self.config;
 
-        let tab_bar_height = if self.show_tab_bar {
+        let tab_bar_height = if self.show_tab_bar && !self.is_tab_bar_vertical() {
             self.tab_bar_pixel_height().unwrap_or(0.)
+        } else {
+            0.
+        };
+        let tab_bar_width = if self.show_tab_bar {
+            self.tab_bar_pixel_width()
         } else {
             0.
         };
@@ -208,7 +213,8 @@ impl super::TermWindow {
 
             let pixel_width = (cols * self.render_metrics.cell_size.width as usize)
                 + (padding_left + padding_right)
-                + (border.left + border.right).get() as usize;
+                + (border.left + border.right).get() as usize
+                + tab_bar_width as usize;
 
             let dims = Dimensions {
                 pixel_width: pixel_width as usize,
@@ -225,6 +231,7 @@ impl super::TermWindow {
                 padding_bottom: padding_bottom,
                 border: border,
                 tab_bar_height: tab_bar_height as usize,
+                tab_bar_width: tab_bar_width as usize,
             };
 
             (size, dims, ri_calc)
@@ -247,10 +254,13 @@ impl super::TermWindow {
                 config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
             let padding_right = effective_right_padding(&config, h_context);
 
-            let avail_width = dimensions.pixel_width.saturating_sub(
-                (padding_left + padding_right) as usize
-                    + (border.left + border.right).get() as usize,
-            );
+            let avail_width = dimensions
+                .pixel_width
+                .saturating_sub(
+                    (padding_left + padding_right) as usize
+                        + (border.left + border.right).get() as usize,
+                )
+                .saturating_sub(tab_bar_width as usize);
             let avail_height = dimensions
                 .pixel_height
                 .saturating_sub(
@@ -283,6 +293,7 @@ impl super::TermWindow {
                 padding_bottom: padding_bottom,
                 border: border,
                 tab_bar_height: tab_bar_height as usize,
+                tab_bar_width: tab_bar_width as usize,
             };
 
             (size, *dimensions, ri_calc)
@@ -489,8 +500,14 @@ impl super::TermWindow {
         };
 
         let show_tab_bar = config.enable_tab_bar && !config.hide_tab_bar_if_only_one_tab;
-        let tab_bar_height = if show_tab_bar {
+        let is_vertical = config.resolved_tab_bar_position().is_vertical();
+        let tab_bar_height = if show_tab_bar && !is_vertical {
             self.tab_bar_pixel_height()? as usize
+        } else {
+            0
+        };
+        let tab_bar_width = if show_tab_bar && is_vertical {
+            Self::tab_bar_pixel_width_impl(&config, &render_metrics, &self.dimensions) as usize
         } else {
             0
         };
@@ -512,7 +529,8 @@ impl super::TermWindow {
         let dimensions = Dimensions {
             pixel_width: ((terminal_size.cols as usize * render_metrics.cell_size.width as usize)
                 + padding_left
-                + effective_right_padding(&config, h_context)),
+                + effective_right_padding(&config, h_context))
+                + tab_bar_width,
             pixel_height: ((terminal_size.rows as usize * render_metrics.cell_size.height as usize)
                 + padding_top
                 + padding_bottom) as usize


### PR DESCRIPTION
## Summary
      - Add `tab_bar_position` config option with `"Top"`, `"Bottom"`, `"Left"`, `"Right"` values
      - Add `tab_bar_width` config option (default `"200px"`) for controlling vertical tab bar width
      - Vertical positioning automatically uses the fancy tab bar; `tab_bar_at_bottom` continues to work for
      backward compatibility

Closes #3537

Disclosure: Built with Claude Code and checked with OpenAI Codex. 

PS: This is my first contribution to open source.