### PR TITLE
tweak(ui::tabbar)[#6739]: flip the black tab shape

### DIFF
--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -152,7 +152,7 @@ impl crate::TermWindow {
                     left: Dimension::Cells(0.5),
                     right: Dimension::Cells(0.5),
                     top: Dimension::Cells(0.2),
-                    bottom: Dimension::Cells(0.25),
+                    bottom: Dimension::Cells(0.5),
                 })
                 .border(BoxDimension::new(Dimension::Pixels(1.)))
                 .colors(ElementColors {
@@ -171,29 +171,37 @@ impl crate::TermWindow {
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
                         right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.2),
+                        top: Dimension::Cells(0.),
                         bottom: Dimension::Cells(0.),
                     })
                     .padding(BoxDimension {
                         left: Dimension::Cells(0.5),
                         right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.25),
+                        top: Dimension::Cells(0.5),
+                        bottom: Dimension::Cells(0.5),
                     })
                     .border(BoxDimension::new(Dimension::Pixels(1.)))
                     .border_corners(Some(Corners {
-                        top_left: SizedPoly {
+                        bottom_left: SizedPoly {
                             width: Dimension::Cells(0.5),
                             height: Dimension::Cells(0.5),
-                            poly: TOP_LEFT_ROUNDED_CORNER,
+                            poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                        },
+                        bottom_right: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.5),
+                            poly: BOTTOM_RIGHT_ROUNDED_CORNER,
+                        },
+                        top_left: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.),
+                            poly: &[],
                         },
                         top_right: SizedPoly {
                             width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_RIGHT_ROUNDED_CORNER,
+                            height: Dimension::Cells(0.),
+                            poly: &[],
                         },
