### PR TITLE
fix: suppress duplicate DA responses for tmux control mode panes

### DIFF
--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -211,13 +211,19 @@ impl TmuxDomainState {
             active_lock: active_lock.clone(),
         };
 
-        let terminal = wezterm_term::Terminal::new(
+        let mut terminal = wezterm_term::Terminal::new(
             size,
             std::sync::Arc::new(config::TermConfig::new()),
             "WezTerm",
             config::wezterm_version(),
             Box::new(writer.clone()),
         );
+        // Suppress DA responses for tmux control mode panes.
+        // tmux's own terminal emulator already responds to DA queries
+        // from pane applications. If wezterm also responds, the response
+        // travels back via send-keys and arrives after the querying
+        // application has exited, leaking as garbage in the shell.
+        terminal.suppress_device_attributes();
 
         Ok(Arc::new(LocalPane::new(
             local_pane_id,

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -373,6 +373,12 @@ pub struct TerminalState {
     /// We don't want that, so we use this flag to remember
     /// whether we want to skip it or not.
     suppress_initial_title_change: bool,
+    /// When true, suppress device attribute responses (DA1, DA2, DA3).
+    /// Used for tmux control mode panes where tmux's own terminal
+    /// emulator already responds to DA queries. Without this,
+    /// wezterm's response arrives late via send-keys and leaks
+    /// as garbage characters in the shell.
+    suppress_device_attributes: bool,
 
     accumulating_title: Option<String>,
 
@@ -574,6 +580,7 @@ impl TerminalState {
             unicode_version_stack: vec![],
             suppress_initial_title_change: false,
             enable_conpty_quirks: false,
+            suppress_device_attributes: false,
             accumulating_title: None,
             lost_focus_seqno: seqno,
             lost_focus_alerted_seqno: seqno,
@@ -587,6 +594,10 @@ impl TerminalState {
     pub fn enable_conpty_quirks(&mut self) {
         self.enable_conpty_quirks = true;
         self.suppress_initial_title_change = true;
+    }
+
+    pub fn suppress_device_attributes(&mut self) {
+        self.suppress_device_attributes = true;
     }
 
     pub fn current_seqno(&self) -> SequenceNo {
@@ -1285,37 +1296,43 @@ impl TerminalState {
                 self.g1_charset = CharSet::Ascii;
             }
             Device::RequestPrimaryDeviceAttributes => {
-                let mut ident = "\x1b[?65".to_string(); // Vt500
-                ident.push_str(";4"); // Sixel graphics
-                ident.push_str(";6"); // Selective erase
-                ident.push_str(";18"); // windowing extensions
-                ident.push_str(";22"); // ANSI color, vt525
-                ident.push_str(";52"); // Clipboard access
-                ident.push('c');
+                if !self.suppress_device_attributes {
+                    let mut ident = "\x1b[?65".to_string(); // Vt500
+                    ident.push_str(";4"); // Sixel graphics
+                    ident.push_str(";6"); // Selective erase
+                    ident.push_str(";18"); // windowing extensions
+                    ident.push_str(";22"); // ANSI color, vt525
+                    ident.push_str(";52"); // Clipboard access
+                    ident.push('c');
 
-                self.writer.write(ident.as_bytes()).ok();
-                self.writer.flush().ok();
+                    self.writer.write(ident.as_bytes()).ok();
+                    self.writer.flush().ok();
+                }
             }
             Device::RequestSecondaryDeviceAttributes => {
-                // Response is: Pp ; Pv ; Pc
-                // Where Pp=1 means vt220
-                // and Pv is the firmware version.
-                // Pc is always 0.
-                // Because our default TERM is xterm, the firmware
-                // version will be considered to be equialent to xterm's
-                // patch levels, with the following effects:
-                // pv < 95 -> ttymouse=xterm
-                // pv >= 95 < 277 -> ttymouse=xterm2
-                // pv >= 277 -> ttymouse=sgr
-                // pv >= 279 - xterm will probe for additional device settings.
-                self.writer.write(b"\x1b[>1;277;0c").ok();
-                self.writer.flush().ok();
+                if !self.suppress_device_attributes {
+                    // Response is: Pp ; Pv ; Pc
+                    // Where Pp=1 means vt220
+                    // and Pv is the firmware version.
+                    // Pc is always 0.
+                    // Because our default TERM is xterm, the firmware
+                    // version will be considered to be equialent to xterm's
+                    // patch levels, with the following effects:
+                    // pv < 95 -> ttymouse=xterm
+                    // pv >= 95 < 277 -> ttymouse=xterm2
+                    // pv >= 277 -> ttymouse=sgr
+                    // pv >= 279 - xterm will probe for additional device settings.
+                    self.writer.write(b"\x1b[>1;277;0c").ok();
+                    self.writer.flush().ok();
+                }
             }
             Device::RequestTertiaryDeviceAttributes => {
-                self.writer
-                    .write(format!("\x1bP!|00000000{}", ST).as_bytes())
-                    .ok();
-                self.writer.flush().ok();
+                if !self.suppress_device_attributes {
+                    self.writer
+                        .write(format!("\x1bP!|00000000{}", ST).as_bytes())
+                        .ok();
+                    self.writer.flush().ok();
+                }
             }
             Device::RequestTerminalNameAndVersion => {
                 self.writer.write(DCS.as_bytes()).ok();


### PR DESCRIPTION
## Summary

When using wezterm with `tmux -CC` (control mode), applications that query terminal Device Attributes (DA1/DA2/DA3) — like neovim — cause garbage characters to appear in the shell after exiting:

```
^[[?65;4;6;18;22;52c
```

**Root cause:** Both tmux and wezterm respond to DA queries, producing duplicate responses:

1. **tmux's terminal emulator** (`input.c`) responds synchronously via the pane PTY — the application receives this immediately
2. **wezterm's terminal state machine** also generates a response, which travels back through the tmux control protocol as a `send-keys` command. This round-trip is slow enough that by the time it arrives, the querying application has exited and the shell receives it as garbage input

**Fix:** Add a `suppress_device_attributes` flag to `TerminalState` (following the existing pattern of `suppress_initial_title_change` and `enable_conpty_quirks`) and set it when creating tmux control mode panes. Since tmux already handles DA responses for pane applications, the duplicate response from wezterm is both redundant and harmful.

## Changes

- `term/src/terminalstate/mod.rs`: Added `suppress_device_attributes` field and setter; guarded DA1, DA2, and DA3 response paths
- `mux/src/tmux_commands.rs`: Call `suppress_device_attributes()` when creating tmux control mode panes

## Test plan

- [x] Verified fix locally: launched wezterm with `tmux -CC`, opened and exited neovim repeatedly — no garbage characters
- [x] Verified without fix: same scenario reproduces the garbage characters consistently
- [x] `cargo fmt` clean
- [x] `cargo test` passes (3 pre-existing SFTP test failures unrelated to this change)
- [x] Non-tmux-CC usage unaffected (flag only set for tmux control mode panes)

Relates to #4167