### PR TITLE
ci: use windows-2025 runner

### DIFF
--- a/.github/workflows/gen_windows.yml
+++ b/.github/workflows/gen_windows.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    runs-on: "windows-2022"
+    runs-on: "windows-2025"
     
     env:
       CARGO_INCREMENTAL: "0"

--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   build:
-    runs-on: "windows-2022"
+    runs-on: "windows-2025"
     
     env:
       BUILD_REASON: "Schedule"

--- a/.github/workflows/gen_windows_tag.yml
+++ b/.github/workflows/gen_windows_tag.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: "windows-2022"
+    runs-on: "windows-2025"
     
     env:
       CARGO_INCREMENTAL: "0"

--- a/ci/generate-workflows.py
+++ b/ci/generate-workflows.py
@@ -1018,9 +1018,7 @@ TARGETS = [
     Target(container="fedora:41"),
     # Target(container="alpine:3.15"),
 
-    # Windows is on 2022 for the time being due to
-    # https://github.com/actions/runner-images/issues/11644
-    Target(name="windows", os="windows-2022", rust_target="x86_64-pc-windows-msvc"),
+    Target(name="windows", os="windows-2025", rust_target="x86_64-pc-windows-msvc"),
 ]
 
 


### PR DESCRIPTION
Inno Setup is now included in the windows-2025 runner [1]. 
Instead of reverting b7dd3bc812f1decaeefed7b77da59a800c73d339, switch to windows-2025.

I came across this when I was working on https://github.com/wezterm/wezterm/pull/7592.

[1] https://github.com/actions/runner-images/pull/13090