-                        bottom_left: SizedPoly::none(),
-                        bottom_right: SizedPoly::none(),
                     }))
                     .colors(ElementColors {
                         border: BorderColor::new(
@@ -216,35 +224,35 @@ impl crate::TermWindow {
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
                         right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.2),
+                        top: Dimension::Cells(0.),
                         bottom: Dimension::Cells(0.),
                     })
                     .padding(BoxDimension {
                         left: Dimension::Cells(0.5),
                         right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.25),
+                        top: Dimension::Cells(0.5),
+                        bottom: Dimension::Cells(0.5),
                     })
                     .border(BoxDimension::new(Dimension::Pixels(1.)))
                     .border_corners(Some(Corners {
-                        top_left: SizedPoly {
+                        bottom_left: SizedPoly {
                             width: Dimension::Cells(0.5),
                             height: Dimension::Cells(0.5),
-                            poly: TOP_LEFT_ROUNDED_CORNER,
+                            poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                        },
+                        bottom_right: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.5),
+                            poly: BOTTOM_RIGHT_ROUNDED_CORNER,
+                        },
+                        top_left: SizedPoly {
+                            width: Dimension::Cells(0.5),
+                            height: Dimension::Cells(0.),
+                            poly: &[],
                         },
                         top_right: SizedPoly {
                             width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_RIGHT_ROUNDED_CORNER,
-                        },
-                        bottom_left: SizedPoly {
-                            width: Dimension::Cells(0.),
-                            height: Dimension::Cells(0.33),
-                            poly: &[],
-                        },
-                        bottom_right: SizedPoly {
-                            width: Dimension::Cells(0.),
-                            height: Dimension::Cells(0.33),
+                            height: Dimension::Cells(0.),
                             poly: &[],
                         },
                     }))

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -111,6 +111,54 @@ impl crate::TermWindow {
             let new_tab_hover = colors.new_tab_hover();
             let active_tab = colors.active_tab();
 
+            let corners = if self.config.tab_bar_at_bottom {
+                Corners {
+                    top_left: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.),
+                        poly: &[],
+                    },
+                    top_right: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.),
+                        poly: &[],
+                    },
+                    bottom_left: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                    },
+                    bottom_right: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: BOTTOM_RIGHT_ROUNDED_CORNER,
+                    },
+                }
+            } else {
+                Corners {
+                    top_left: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: TOP_LEFT_ROUNDED_CORNER,
+                    },
+                    top_right: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.5),
+                        poly: TOP_RIGHT_ROUNDED_CORNER,
+                    },
+                    bottom_left: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.),
+                        poly: &[],
+                    },
+                    bottom_right: SizedPoly {
+                        width: Dimension::Cells(0.5),
+                        height: Dimension::Cells(0.),
+                        poly: &[],
+                    },
+                }
+            };
+
             match item.item {
                 TabBarItem::RightStatus | TabBarItem::LeftStatus | TabBarItem::None => element
                     .item_type(UIItemType::TabBar(TabBarItem::None))
@@ -145,14 +193,14 @@ impl crate::TermWindow {
                 .margin(BoxDimension {
                     left: Dimension::Cells(0.5),
                     right: Dimension::Cells(0.),
-                    top: Dimension::Cells(0.2),
+                    top: Dimension::Cells(0.),
                     bottom: Dimension::Cells(0.),
                 })
                 .padding(BoxDimension {
                     left: Dimension::Cells(0.5),
                     right: Dimension::Cells(0.5),
-                    top: Dimension::Cells(0.2),
-                    bottom: Dimension::Cells(0.25),
+                    top: Dimension::Cells(0.5),
+                    bottom: Dimension::Cells(0.5),
                 })
                 .border(BoxDimension::new(Dimension::Pixels(1.)))
                 .colors(ElementColors {
@@ -171,30 +219,17 @@ impl crate::TermWindow {
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
                         right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.2),
+                        top: Dimension::Cells(0.),
                         bottom: Dimension::Cells(0.),
                     })
                     .padding(BoxDimension {
                         left: Dimension::Cells(0.5),
                         right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.25),
+                        top: Dimension::Cells(0.5),
+                        bottom: Dimension::Cells(0.5),
                     })
                     .border(BoxDimension::new(Dimension::Pixels(1.)))
-                    .border_corners(Some(Corners {
-                        top_left: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_LEFT_ROUNDED_CORNER,
-                        },
-                        top_right: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_RIGHT_ROUNDED_CORNER,
-                        },
-                        bottom_left: SizedPoly::none(),
-                        bottom_right: SizedPoly::none(),
-                    }))
+                    .border_corners(Some(corners))
                     .colors(ElementColors {
                         border: BorderColor::new(
                             bg_color
@@ -216,38 +251,17 @@ impl crate::TermWindow {
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
                         right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.2),
+                        top: Dimension::Cells(0.),
                         bottom: Dimension::Cells(0.),
                     })
                     .padding(BoxDimension {
                         left: Dimension::Cells(0.5),
                         right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.2),
-                        bottom: Dimension::Cells(0.25),
+                        top: Dimension::Cells(0.5),
+                        bottom: Dimension::Cells(0.5),
                     })
                     .border(BoxDimension::new(Dimension::Pixels(1.)))
-                    .border_corners(Some(Corners {
-                        top_left: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_LEFT_ROUNDED_CORNER,
-                        },
-                        top_right: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: TOP_RIGHT_ROUNDED_CORNER,
-                        },
-                        bottom_left: SizedPoly {
-                            width: Dimension::Cells(0.),
-                            height: Dimension::Cells(0.33),
-                            poly: &[],
-                        },
-                        bottom_right: SizedPoly {
-                            width: Dimension::Cells(0.),
-                            height: Dimension::Cells(0.33),
-                            poly: &[],
-                        },
-                    }))
+                    .border_corners(Some(corners))
                     .colors({
                         let inactive_tab = colors.inactive_tab();
                         let bg = bg_color

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -152,7 +152,7 @@ impl crate::TermWindow {
                     left: Dimension::Cells(0.5),
                     right: Dimension::Cells(0.5),
                     top: Dimension::Cells(0.2),
-                    bottom: Dimension::Cells(0.5),
+                    bottom: Dimension::Cells(0.25),
                 })
                 .border(BoxDimension::new(Dimension::Pixels(1.)))
                 .colors(ElementColors {
@@ -171,37 +171,29 @@ impl crate::TermWindow {
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
                         right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.),
+                        top: Dimension::Cells(0.2),
                         bottom: Dimension::Cells(0.),
                     })
                     .padding(BoxDimension {
                         left: Dimension::Cells(0.5),
                         right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.5),
-                        bottom: Dimension::Cells(0.5),
+                        top: Dimension::Cells(0.2),
+                        bottom: Dimension::Cells(0.25),
                     })
                     .border(BoxDimension::new(Dimension::Pixels(1.)))
                     .border_corners(Some(Corners {
-                        bottom_left: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: BOTTOM_LEFT_ROUNDED_CORNER,
-                        },
-                        bottom_right: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: BOTTOM_RIGHT_ROUNDED_CORNER,
-                        },
                         top_left: SizedPoly {
                             width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.),
-                            poly: &[],
+                            height: Dimension::Cells(0.5),
+                            poly: TOP_LEFT_ROUNDED_CORNER,
                         },
                         top_right: SizedPoly {
                             width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.),
