### PR TITLE
Focus the originating pane/tab when a toast notification is clicked

### DIFF
--- a/wezterm-font/src/lib.rs
+++ b/wezterm-font/src/lib.rs
@@ -440,6 +440,7 @@ impl FallbackResolveInfo {
                     ),
                     url: Some(url.to_string()),
                     timeout: Some(Duration::from_secs(15)),
+                    on_click: None,
                 }
                 .show();
             } else {

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 use wezterm_term::{Alert, ClipboardSelection};
-use wezterm_toast_notification::*;
+use wezterm_toast_notification;
 
 pub struct GuiFrontEnd {
     connection: Rc<Connection>,
@@ -100,7 +100,7 @@ impl GuiFrontEnd {
                         Alert::ToastNotification {
                             title,
                             body,
-                            focus: _,
+                            focus,
                         },
                 } => {
                     let mux = Mux::get();
@@ -124,10 +124,39 @@ impl GuiFrontEnd {
                             if show {
                                 let message = if title.is_none() { "" } else { &body };
                                 let title = title.as_ref().unwrap_or(&body);
-                                // FIXME: if notification.focus is true, we should do
-                                // something here to arrange to focus pane_id when the
-                                // notification is clicked
-                                persistent_toast_notification(title, message);
+
+                                // When focus is requested, arrange to activate
+                                // the pane/tab that sent the notification when
+                                // the user clicks on it.
+                                let on_click = if focus {
+                                    Some(Box::new(move || {
+                                        promise::spawn::spawn_into_main_thread(async move {
+                                            let mux = Mux::get();
+                                            if let Err(err) =
+                                                mux.focus_pane_and_containing_tab(pane_id)
+                                            {
+                                                log::error!(
+                                                    "Error focusing pane from notification \
+                                                     click: {err:#}"
+                                                );
+                                            }
+                                        })
+                                        .detach();
+                                    })
+                                        as Box<dyn FnOnce() + Send + 'static>)
+                                } else {
+                                    None
+                                };
+
+                                wezterm_toast_notification::show(
+                                    wezterm_toast_notification::ToastNotification {
+                                        title: title.to_string(),
+                                        message: message.to_string(),
+                                        url: None,
+                                        timeout: None,
+                                        on_click,
+                                    },
+                                );
                             }
                         }
                     }

--- a/wezterm-gui/src/scripting/guiwin.rs
+++ b/wezterm-gui/src/scripting/guiwin.rs
@@ -88,7 +88,8 @@ impl UserData for GuiWin {
                     title,
                     message,
                     url,
-                    timeout: timeout.map(std::time::Duration::from_millis)
+                    timeout: timeout.map(std::time::Duration::from_millis),
+                    on_click: None,
                 });
                 Ok(())
             },

--- a/wezterm-toast-notification/src/dbus.rs
+++ b/wezterm-toast-notification/src/dbus.rs
@@ -109,7 +109,7 @@ async fn show_notif_impl(notif: ToastNotification) -> Result<(), Box<dyn std::er
             "org.wezfurlong.wezterm",
             &notif.title,
             &notif.message,
-            if notif.url.is_some() {
+            if notif.url.is_some() || notif.on_click.is_some() {
                 &["show", "Show"]
             } else {
                 &[]
@@ -118,6 +118,9 @@ async fn show_notif_impl(notif: ToastNotification) -> Result<(), Box<dyn std::er
             notif.timeout.map(|d| d.as_millis() as _).unwrap_or(0),
         )
         .await?;
+
+    // Move on_click out so we can consume it (FnOnce) in the action handler.
+    let mut on_click = notif.on_click;
 
     let (mut invoked_stream, abort_invoked) = abortable(proxy.receive_action_invoked().await?);
     let (mut closed_stream, abort_closed) = abortable(proxy.receive_notification_closed().await?);
@@ -129,9 +132,12 @@ async fn show_notif_impl(notif: ToastNotification) -> Result<(), Box<dyn std::er
                 if args.nid == notification {
                     if let Some(url) = notif.url.as_ref() {
                         wezterm_open_url::open_url(url);
-                        abort_closed.abort();
-                        break;
                     }
+                    if let Some(callback) = on_click.take() {
+                        callback();
+                    }
+                    abort_closed.abort();
+                    break;
                 }
             }
             Ok::<(), zbus::Error>(())

--- a/wezterm-toast-notification/src/lib.rs
+++ b/wezterm-toast-notification/src/lib.rs
@@ -2,12 +2,26 @@ mod dbus;
 mod macos;
 mod windows;
 
-#[derive(Debug, Clone)]
 pub struct ToastNotification {
     pub title: String,
     pub message: String,
     pub url: Option<String>,
     pub timeout: Option<std::time::Duration>,
+    /// Called when the user clicks the notification.
+    /// Use this to focus the pane/tab that triggered the notification.
+    pub on_click: Option<Box<dyn FnOnce() + Send + 'static>>,
+}
+
+impl std::fmt::Debug for ToastNotification {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ToastNotification")
+            .field("title", &self.title)
+            .field("message", &self.message)
+            .field("url", &self.url)
+            .field("timeout", &self.timeout)
+            .field("on_click", &self.on_click.as_ref().map(|_| "..."))
+            .finish()
+    }
 }
 
 impl ToastNotification {
@@ -44,6 +58,7 @@ pub fn persistent_toast_notification_with_click_to_open_url(title: &str, message
         message: message.to_string(),
         url: Some(url.to_string()),
         timeout: None,
+        on_click: None,
     });
 }
 
