### PR TITLE
fix: sync user_vars on mux reconnect (Issue #5832)

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -925,6 +925,8 @@ pub struct GetPaneRenderChangesResponse {
 
     pub input_serial: Option<InputSerial>,
     pub seqno: SequenceNo,
+    #[serde(default)]
+    pub user_vars: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -138,6 +138,7 @@ impl ClientPane {
         match pdu {
             Pdu::GetPaneRenderChangesResponse(mut delta) => {
                 *self.mouse_grabbed.lock() = delta.mouse_grabbed;
+                *self.user_vars.lock() = std::mem::take(&mut delta.user_vars);
 
                 let bonus_lines = std::mem::take(&mut delta.bonus_lines);
                 let client = { Arc::clone(&self.renderable.lock().inner.borrow().client) };

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -139,6 +139,7 @@ impl PerPane {
             working_dir: working_dir.map(Into::into),
             input_serial: force_with_input_serial,
             seqno: self.seqno,
+            user_vars: pane.copy_user_vars(),
         })
     }
 }


### PR DESCRIPTION
Fixes #5832

## Problem

When reconnecting to a mux server (detach → reattach), user variables
set during the session are lost. This is because `GetPaneRenderChangesResponse`
does not include `user_vars` — only real-time changes via `NotifyAlert`
are propagated. On reconnect, the client starts with an empty HashMap.

## Solution

Include `user_vars` in `GetPaneRenderChangesResponse` so that they are
synced on every render update, including the first one after reconnect.

Changes (3 files, +4 lines):

- **codec/src/lib.rs**: Add `user_vars: HashMap<String, String>` field
  to `GetPaneRenderChangesResponse` with `#[serde(default)]`
- **wezterm-mux-server-impl/src/sessionhandler.rs**: Populate `user_vars`
  via `pane.copy_user_vars()` in the response
- **wezterm-client/src/pane/clientpane.rs**: Apply received `user_vars`
  to the client pane state

## Compatibility note

Adding a field to `GetPaneRenderChangesResponse` changes the bincode
serialization format. Although `#[serde(default)]` is present, bincode
does not support optional trailing fields the way JSON does, so mixed
versions will fail to communicate.

This may warrant a `CODEC_VERSION` bump. I've left it unchanged in this
PR — happy to add the bump if preferred.

## Testing

Verified with a local build: set a user var in a mux session, detach,
reattach, and confirm the user var is preserved.