-                            poly: &[],
+                            height: Dimension::Cells(0.5),
+                            poly: TOP_RIGHT_ROUNDED_CORNER,
                         },
+                        bottom_left: SizedPoly::none(),
+                        bottom_right: SizedPoly::none(),
                     }))
                     .colors(ElementColors {
                         border: BorderColor::new(
@@ -224,35 +216,35 @@ impl crate::TermWindow {
                     .margin(BoxDimension {
                         left: Dimension::Cells(0.),
                         right: Dimension::Cells(0.),
-                        top: Dimension::Cells(0.),
+                        top: Dimension::Cells(0.2),
                         bottom: Dimension::Cells(0.),
                     })
                     .padding(BoxDimension {
                         left: Dimension::Cells(0.5),
                         right: Dimension::Cells(0.5),
-                        top: Dimension::Cells(0.5),
-                        bottom: Dimension::Cells(0.5),
+                        top: Dimension::Cells(0.2),
+                        bottom: Dimension::Cells(0.25),
                     })
                     .border(BoxDimension::new(Dimension::Pixels(1.)))
                     .border_corners(Some(Corners {
-                        bottom_left: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: BOTTOM_LEFT_ROUNDED_CORNER,
-                        },
-                        bottom_right: SizedPoly {
-                            width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.5),
-                            poly: BOTTOM_RIGHT_ROUNDED_CORNER,
-                        },
                         top_left: SizedPoly {
                             width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.),
-                            poly: &[],
+                            height: Dimension::Cells(0.5),
+                            poly: TOP_LEFT_ROUNDED_CORNER,
                         },
                         top_right: SizedPoly {
                             width: Dimension::Cells(0.5),
-                            height: Dimension::Cells(0.),
+                            height: Dimension::Cells(0.5),
+                            poly: TOP_RIGHT_ROUNDED_CORNER,
+                        },
+                        bottom_left: SizedPoly {
+                            width: Dimension::Cells(0.),
+                            height: Dimension::Cells(0.33),
+                            poly: &[],
+                        },
+                        bottom_right: SizedPoly {
+                            width: Dimension::Cells(0.),
+                            height: Dimension::Cells(0.33),
                             poly: &[],
                         },
                     }))


### PR DESCRIPTION
Hi Wez,

this is a hack to solve ticket #6739.

I did not fully knew, what I was doing, but I managed to flip the shape and remove the top padding of the tabs.

<img width="978" height="717" alt="image" src="https://github.com/user-attachments/assets/c9301de7-08a4-4bf1-b0ff-56031e3dba30" />

I tested opening multiple tabs, changing the active one, and hovering.

To my taste the tab bar is just a little too thick, but maybe not.

I have ran

```sh
cargo fmt --all
cargo test --all
```

I got, but I think this is because of my system, does not seem to be because of my change.

```sh
thread 'e2e::sftp::symlink_should_succeed_even_if_path_missing' (210073) panicked at wezterm-ssh/tests/e2e/sftp.rs:562:14:
Unexpected file, failed var is symlink
├── follow: false
└── error: No such file or directory (os error 2)

path=/tmp/.tmp0WrA26/link
[2026-02-19T15:41:11Z TRACE wezterm_ssh::session] Drop Session


failures:
    e2e::sftp::symlink_should_create_symlink_pointing_to_directory
    e2e::sftp::symlink_should_create_symlink_pointing_to_file
    e2e::sftp::symlink_should_succeed_even_if_path_missing

test result: FAILED. 36 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.87s

error: test failed, to rerun pass `-p wezterm-ssh --test lib`
```

Thanks.