@@ -53,6 +68,7 @@ pub fn persistent_toast_notification(title: &str, message: &str) {
         message: message.to_string(),
         url: None,
         timeout: None,
+        on_click: None,
     });
 }
 

--- a/wezterm-toast-notification/src/macos.rs
+++ b/wezterm-toast-notification/src/macos.rs
@@ -11,7 +11,8 @@ use objc2_user_notifications::{
     UNNotificationPresentationOptions, UNNotificationRequest, UNNotificationResponse,
     UNUserNotificationCenter, UNUserNotificationCenterDelegate,
 };
-use std::sync::{LazyLock, Once};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex, Once};
 
 const NEEDS_SIGN: &str = "Note that the application must be code-signed \
                           for UNUserNotificationCenter to work";
@@ -64,13 +65,26 @@ define_class!(
             let action = response.actionIdentifier();
             let user_info = response.notification().request().content().userInfo();
             let url = user_info.valueForKey(ns_string!("url"));
+            let identifier = response
+                .notification()
+                .request()
+                .identifier()
+                .to_string();
 
-            log::debug!("did_receive_notification -> action={action:?} url={url:?}");
+            log::debug!(
+                "did_receive_notification -> action={action:?} url={url:?} id={identifier}"
+            );
 
             if let Some(url) = url {
                 if let Ok(url_str) = url.downcast::<NSString>() {
                     wezterm_open_url::open_url(&url_str.to_string());
                 }
+            }
+
+            // Invoke the on_click callback (e.g. to focus the pane/tab
+            // that triggered this notification).
+            if let Some(callback) = CLICK_CALLBACKS.lock().unwrap().remove(&identifier) {
+                callback();
             }
 
             completion_handler.call(());
@@ -95,6 +109,11 @@ impl Drop for NotifDelegate {
 
 const CENTER: LazyLock<Retained<UNUserNotificationCenter>> =
     LazyLock::new(|| unsafe { UNUserNotificationCenter::currentNotificationCenter() });
+
+/// Registry of on_click callbacks keyed by notification identifier.
+/// Stored when a notification is shown, removed and invoked when clicked.
+static CLICK_CALLBACKS: LazyLock<Mutex<HashMap<String, Box<dyn FnOnce() + Send>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 pub fn initialize() {
     static INIT: Once = Once::new();
@@ -147,10 +166,14 @@ pub fn initialize() {
     });
 }
 
-pub fn show_notif(toast: ToastNotification) -> Result<(), Box<dyn std::error::Error>> {
+pub fn show_notif(mut toast: ToastNotification) -> Result<(), Box<dyn std::error::Error>> {
     initialize();
     unsafe {
         log::debug!("show_notif center.delegate is {:?}", CENTER.delegate());
+
+        // Take on_click out early so `toast` can still be moved into the
+        // completion closure below without a partial-move error.
+        let on_click = toast.on_click.take();
 
         let notif = UNMutableNotificationContent::new();
         notif.setTitle(&NSString::from_str(&toast.title));
@@ -166,7 +189,16 @@ pub fn show_notif(toast: ToastNotification) -> Result<(), Box<dyn std::error::Er
             notif.setCategoryIdentifier(ns_string!("SHOW_URL_ACTION"));
         }
 
+        // Register the on_click callback so the delegate can invoke it
+        // when the user taps this notification.
         let identifier = uuid::Uuid::new_v4().to_string();
+        if let Some(on_click) = on_click {
+            CLICK_CALLBACKS
+                .lock()
+                .unwrap()
+                .insert(identifier.clone(), on_click);
+        }
+
         let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
             &NSString::from_str(&identifier),
             &*notif,
@@ -186,7 +218,9 @@ pub fn show_notif(toast: ToastNotification) -> Result<(), Box<dyn std::error::Er
                         let identifier = identifier.clone();
                         std::thread::spawn(move || {
                             std::thread::sleep(timeout);
-                            // Remove this notification
+                            // Remove this notification and clean up any
+                            // pending on_click callback.
+                            CLICK_CALLBACKS.lock().unwrap().remove(&identifier);
                             let ident_array =
                                 NSArray::from_retained_slice(&[NSString::from_str(&identifier)]);
                             CENTER.removeDeliveredNotificationsWithIdentifiers(&ident_array);

--- a/wezterm-toast-notification/src/windows.rs
+++ b/wezterm-toast-notification/src/windows.rs
@@ -18,7 +18,7 @@ fn unwrap_arg<T>(a: &Option<T>) -> Result<&T, WinError> {
     }
 }
 
-fn show_notif_impl(toast: TN) -> Result<(), Box<dyn std::error::Error>> {
+fn show_notif_impl(mut toast: TN) -> Result<(), Box<dyn std::error::Error>> {
     let xml = XmlDocument::new()?;
 
     let url_actions = if toast.url.is_some() {
@@ -30,6 +30,9 @@ fn show_notif_impl(toast: TN) -> Result<(), Box<dyn std::error::Error>> {
     } else {
         ""
     };
+
+    // Take on_click out so we can move it into the closure below.
+    let on_click = toast.on_click.take();
 
     xml.LoadXml(HSTRING::from(format!(
         r#"<toast duration="long">
@@ -48,6 +51,10 @@ fn show_notif_impl(toast: TN) -> Result<(), Box<dyn std::error::Error>> {
 
     let notif = ToastNotification::CreateToastNotification(xml)?;
 
+    // Wrap on_click in a Mutex so TypedEventHandler (which requires Fn,
+    // not FnOnce) can take it out exactly once.
+    let on_click = std::sync::Mutex::new(on_click);
+
     notif.Activated(TypedEventHandler::new(
         move |_: &Option<ToastNotification>, result: &Option<IInspectable>| {
             // let myself = unwrap_arg(myself)?;
@@ -59,6 +66,10 @@ fn show_notif_impl(toast: TN) -> Result<(), Box<dyn std::error::Error>> {
                 if let Some(url) = toast.url.as_ref() {
                     wezterm_open_url::open_url(url);
                 }
+            }
+
+            if let Some(callback) = on_click.lock().unwrap().take() {
+                callback();
             }
 
             Ok(())


### PR DESCRIPTION
## Summary

When a terminal program sends an OSC 777 / OSC 9 / OSC 99 notification, clicking the resulting toast now activates the **pane and tab that emitted it**, instead of just bringing the WezTerm window to the foreground.

This resolves the FIXME that was already in `frontend.rs`:

```rust
// FIXME: if notification.focus is true, we should do
// something here to arrange to focus pane_id when the
// notification is clicked
```

Fixes #7171

## Approach

**`ToastNotification`** gets a new `on_click: Option<Box<dyn FnOnce() + Send + 'static>>` field — an opaque callback invoked when the user clicks the notification. This keeps the notification crate decoupled from the mux.

**`frontend.rs`** constructs the callback to call `Mux::focus_pane_and_containing_tab(pane_id)` on the main thread (same pattern used by `MuxNotification::PaneFocused`). Only set when `focus: true` in the alert.

**Platform backends** invoke the callback from their click handlers:

| Platform | Mechanism |
|----------|-----------|
| **macOS** (UNUserNotificationCenter) | Global `HashMap<UUID, callback>` registry. Stored on dispatch, invoked from `did_receive_notification`, cleaned up on click/timeout. |
| **Linux** (dbus) | Invoked inline in the existing `action_invoked` stream handler. |
| **Windows** (toast) | Invoked from the `Activated` handler, wrapped in a `Mutex` to satisfy the `Fn` (not `FnOnce`) bound on `TypedEventHandler`. |

## Changes

- `wezterm-toast-notification/src/lib.rs` — Add `on_click` field, manual `Debug` impl (replaces derive since `Box<dyn FnOnce>` isn't `Debug`/`Clone`)
- `wezterm-toast-notification/src/macos.rs` — Callback registry + delegate integration
- `wezterm-toast-notification/src/dbus.rs` — Invoke callback on action, also fixed a bug where clicking a notification without a URL would not close the listener streams
- `wezterm-toast-notification/src/windows.rs` — Invoke callback on activation
- `wezterm-gui/src/frontend.rs` — Wire up `focus_pane_and_containing_tab` via `on_click`
- `wezterm-gui/src/scripting/guiwin.rs`, `wezterm-font/src/lib.rs` — Add `on_click: None` to existing struct literals

## Testing

- Built and verified `cargo check` passes on macOS (all existing warnings unchanged)
- The macOS path is the primary one I can test; Linux/Windows changes follow the same pattern and are structurally simple
