### PR TITLE
Fix X11 EGL surface use-after-free during window destruction

### DIFF
--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -118,6 +118,11 @@ const _NET_WM_MOVERESIZE_CANCEL: u32 = 11;
 
 impl Drop for XWindowInner {
     fn drop(&mut self) {
+        // Drop the event handler first, because it indirectly owns the TermWindow
+        // and its glium resources. Those resources need a still-valid native window
+        // so that make_current() can succeed in their Drop impls.
+        self.drop_event_handler();
+
         if self.window_id != xcb::x::Window::none() {
             if let Some(conn) = self.conn.upgrade() {
                 self.conn()
@@ -158,6 +163,15 @@ impl HasWindowHandle for XWindowInner {
 }
 
 impl XWindowInner {
+    fn drop_event_handler(&mut self) {
+        // The handler captures TermWindow; dropping it before issuing
+        // DestroyWindow keeps the EGL surface valid for glium cleanup.
+        drop(std::mem::replace(
+            &mut self.events,
+            WindowEventSender::new(|_, _| {}),
+        ));
+    }
+
     fn enable_opengl(&mut self) -> anyhow::Result<Rc<glium::backend::Context>> {
         let conn = self.conn();
 
@@ -1590,6 +1604,10 @@ impl XWindowInner {
         conn.flush()
             .context("flush pending requests prior to issuing DestroyWindow")
             .ok();
+        // Drop the event handler first, because it indirectly owns the TermWindow
+        // and its glium resources. Those resources need a still-valid native window
+        // so that make_current() can succeed in their Drop impls.
+        self.drop_event_handler();
         // Remove the window from the map now, as GL state
         // requires that it is able to make_current() in its
         // Drop impl, and that cannot succeed after we've


### PR DESCRIPTION
I was working on adding a function to move a tab from one window to another and encountered crashes when closing windows. I am running WezTerm on X11. 

After a bit of digging, I think I found the culprit, though I am not entirely sure it's the only issue (even though the crashes are gone for me now).

The problem is that the event handler retains TermWindow, which, in turn, retains `glium::backend::Context`, which requires the X11 window handle to be alive when being dropped so that it can call `make_current`. If we destroy the X11 window before destroying the glium context, we get a crash. So the solution is to ensure that the glium context is dropped before we destroy the window.

There might be more places which retain the glium context (it's behind an Rc, after all), but I am not familiar enough with the codebase to track them down. All I know is that this fix solves the crashes I am having.