### PR TITLE
FIX: infinite feedback loop on slow SSHMUX connections when pane-switching, which hangs wezterm

### DIFF
--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -226,6 +226,18 @@ impl ClientPane {
                 // it here.
                 log::trace!("advised of remote pane focus: {pane_id}");
 
+                // Pre-set focused_remote_pane_id to match what the server told us.
+                // This prevents advise_focus() from echoing SetFocusedPane back to
+                // the server when focus_pane_and_containing_tab triggers
+                // advise_focus_change -> focus_changed(true) -> advise_focus().
+                // Without this, the echo creates an infinite feedback loop that
+                // hangs the GUI, especially over high-latency connections where
+                // stale echoes cause focus oscillation between panes.
+                {
+                    let mut focused = self.client.focused_remote_pane_id.lock().unwrap();
+                    *focused = Some(self.remote_pane_id);
+                }
+
                 let mux = Mux::get();
                 if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
                     log::error!("Error reconciling remote PaneFocused notification: {err:#}");


### PR DESCRIPTION
### Issue:

When switching panes/tabs over high-latency SSHMUX connections, wezterm hangs due to an infinite feedback loop between client and server:

1. User switches pane focus → client sends `SetFocusedPane(B)` to server
2. Server applies the change and broadcasts `PaneFocused(B)` back to all clients, including the originator
3. Client receives the echo → `focus_pane_and_containing_tab()` → `set_active_pane()` → `advise_focus_change()` → `focus_changed(true)` → `advise_focus()` → sends another `SetFocusedPane(B)` back to server
5. Goto 2

With rapid switching (A→B→A), stale echoes cause oscillation between panes, flooding the event loop.
The existing guard in `advise_focus()` on `focused_remote_pane_id` does not prevent this because during oscillation the focus genuinely alternates between different pane IDs.

### Fix:

In `process_unilateral()`'s `PaneFocused` handler, pre-set `focused_remote_pane_id` to match the server's notification **before** calling `focus_pane_and_containing_tab`. 
This way, when the call chain reaches `advise_focus()`, the guard sees the pane as already focused and suppresses the echo `SetFocusedPane` — breaking the loop.

The change is entirely client-side, very short, and no protocol version bumps nor server changes are needed.
A limitation of this fix is that rapid switching can still cause brief visual glitches where focus momentarily lands the wrong pane (this is still much preferable to the current behaviour, that simply results in wezterm hanging and requiring a restart).

It is my understanding that this PR fixes: #4390, #4693, #7388

### Related:

These two PR #6349, #7399 propose fixes for the mentioned issue (here, and in the linked issues) via a counter.
It seems that there are some unresolved questions about a single location where this counter is incremented (`ClientPane::advise_focus` could be a good place, with the counter handled locally and then transmitted only, instead of having both client and server generating the counters), and these implementations necessarily are more complex.

It would be great if this PR could be accepted for improve the situation for now.