### PR TITLE
Add WebGPU post-processing shader pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6910,6 +6910,7 @@ dependencies = [
  "mlua",
  "mux",
  "mux-lua",
+ "naga",
  "nucleo-matcher",
  "ordered-float 4.6.0",
  "parking_lot",

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -560,6 +560,12 @@ pub struct Config {
     #[dynamic(default)]
     pub background: Vec<BackgroundLayer>,
 
+    /// Paths to custom post-processing fragment shaders (WGSL).
+    /// These are applied in order after the terminal is rendered.
+    /// Relative paths are resolved relative to the config file directory.
+    #[dynamic(default)]
+    pub custom_shaders: Vec<PathBuf>,
+
     /// Only works on MacOS
     #[dynamic(default)]
     pub macos_window_background_blur: i64,
@@ -1327,6 +1333,13 @@ impl Config {
             if let Some(path) = &self.window_background_image {
                 if !path.is_absolute() {
                     cfg.window_background_image.replace(config_dir.join(path));
+                }
+            }
+
+            for shader_path in &mut cfg.custom_shaders {
+                if !shader_path.is_absolute() {
+                    let dir = config_dir.join(&shader_path);
+                    *shader_path = dir;
                 }
             }
         }
@@ -2192,4 +2205,18 @@ fn default_macos_forward_mods() -> Modifiers {
 
 fn default_colr_rasterizer() -> FontRasterizerSelection {
     FontRasterizerSelection::Harfbuzz
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_custom_shaders_default_empty() {
+        let config = Config::default();
+        assert!(
+            config.custom_shaders.is_empty(),
+            "Default config should have no custom_shaders"
+        );
+    }
 }

--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -634,6 +634,11 @@ impl ConfigInner {
 
         self.notify();
         if self.config.automatically_reload_config {
+            // Watch custom shader files for hot-reload
+            for shader_path in &self.config.custom_shaders {
+                watch_paths.push(shader_path.clone());
+            }
+
             for path in watch_paths {
                 self.watch_path(path);
             }

--- a/examples/crt-scanline.wgsl
+++ b/examples/crt-scanline.wgsl
@@ -1,0 +1,138 @@
+// CRT / Scanline post-processing shader for wezterm.
+//
+// Designed to be subtle enough for daily use while giving the terminal
+// a retro CRT feel. All struct/binding declarations are auto-prepended
+// by the wezterm post-processing pipeline -- this file only contains
+// helper functions and the required fs_postprocess entry point.
+
+// ---------------------------------------------------------------
+// Constants -- tweak these to taste
+// ---------------------------------------------------------------
+
+// Barrel distortion strength. Higher = more curvature.
+const BARREL_STRENGTH: f32 = 0.04;
+
+// Scanline intensity (0 = no scanlines, 1 = fully black lines).
+const SCANLINE_INTENSITY: f32 = 0.08;
+// How fast scanlines scroll (pixels per second in UV space).
+const SCANLINE_SCROLL_SPEED: f32 = 0.02;
+// Scanline frequency -- higher = thinner, more frequent lines.
+const SCANLINE_FREQUENCY: f32 = 800.0;
+
+// Vignette strength. Higher = darker edges.
+const VIGNETTE_STRENGTH: f32 = 0.25;
+// Vignette softness. Higher = wider bright center.
+const VIGNETTE_SOFTNESS: f32 = 0.45;
+
+// Chromatic aberration offset in UV space. Keep very small.
+const CHROMA_OFFSET: f32 = 0.0008;
+
+// Phosphor glow / bloom radius in UV space.
+const GLOW_RADIUS: f32 = 0.001;
+// How much the glow adds to the original image.
+const GLOW_STRENGTH: f32 = 0.12;
+
+// ---------------------------------------------------------------
+// Barrel distortion
+// ---------------------------------------------------------------
+// Simulates the curved glass of a CRT by warping UVs outward
+// from the center. Pixels near the edges are pushed further out,
+// creating the characteristic pillow/barrel shape.
+fn barrel_distort(uv: vec2<f32>) -> vec2<f32> {
+    // Re-center so (0,0) is the middle of the screen.
+    let centered = uv - 0.5;
+    let r2 = dot(centered, centered);
+    // Apply radial distortion proportional to squared distance.
+    let distorted = centered * (1.0 + BARREL_STRENGTH * r2);
+    return distorted + 0.5;
+}
+
+// ---------------------------------------------------------------
+// Vignette
+// ---------------------------------------------------------------
+// Darkens pixels toward the screen edges, mimicking the uneven
+// brightness of a real CRT where the electron beam is weaker at
+// the periphery.
+fn vignette(uv: vec2<f32>) -> f32 {
+    let centered = uv - 0.5;
+    let dist = length(centered);
+    return smoothstep(VIGNETTE_SOFTNESS, VIGNETTE_SOFTNESS - VIGNETTE_STRENGTH, dist);
+}
+
+// ---------------------------------------------------------------
+// Scanlines
+// ---------------------------------------------------------------
+// Produces horizontal darkening bands that slowly scroll downward,
+// imitating the visible raster lines of a CRT phosphor screen.
+fn scanline(uv: vec2<f32>, time: f32) -> f32 {
+    // Use the vertical position (in pixel-ish units) plus a slow
+    // time-based offset so the lines drift gently downward.
+    let y = uv.y * SCANLINE_FREQUENCY + time * SCANLINE_SCROLL_SPEED * SCANLINE_FREQUENCY;
+    // sin produces [-1,1]; we remap so the darkest point reaches
+    // SCANLINE_INTENSITY darkness and the brightest is 1.0.
+    let line = 1.0 - SCANLINE_INTENSITY * (0.5 + 0.5 * sin(y * 3.14159265));
+    return line;
+}
+
+// ---------------------------------------------------------------
+// Phosphor glow (cheap bloom approximation)
+// ---------------------------------------------------------------
+// Averages a small cross-shaped neighbourhood around the pixel to
+// simulate the soft phosphor glow / bloom of a CRT. Keeps the
+// tap count low (5 taps) so the shader stays lightweight.
+fn phosphor_glow(uv: vec2<f32>) -> vec4<f32> {
+    let center = textureSample(screen_texture, screen_sampler, uv);
+    let left   = textureSample(screen_texture, screen_sampler, uv + vec2<f32>(-GLOW_RADIUS, 0.0));
+    let right  = textureSample(screen_texture, screen_sampler, uv + vec2<f32>( GLOW_RADIUS, 0.0));
+    let up     = textureSample(screen_texture, screen_sampler, uv + vec2<f32>(0.0, -GLOW_RADIUS));
+    let down   = textureSample(screen_texture, screen_sampler, uv + vec2<f32>(0.0,  GLOW_RADIUS));
+    let blur = (center + left + right + up + down) / 5.0;
+    return mix(center, blur, GLOW_STRENGTH);
+}
+
+// ---------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    // --- Barrel distortion ---
+    // Warp UVs to simulate CRT screen curvature.
+    let uv = barrel_distort(in.uv);
+
+    // Clamp UVs so texture sampling stays in-bounds. We sample
+    // *before* the out-of-bounds check because WGSL requires all
+    // textureSample calls to be in uniform control flow (no
+    // early-return before them).
+    let safe_uv = clamp(uv, vec2<f32>(0.0), vec2<f32>(1.0));
+
+    // --- Chromatic aberration ---
+    // Offset each colour channel slightly along the horizontal axis
+    // to mimic imperfect convergence of the CRT's RGB electron guns.
+    let r = textureSample(screen_texture, screen_sampler, safe_uv + vec2<f32>( CHROMA_OFFSET, 0.0)).r;
+    let g = textureSample(screen_texture, screen_sampler, safe_uv).g;
+    let b = textureSample(screen_texture, screen_sampler, safe_uv + vec2<f32>(-CHROMA_OFFSET, 0.0)).b;
+
+    // --- Phosphor glow ---
+    // Blend in a soft neighbourhood average to simulate bloom.
+    let glow = phosphor_glow(safe_uv);
+
+    // If the distorted UV falls outside [0,1] we are past the
+    // curved screen edge -- render black.
+    if (uv.x < 0.0 || uv.x > 1.0 || uv.y < 0.0 || uv.y > 1.0) {
+        return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+    }
+
+    var color = vec3<f32>(r, g, b);
+    color = mix(color, glow.rgb, GLOW_STRENGTH);
+
+    // --- Scanlines ---
+    // Multiply by the scanline mask to add horizontal dark bands.
+    color *= scanline(uv, pp.time);
+
+    // --- Vignette ---
+    // Darken toward the edges of the screen.
+    color *= vignette(uv);
+
+    // Preserve fully opaque alpha so compositing is unaffected.
+    return vec4<f32>(color, 1.0);
+}

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -126,3 +126,4 @@ windows = { workspace=true, features = [
 benchmarking.workspace = true
 env_logger.workspace = true
 k9.workspace = true
+naga = { version = "25", features = ["wgsl-in"] }

--- a/wezterm-gui/src/postprocess.wgsl
+++ b/wezterm-gui/src/postprocess.wgsl
@@ -1,0 +1,46 @@
+// Post-process pipeline: vertex shader and default passthrough fragment shader.
+//
+// The vertex shader generates a fullscreen triangle from 3 vertices
+// with no index buffer required.
+//
+// User fragment shaders will have the binding declarations below
+// auto-prepended, so they only need to define `fn fs_postprocess`.
+
+struct PostProcessUniform {
+    resolution: vec2<f32>,
+    time: f32,
+    time_delta: f32,
+    frame: u32,
+    _padding_0: u32,
+    _padding_1: u32,
+    _padding_2: u32,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@group(0) @binding(0) var screen_texture: texture_2d<f32>;
+@group(0) @binding(1) var screen_sampler: sampler;
+
+@group(1) @binding(0) var<uniform> pp: PostProcessUniform;
+
+@vertex
+fn vs_postprocess(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    // Fullscreen triangle: 3 vertices that cover the entire clip space.
+    // vertex 0: (-1, -1)  vertex 1: (3, -1)  vertex 2: (-1, 3)
+    var out: VertexOutput;
+    let x = f32(i32(vertex_index & 1u) * 4 - 1);
+    let y = f32(i32(vertex_index >> 1u) * 4 - 1);
+    out.position = vec4<f32>(x, y, 0.0, 1.0);
+    // Map clip coords to UV: x [-1,1] -> [0,1], y [-1,1] -> [1,0] (flip Y)
+    out.uv = vec2<f32>((x + 1.0) * 0.5, (1.0 - y) * 0.5);
+    return out;
+}
+
+// Default passthrough fragment shader: samples the screen texture unchanged.
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -25,7 +25,7 @@ use crate::termwindow::render::{
     CachedLineState, LineQuadCacheKey, LineQuadCacheValue, LineToEleShapeCacheKey,
     LineToElementShapeItem,
 };
-use crate::termwindow::webgpu::WebGpuState;
+use crate::termwindow::webgpu::{PostProcessState, WebGpuState};
 use ::wezterm_term::input::{ClickPosition, MouseButton as TMB};
 use ::window::*;
 use anyhow::{anyhow, ensure, Context};
@@ -462,6 +462,9 @@ pub struct TermWindow {
 
     gl: Option<Rc<glium::backend::Context>>,
     webgpu: Option<Rc<WebGpuState>>,
+    post_process: Option<PostProcessState>,
+    last_post_process_time: Option<Instant>,
+    post_process_frame: u32,
     config_subscription: Option<config::ConfigSubscription>,
 }
 
@@ -688,6 +691,9 @@ impl TermWindow {
             os_parameters: None,
             gl: None,
             webgpu: None,
+            post_process: None,
+            last_post_process_time: None,
+            post_process_frame: 0,
             window: None,
             window_background,
             config: config.clone(),
@@ -885,6 +891,7 @@ impl TermWindow {
             myself.load_os_parameters();
             window.show();
             myself.subscribe_to_pane_updates();
+            myself.reload_post_process_shaders();
             myself.emit_window_event("window-config-reloaded", None);
             myself.emit_status_event();
         }
@@ -1837,8 +1844,70 @@ impl TermWindow {
             &self.render_metrics,
         );
 
+        // Reload post-process shaders
+        self.reload_post_process_shaders();
+
         self.invalidate_modal();
         self.emit_window_event("window-config-reloaded", None);
+    }
+
+    /// Create, recreate, or remove post-process state based on current config.
+    /// Only active when using the WebGpu frontend.
+    fn reload_post_process_shaders(&mut self) {
+        use crate::termwindow::webgpu::PostProcessState;
+
+        let shader_paths = &self.config.custom_shaders;
+
+        if shader_paths.is_empty() {
+            if self.post_process.is_some() {
+                log::info!("postprocess: custom_shaders cleared, removing post-process pipeline");
+                self.post_process = None;
+                self.last_post_process_time = None;
+                self.post_process_frame = 0;
+            }
+            return;
+        }
+
+        // Post-process only works with WebGpu backend
+        let webgpu = match self.webgpu.as_ref() {
+            Some(w) => w,
+            None => {
+                if !shader_paths.is_empty() {
+                    log::warn!(
+                        "postprocess: custom_shaders configured but not using WebGpu frontend; \
+                         shaders will be ignored. Set front_end = \"WebGpu\" to enable."
+                    );
+                }
+                self.post_process = None;
+                return;
+            }
+        };
+
+        let config = webgpu.config.borrow();
+        let format = config.format;
+        let width = config.width;
+        let height = config.height;
+        drop(config);
+
+        match PostProcessState::new(&webgpu.device, format, width, height, shader_paths) {
+            Some(state) => {
+                log::info!(
+                    "postprocess: initialized with {} pipeline(s)",
+                    state.pipelines.len()
+                );
+                self.post_process = Some(state);
+                self.last_post_process_time = None;
+                self.post_process_frame = 0;
+            }
+            None => {
+                log::error!(
+                    "postprocess: failed to create post-process state, falling back to no shaders"
+                );
+                self.post_process = None;
+                self.last_post_process_time = None;
+                self.post_process_frame = 0;
+            }
+        }
     }
 
     fn invalidate_modal(&mut self) {

--- a/wezterm-gui/src/termwindow/render/draw.rs
+++ b/wezterm-gui/src/termwindow/render/draw.rs
@@ -1,5 +1,5 @@
 use crate::colorease::ColorEaseUniform;
-use crate::termwindow::webgpu::ShaderUniform;
+use crate::termwindow::webgpu::{PostProcessUniform, ShaderUniform};
 use crate::termwindow::RenderFrame;
 use crate::uniforms::UniformBuilder;
 use ::window::glium;
@@ -8,6 +8,38 @@ use ::window::glium::uniforms::{
 };
 use ::window::glium::{BlendingFunction, LinearBlendingFactor, Surface};
 use config::FreeTypeLoadTarget;
+use std::time::Instant;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReadSource {
+    Intermediate,
+    PingPong,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WriteTarget {
+    PingPong,
+    Intermediate,
+    Surface,
+}
+
+pub(crate) fn ping_pong_targets(index: usize, count: usize) -> (ReadSource, WriteTarget) {
+    debug_assert!(count > 0, "ping_pong_targets: count must be > 0");
+    let is_last = index == count - 1;
+    let read = if index % 2 == 0 {
+        ReadSource::Intermediate
+    } else {
+        ReadSource::PingPong
+    };
+    let write = if is_last {
+        WriteTarget::Surface
+    } else if index % 2 == 0 {
+        WriteTarget::PingPong
+    } else {
+        WriteTarget::Intermediate
+    };
+    (read, write)
+}
 
 impl crate::TermWindow {
     pub fn call_draw(&mut self, frame: &mut RenderFrame) -> anyhow::Result<()> {
@@ -20,13 +52,23 @@ impl crate::TermWindow {
     fn call_draw_webgpu(&mut self) -> anyhow::Result<()> {
         use crate::termwindow::webgpu::WebGpuTexture;
 
-        let webgpu = self.webgpu.as_mut().unwrap();
+        let webgpu = self.webgpu.as_ref().unwrap();
         let render_state = self.render_state.as_ref().unwrap();
 
         let output = webgpu.surface.get_current_texture()?;
-        let view = output
+        let surface_view = output
             .texture
             .create_view(&wgpu::TextureViewDescriptor::default());
+
+        // When post-processing is active, render layers to the intermediate
+        // texture instead of directly to the surface.
+        let has_postprocess = self.post_process.is_some();
+        let render_target_view = if has_postprocess {
+            &self.post_process.as_ref().unwrap().intermediate_view
+        } else {
+            &surface_view
+        };
+
         let mut encoder = webgpu
             .device
             .create_command_encoder(&wgpu::CommandEncoderDescriptor {
@@ -98,7 +140,7 @@ impl crate::TermWindow {
                     let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                         label: Some("Render Pass"),
                         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: &view,
+                            view: render_target_view,
                             resolve_target: None,
                             ops: wgpu::Operations {
                                 load: if cleared {
@@ -139,6 +181,83 @@ impl crate::TermWindow {
                 }
 
                 vb.next_index();
+            }
+        }
+
+        // Run post-process shader chain if active
+        if let Some(pp) = &self.post_process {
+            // Update the uniform buffer with current frame data
+            let now = Instant::now();
+            let time = self.created.elapsed().as_secs_f32();
+            let time_delta = self
+                .last_post_process_time
+                .map(|t| now.duration_since(t).as_secs_f32())
+                .unwrap_or(0.0);
+            self.last_post_process_time = Some(now);
+            self.post_process_frame = self.post_process_frame.wrapping_add(1);
+
+            let uniform = PostProcessUniform {
+                resolution: [
+                    self.dimensions.pixel_width as f32,
+                    self.dimensions.pixel_height as f32,
+                ],
+                time,
+                time_delta,
+                frame: self.post_process_frame,
+                _padding: [0; 3],
+            };
+            webgpu
+                .queue
+                .write_buffer(&pp.uniform_buffer, 0, bytemuck::cast_slice(&[uniform]));
+
+            let num_pipelines = pp.pipelines.len();
+
+            for (i, pipeline) in pp.pipelines.iter().enumerate() {
+                // Determine which texture to read from and which to write to.
+                // Pattern for N shaders:
+                //   shader 0: read intermediate, write to pingpong (or surface if N==1)
+                //   shader 1: read pingpong, write to intermediate (or surface if last)
+                //   shader 2: read intermediate, write to pingpong (or surface if last)
+                //   ...
+                // Even-indexed shaders read from intermediate, odd from pingpong.
+                // The last shader always writes to the surface.
+                let (read_src, write_dst) = ping_pong_targets(i, num_pipelines);
+
+                let read_bind_group = match read_src {
+                    ReadSource::Intermediate => &pp.bind_group_intermediate,
+                    ReadSource::PingPong => pp.bind_group_pingpong.as_ref().unwrap(),
+                };
+
+                let write_view = match write_dst {
+                    WriteTarget::Surface => &surface_view,
+                    WriteTarget::PingPong => pp.ping_pong_view.as_ref().unwrap(),
+                    WriteTarget::Intermediate => &pp.intermediate_view,
+                };
+
+                let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: Some("PostProcess Pass"),
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: write_view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(wgpu::Color {
+                                r: 0.,
+                                g: 0.,
+                                b: 0.,
+                                a: 0.,
+                            }),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    occlusion_query_set: None,
+                    timestamp_writes: None,
+                });
+
+                render_pass.set_pipeline(pipeline);
+                render_pass.set_bind_group(0, read_bind_group, &[]);
+                render_pass.set_bind_group(1, &pp.uniform_bind_group, &[]);
+                render_pass.draw(0..3, 0..1);
             }
         }
 
@@ -272,5 +391,43 @@ impl crate::TermWindow {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ping_pong_single_shader() {
+        let (read, write) = ping_pong_targets(0, 1);
+        assert_eq!(read, ReadSource::Intermediate);
+        assert_eq!(write, WriteTarget::Surface);
+    }
+
+    #[test]
+    fn test_ping_pong_two_shaders() {
+        let (r0, w0) = ping_pong_targets(0, 2);
+        assert_eq!(r0, ReadSource::Intermediate);
+        assert_eq!(w0, WriteTarget::PingPong);
+
+        let (r1, w1) = ping_pong_targets(1, 2);
+        assert_eq!(r1, ReadSource::PingPong);
+        assert_eq!(w1, WriteTarget::Surface);
+    }
+
+    #[test]
+    fn test_ping_pong_three_shaders() {
+        let (r0, w0) = ping_pong_targets(0, 3);
+        assert_eq!(r0, ReadSource::Intermediate);
+        assert_eq!(w0, WriteTarget::PingPong);
+
+        let (r1, w1) = ping_pong_targets(1, 3);
+        assert_eq!(r1, ReadSource::PingPong);
+        assert_eq!(w1, WriteTarget::Intermediate);
+
+        let (r2, w2) = ping_pong_targets(2, 3);
+        assert_eq!(r2, ReadSource::Intermediate);
+        assert_eq!(w2, WriteTarget::Surface);
     }
 }

--- a/wezterm-gui/src/termwindow/render/paint.rs
+++ b/wezterm-gui/src/termwindow/render/paint.rs
@@ -115,6 +115,19 @@ impl crate::TermWindow {
         metrics::histogram!("gui.paint.impl").record(self.last_frame_duration);
         metrics::histogram!("gui.paint.impl.rate").record(1.);
 
+        // When post-process shaders are active, schedule continuous redraws
+        // so that time-based shader effects animate smoothly
+        if self.post_process.is_some() {
+            let mut anim = self.has_animation.borrow_mut();
+            let next = Instant::now() + Duration::from_millis(16);
+            match *anim {
+                Some(existing) if existing <= next => {}
+                _ => {
+                    *anim = Some(next);
+                }
+            }
+        }
+
         // If self.has_animation is some, then the last render detected
         // image attachments with multiple frames, so we also need to
         // invalidate the viewport when the next frame is due

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -53,8 +53,24 @@ impl super::TermWindow {
             self.load_os_parameters();
         }
 
-        if let Some(webgpu) = self.webgpu.as_mut() {
+        if let Some(webgpu) = self.webgpu.as_ref() {
             webgpu.resize(dimensions);
+
+            // Recreate post-process textures at the new dimensions
+            let mut drop_post_process = false;
+            if let Some(pp) = self.post_process.as_mut() {
+                let width = dimensions.pixel_width as u32;
+                let height = dimensions.pixel_height as u32;
+                if width > 0 && height > 0 {
+                    if !pp.resize(&webgpu.device, width, height) {
+                        log::warn!("postprocess: dropping state due to failed resize");
+                        drop_post_process = true;
+                    }
+                }
+            }
+            if drop_post_process {
+                self.post_process = None;
+            }
         }
 
         // For simple, user-interactive resizes where the dpi doesn't change,

--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -2,6 +2,7 @@ use crate::quad::Vertex;
 use anyhow::anyhow;
 use config::{ConfigHandle, GpuInfo, WebGpuPowerPreference};
 use std::cell::RefCell;
+use std::path::Path;
 use std::sync::Arc;
 use wgpu::util::DeviceExt;
 use window::bitmaps::Texture2d;
@@ -19,6 +20,526 @@ pub struct ShaderUniform {
     pub projection: [[f32; 4]; 4],
     // sampler2D atlas_nearest_sampler;
     // sampler2D atlas_linear_sampler;
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct PostProcessUniform {
+    pub resolution: [f32; 2],
+    pub time: f32,
+    pub time_delta: f32,
+    pub frame: u32,
+    pub _padding: [u32; 3],
+}
+
+/// State for the post-processing shader pipeline.
+/// Stored on TermWindow directly (not inside WebGpuState) to avoid
+/// Rc/RefCell complexity when accessing the wgpu device.
+pub struct PostProcessState {
+    pub intermediate_texture: wgpu::Texture,
+    pub intermediate_view: wgpu::TextureView,
+    pub sampler: wgpu::Sampler,
+    pub bind_group_layout: wgpu::BindGroupLayout,
+    pub _uniform_bind_group_layout: wgpu::BindGroupLayout,
+    pub bind_group_intermediate: wgpu::BindGroup,
+    pub bind_group_pingpong: Option<wgpu::BindGroup>,
+    pub uniform_buffer: wgpu::Buffer,
+    pub uniform_bind_group: wgpu::BindGroup,
+    pub pipelines: Vec<wgpu::RenderPipeline>,
+    pub ping_pong_texture: Option<wgpu::Texture>,
+    pub ping_pong_view: Option<wgpu::TextureView>,
+    /// The surface format used when these resources were created,
+    /// so we can detect if it changes on resize.
+    pub format: wgpu::TextureFormat,
+}
+
+/// The preamble from postprocess.wgsl minus the default fs_postprocess function.
+/// User shaders only need to provide `fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32>`.
+const POSTPROCESS_PREAMBLE: &str = "\
+struct PostProcessUniform {
+    resolution: vec2<f32>,
+    time: f32,
+    time_delta: f32,
+    frame: u32,
+    _padding_0: u32,
+    _padding_1: u32,
+    _padding_2: u32,
+};
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@group(0) @binding(0) var screen_texture: texture_2d<f32>;
+@group(0) @binding(1) var screen_sampler: sampler;
+
+@group(1) @binding(0) var<uniform> pp: PostProcessUniform;
+
+@vertex
+fn vs_postprocess(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var out: VertexOutput;
+    let x = f32(i32(vertex_index & 1u) * 4 - 1);
+    let y = f32(i32(vertex_index >> 1u) * 4 - 1);
+    out.position = vec4<f32>(x, y, 0.0, 1.0);
+    out.uv = vec2<f32>((x + 1.0) * 0.5, (1.0 - y) * 0.5);
+    return out;
+}
+
+";
+
+/// Strip BOM, decode UTF-8, validate non-empty, and prepend the standard
+/// preamble. Returns the full WGSL source ready for compilation, or None
+/// on any input problem (logged).
+pub(crate) fn prepare_shader_source(raw_bytes: &[u8], path: &Path) -> Option<String> {
+    // Handle BOM and decode as UTF-8
+    let source_str = if raw_bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        // UTF-8 BOM — skip it
+        match std::str::from_utf8(&raw_bytes[3..]) {
+            Ok(s) => s.to_string(),
+            Err(e) => {
+                log::error!(
+                    "postprocess: shader file {} is not valid UTF-8: {:#}",
+                    path.display(),
+                    e
+                );
+                return None;
+            }
+        }
+    } else {
+        match std::str::from_utf8(raw_bytes) {
+            Ok(s) => s.to_string(),
+            Err(e) => {
+                log::error!(
+                    "postprocess: shader file {} is not valid UTF-8: {:#}",
+                    path.display(),
+                    e
+                );
+                return None;
+            }
+        }
+    };
+
+    let trimmed = source_str.trim();
+    if trimmed.is_empty() {
+        log::error!(
+            "postprocess: shader file {} is empty",
+            path.display()
+        );
+        return None;
+    }
+
+    // Prepend the standard preamble (structs, bindings, vertex shader)
+    // so user only needs to define fs_postprocess
+    Some(format!("{}{}", POSTPROCESS_PREAMBLE, source_str))
+}
+
+/// Compile a single post-process shader from a file path.
+/// Returns None on any failure (missing file, bad WGSL, pipeline error)
+/// without crashing — errors are logged.
+fn compile_postprocess_shader(
+    device: &wgpu::Device,
+    path: &Path,
+    format: wgpu::TextureFormat,
+    texture_bind_group_layout: &wgpu::BindGroupLayout,
+    uniform_bind_group_layout: &wgpu::BindGroupLayout,
+) -> Option<wgpu::RenderPipeline> {
+    let raw_source = match std::fs::read(path) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            log::error!(
+                "postprocess: failed to read shader file {}: {:#}",
+                path.display(),
+                e
+            );
+            return None;
+        }
+    };
+
+    let full_source = prepare_shader_source(&raw_source, path)?;
+
+    // Use error scopes to catch validation errors without crashing
+    device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+    let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some(&format!("PostProcess Shader: {}", path.display())),
+        source: wgpu::ShaderSource::Wgsl(full_source.into()),
+    });
+
+    // Poll for validation errors from shader compilation
+    let shader_error = smol::block_on(device.pop_error_scope());
+    if let Some(err) = shader_error {
+        log::error!(
+            "postprocess: shader compilation failed for {}: {:#}",
+            path.display(),
+            err
+        );
+        return None;
+    }
+
+    // Build the pipeline layout: group 0 = texture+sampler, group 1 = uniform
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some(&format!("PostProcess Pipeline Layout: {}", path.display())),
+        bind_group_layouts: &[texture_bind_group_layout, uniform_bind_group_layout],
+        push_constant_ranges: &[],
+    });
+
+    device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+    let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some(&format!("PostProcess Pipeline: {}", path.display())),
+        layout: Some(&pipeline_layout),
+        vertex: wgpu::VertexState {
+            module: &shader_module,
+            entry_point: Some("vs_postprocess"),
+            buffers: &[], // fullscreen triangle, no vertex buffers
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &shader_module,
+            entry_point: Some("fs_postprocess"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                blend: None, // post-process replaces pixels, no blending
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState {
+            topology: wgpu::PrimitiveTopology::TriangleList,
+            strip_index_format: None,
+            front_face: wgpu::FrontFace::Ccw,
+            cull_mode: None,
+            polygon_mode: wgpu::PolygonMode::Fill,
+            unclipped_depth: false,
+            conservative: false,
+        },
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState {
+            count: 1,
+            mask: !0,
+            alpha_to_coverage_enabled: false,
+        },
+        multiview: None,
+        cache: None,
+    });
+
+    let pipeline_error = smol::block_on(device.pop_error_scope());
+    if let Some(err) = pipeline_error {
+        log::error!(
+            "postprocess: render pipeline creation failed for {}: {:#}",
+            path.display(),
+            err
+        );
+        return None;
+    }
+
+    log::info!(
+        "postprocess: successfully compiled shader {}",
+        path.display()
+    );
+    Some(pipeline)
+}
+
+impl PostProcessState {
+    /// Create the full post-process state: intermediate textures, bind groups,
+    /// compiled shader pipelines. Returns None if no shaders compiled successfully
+    /// or if dimensions are zero.
+    pub fn new(
+        device: &wgpu::Device,
+        format: wgpu::TextureFormat,
+        width: u32,
+        height: u32,
+        shader_paths: &[std::path::PathBuf],
+    ) -> Option<Self> {
+        if width == 0 || height == 0 {
+            log::warn!("postprocess: skipping creation with zero dimensions");
+            return None;
+        }
+
+        if shader_paths.is_empty() {
+            return None;
+        }
+
+        // Build bind group layouts first so we can compile pipelines
+        let texture_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            multisampled: false,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+                label: Some("PostProcess texture bind group layout"),
+            });
+
+        let uniform_bind_group_layout =
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                entries: &[wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+                label: Some("PostProcess uniform bind group layout"),
+            });
+
+        // Compile all shader pipelines, skipping any that fail
+        let pipelines: Vec<wgpu::RenderPipeline> = shader_paths
+            .iter()
+            .filter_map(|path| {
+                compile_postprocess_shader(
+                    device,
+                    path,
+                    format,
+                    &texture_bind_group_layout,
+                    &uniform_bind_group_layout,
+                )
+            })
+            .collect();
+
+        if pipelines.is_empty() {
+            log::error!(
+                "postprocess: no shaders compiled successfully out of {} configured",
+                shader_paths.len()
+            );
+            return None;
+        }
+
+        log::info!(
+            "postprocess: {} of {} shaders compiled successfully",
+            pipelines.len(),
+            shader_paths.len()
+        );
+
+        // Create intermediate texture — same format as surface
+        let intermediate_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("PostProcess Intermediate Texture"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        let intermediate_view =
+            intermediate_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Sampler for reading intermediate/ping-pong textures
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        // Uniform buffer
+        let uniform_buffer =
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("PostProcess Uniform Buffer"),
+                contents: bytemuck::cast_slice(&[PostProcessUniform::default()]),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            });
+
+        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &uniform_bind_group_layout,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+            label: Some("PostProcess Uniform Bind Group"),
+        });
+
+        // Pre-create bind group for reading the intermediate texture
+        let bind_group_intermediate =
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                layout: &texture_bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&intermediate_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&sampler),
+                    },
+                ],
+                label: Some("PostProcess Intermediate Bind Group"),
+            });
+
+        // Ping-pong texture only needed when >1 shader in the chain
+        let (ping_pong_texture, ping_pong_view, bind_group_pingpong) = if pipelines.len() > 1 {
+            let pp_texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("PostProcess Ping-Pong Texture"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+            let pp_view =
+                pp_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+            let pp_bind_group =
+                device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    layout: &texture_bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(&pp_view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Sampler(&sampler),
+                        },
+                    ],
+                    label: Some("PostProcess Ping-Pong Bind Group"),
+                });
+
+            (Some(pp_texture), Some(pp_view), Some(pp_bind_group))
+        } else {
+            (None, None, None)
+        };
+
+        Some(PostProcessState {
+            intermediate_texture,
+            intermediate_view,
+            sampler,
+            bind_group_layout: texture_bind_group_layout,
+            _uniform_bind_group_layout: uniform_bind_group_layout,
+            bind_group_intermediate,
+            bind_group_pingpong,
+            uniform_buffer,
+            uniform_bind_group,
+            pipelines,
+            ping_pong_texture,
+            ping_pong_view,
+            format,
+        })
+    }
+
+    /// Recreate textures and bind groups at new dimensions.
+    /// Preserves compiled pipelines (they are dimension-independent).
+    /// Returns false if dimensions are zero (caller should drop state).
+    pub fn resize(&mut self, device: &wgpu::Device, width: u32, height: u32) -> bool {
+        if width == 0 || height == 0 {
+            log::warn!("postprocess: resize called with zero dimensions, skipping");
+            return false;
+        }
+
+        let format = self.format;
+
+        // Recreate intermediate texture
+        self.intermediate_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("PostProcess Intermediate Texture"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        });
+        self.intermediate_view = self
+            .intermediate_texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+
+        // Recreate bind group for intermediate
+        self.bind_group_intermediate =
+            device.create_bind_group(&wgpu::BindGroupDescriptor {
+                layout: &self.bind_group_layout,
+                entries: &[
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: wgpu::BindingResource::TextureView(&self.intermediate_view),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: wgpu::BindingResource::Sampler(&self.sampler),
+                    },
+                ],
+                label: Some("PostProcess Intermediate Bind Group"),
+            });
+
+        // Recreate ping-pong if present
+        if self.ping_pong_texture.is_some() {
+            let pp_texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some("PostProcess Ping-Pong Texture"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            });
+            let pp_view =
+                pp_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+            self.bind_group_pingpong =
+                Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    layout: &self.bind_group_layout,
+                    entries: &[
+                        wgpu::BindGroupEntry {
+                            binding: 0,
+                            resource: wgpu::BindingResource::TextureView(&pp_view),
+                        },
+                        wgpu::BindGroupEntry {
+                            binding: 1,
+                            resource: wgpu::BindingResource::Sampler(&self.sampler),
+                        },
+                    ],
+                    label: Some("PostProcess Ping-Pong Bind Group"),
+                }));
+
+            self.ping_pong_texture = Some(pp_texture);
+            self.ping_pong_view = Some(pp_view);
+        }
+
+        true
+    }
 }
 
 pub struct WebGpuState {
@@ -557,5 +1078,636 @@ impl WebGpuState {
             // <https://github.com/wezterm/wezterm/issues/2881>
             self.surface.configure(&self.device, &config);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_postprocess_uniform_layout() {
+        assert_eq!(
+            std::mem::size_of::<PostProcessUniform>(),
+            32,
+            "PostProcessUniform must be 32 bytes for GPU alignment"
+        );
+    }
+
+    #[test]
+    fn test_preamble_is_valid_wgsl() {
+        // Parse the preamble + a minimal valid fragment shader
+        let source = format!(
+            "{}\n{}",
+            POSTPROCESS_PREAMBLE,
+            r#"
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}
+"#
+        );
+        let result = naga::front::wgsl::parse_str(&source);
+        assert!(result.is_ok(), "Preamble + minimal shader must parse: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_prepare_shader_source_valid() {
+        let body = b"@fragment\nfn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {\n    return vec4<f32>(1.0);\n}\n";
+        let result = prepare_shader_source(body, &PathBuf::from("test.wgsl"));
+        assert!(result.is_some());
+        let source = result.unwrap();
+        assert!(source.starts_with("struct PostProcessUniform"));
+        assert!(source.contains("fn fs_postprocess"));
+    }
+
+    #[test]
+    fn test_prepare_shader_source_bom() {
+        let mut bytes = vec![0xEF, 0xBB, 0xBF]; // UTF-8 BOM
+        bytes.extend_from_slice(b"@fragment\nfn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {\n    return vec4<f32>(1.0);\n}\n");
+        let result = prepare_shader_source(&bytes, &PathBuf::from("bom.wgsl"));
+        assert!(result.is_some());
+        let source = result.unwrap();
+        // BOM should be stripped, preamble prepended
+        assert!(source.starts_with("struct PostProcessUniform"));
+        assert!(!source.contains('\u{FEFF}'));
+    }
+
+    #[test]
+    fn test_prepare_shader_source_empty() {
+        assert!(prepare_shader_source(b"", &PathBuf::from("empty.wgsl")).is_none());
+        assert!(prepare_shader_source(b"   \n  \t  ", &PathBuf::from("whitespace.wgsl")).is_none());
+    }
+
+    #[test]
+    fn test_prepare_shader_source_invalid_utf8() {
+        let bytes: &[u8] = &[0xFF, 0xFE, 0x80, 0x81];
+        assert!(prepare_shader_source(bytes, &PathBuf::from("bad.wgsl")).is_none());
+    }
+
+    // --- GPU tests (Tier 2) ---
+
+    fn create_test_bind_group_layouts(
+        device: &wgpu::Device,
+    ) -> (wgpu::BindGroupLayout, wgpu::BindGroupLayout) {
+        let texture_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+            ],
+            label: Some("Test texture BGL"),
+        });
+
+        let uniform_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::VERTEX | wgpu::ShaderStages::FRAGMENT,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+            label: Some("Test uniform BGL"),
+        });
+
+        (texture_bgl, uniform_bgl)
+    }
+
+    fn create_test_device() -> Option<(wgpu::Device, wgpu::Queue)> {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+
+        // Try software/fallback adapter first
+        let adapter = smol::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::None,
+            compatible_surface: None,
+            force_fallback_adapter: true,
+        }))
+        .or_else(|_| {
+            smol::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::None,
+                compatible_surface: None,
+                force_fallback_adapter: false,
+            }))
+        })
+        .ok()?;
+
+        let (device, queue) = smol::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults()
+                    .using_resolution(adapter.limits()),
+                label: Some("Test Device"),
+                memory_hints: Default::default(),
+                trace: wgpu::Trace::Off,
+            },
+        ))
+        .ok()?;
+
+        Some((device, queue))
+    }
+
+    #[test]
+    fn test_compile_valid_shader() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_compile_valid_shader: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let shader_path = dir.path().join("valid.wgsl");
+        std::fs::write(
+            &shader_path,
+            r#"
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}
+"#,
+        )
+        .unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let (texture_bgl, uniform_bgl) = create_test_bind_group_layouts(&device);
+
+        let result = compile_postprocess_shader(&device, &shader_path, format, &texture_bgl, &uniform_bgl);
+        assert!(result.is_some(), "Valid shader should compile successfully");
+    }
+
+    #[test]
+    fn test_compile_invalid_shader() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_compile_invalid_shader: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let shader_path = dir.path().join("invalid.wgsl");
+        std::fs::write(&shader_path, "this is not valid WGSL at all!!!").unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let (texture_bgl, uniform_bgl) = create_test_bind_group_layouts(&device);
+
+        let result = compile_postprocess_shader(&device, &shader_path, format, &texture_bgl, &uniform_bgl);
+        assert!(result.is_none(), "Invalid shader should return None");
+    }
+
+    #[test]
+    fn test_compile_missing_entry_point() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_compile_missing_entry_point: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let shader_path = dir.path().join("no_entry.wgsl");
+        // Valid WGSL but wrong function name
+        std::fs::write(
+            &shader_path,
+            r#"
+@fragment
+fn wrong_name(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}
+"#,
+        )
+        .unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let (texture_bgl, uniform_bgl) = create_test_bind_group_layouts(&device);
+
+        let result = compile_postprocess_shader(&device, &shader_path, format, &texture_bgl, &uniform_bgl);
+        assert!(result.is_none(), "Missing entry point should return None");
+    }
+
+    #[test]
+    fn test_compile_missing_file() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_compile_missing_file: no GPU adapter available");
+            return;
+        };
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let (texture_bgl, uniform_bgl) = create_test_bind_group_layouts(&device);
+
+        let result = compile_postprocess_shader(
+            &device,
+            &PathBuf::from("/nonexistent/shader.wgsl"),
+            format,
+            &texture_bgl,
+            &uniform_bgl,
+        );
+        assert!(result.is_none(), "Missing file should return None");
+    }
+
+    #[test]
+    fn test_postprocess_state_single_shader() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_postprocess_state_single_shader: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let shader_path = dir.path().join("single.wgsl");
+        std::fs::write(
+            &shader_path,
+            r#"
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}
+"#,
+        )
+        .unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let state = PostProcessState::new(&device, format, 800, 600, &[shader_path]);
+        assert!(state.is_some(), "Single valid shader should create state");
+        let state = state.unwrap();
+        assert_eq!(state.pipelines.len(), 1);
+        assert!(state.ping_pong_texture.is_none(), "Single shader needs no ping-pong texture");
+    }
+
+    #[test]
+    fn test_postprocess_state_multi_shader() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_postprocess_state_multi_shader: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let shader_body = r#"
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}
+"#;
+        let path1 = dir.path().join("s1.wgsl");
+        let path2 = dir.path().join("s2.wgsl");
+        std::fs::write(&path1, shader_body).unwrap();
+        std::fs::write(&path2, shader_body).unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let state = PostProcessState::new(&device, format, 800, 600, &[path1, path2]);
+        assert!(state.is_some(), "Two valid shaders should create state");
+        let state = state.unwrap();
+        assert_eq!(state.pipelines.len(), 2);
+        assert!(state.ping_pong_texture.is_some(), "Multi shader needs ping-pong texture");
+    }
+
+    #[test]
+    fn test_postprocess_state_zero_dimensions() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_postprocess_state_zero_dimensions: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let shader_path = dir.path().join("z.wgsl");
+        std::fs::write(
+            &shader_path,
+            "@fragment\nfn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> { return vec4<f32>(1.0); }\n",
+        )
+        .unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        assert!(PostProcessState::new(&device, format, 0, 600, &[shader_path.clone()]).is_none());
+        assert!(PostProcessState::new(&device, format, 800, 0, &[shader_path]).is_none());
+    }
+
+    #[test]
+    fn test_postprocess_state_no_valid_shaders() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_postprocess_state_no_valid_shaders: no GPU adapter available");
+            return;
+        };
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let result = PostProcessState::new(
+            &device,
+            format,
+            800,
+            600,
+            &[PathBuf::from("/no/such/a.wgsl"), PathBuf::from("/no/such/b.wgsl")],
+        );
+        assert!(result.is_none(), "No valid shaders should return None");
+    }
+
+    #[test]
+    fn test_postprocess_state_mixed_valid_invalid() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_postprocess_state_mixed_valid_invalid: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let valid_path = dir.path().join("good.wgsl");
+        std::fs::write(
+            &valid_path,
+            r#"
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}
+"#,
+        )
+        .unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let state = PostProcessState::new(
+            &device,
+            format,
+            800,
+            600,
+            &[valid_path, PathBuf::from("/no/such/bad.wgsl")],
+        );
+        assert!(state.is_some(), "Mixed valid/invalid should still create state");
+        assert_eq!(state.unwrap().pipelines.len(), 1);
+    }
+
+    #[test]
+    fn test_postprocess_state_resize() {
+        let Some((device, _queue)) = create_test_device() else {
+            eprintln!("Skipping test_postprocess_state_resize: no GPU adapter available");
+            return;
+        };
+
+        let dir = tempfile::tempdir().unwrap();
+        let shader_path = dir.path().join("resize.wgsl");
+        std::fs::write(
+            &shader_path,
+            r#"
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    return textureSample(screen_texture, screen_sampler, in.uv);
+}
+"#,
+        )
+        .unwrap();
+
+        let format = wgpu::TextureFormat::Bgra8UnormSrgb;
+        let mut state = PostProcessState::new(&device, format, 800, 600, &[shader_path]).unwrap();
+
+        assert!(state.resize(&device, 1024, 768), "Resize to valid dims should return true");
+        assert!(!state.resize(&device, 0, 768), "Resize to zero width should return false");
+        assert!(!state.resize(&device, 1024, 0), "Resize to zero height should return false");
+    }
+
+    #[test]
+    fn test_shader_actually_renders() {
+        let Some((device, queue)) = create_test_device() else {
+            eprintln!("Skipping test_shader_actually_renders: no GPU adapter available");
+            return;
+        };
+
+        let tex_width: u32 = 4;
+        let tex_height: u32 = 4;
+        let format = wgpu::TextureFormat::Rgba8Unorm;
+
+        // --- Source texture: solid red ---
+        let source_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Test source texture"),
+            size: wgpu::Extent3d {
+                width: tex_width,
+                height: tex_height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+
+        let red_pixel: [u8; 4] = [255, 0, 0, 255];
+        let pixel_data: Vec<u8> = red_pixel
+            .iter()
+            .copied()
+            .cycle()
+            .take((tex_width * tex_height * 4) as usize)
+            .collect();
+
+        queue.write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &source_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &pixel_data,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(tex_width * 4),
+                rows_per_image: Some(tex_height),
+            },
+            wgpu::Extent3d {
+                width: tex_width,
+                height: tex_height,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        let source_view = source_texture.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // --- Render target texture ---
+        let render_target = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Test render target"),
+            size: wgpu::Extent3d {
+                width: tex_width,
+                height: tex_height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let render_target_view =
+            render_target.create_view(&wgpu::TextureViewDescriptor::default());
+
+        // --- Bind group layouts ---
+        let (texture_bgl, uniform_bgl) = create_test_bind_group_layouts(&device);
+
+        // --- Sampler ---
+        let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("Test sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Linear,
+            ..Default::default()
+        });
+
+        // --- Texture bind group (group 0) ---
+        let texture_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Test texture bind group"),
+            layout: &texture_bgl,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&source_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&sampler),
+                },
+            ],
+        });
+
+        // --- Uniform buffer + bind group (group 1) ---
+        let uniform = PostProcessUniform::default();
+        let uniform_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Test uniform buffer"),
+            contents: bytemuck::cast_slice(&[uniform]),
+            usage: wgpu::BufferUsages::UNIFORM,
+        });
+        let uniform_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Test uniform bind group"),
+            layout: &uniform_bgl,
+            entries: &[wgpu::BindGroupEntry {
+                binding: 0,
+                resource: uniform_buffer.as_entire_binding(),
+            }],
+        });
+
+        // --- Compile the color-inversion shader ---
+        let dir = tempfile::tempdir().unwrap();
+        let shader_path = dir.path().join("invert.wgsl");
+        std::fs::write(
+            &shader_path,
+            r#"
+@fragment
+fn fs_postprocess(in: VertexOutput) -> @location(0) vec4<f32> {
+    let color = textureSample(screen_texture, screen_sampler, in.uv);
+    return vec4<f32>(1.0 - color.r, 1.0 - color.g, 1.0 - color.b, color.a);
+}
+"#,
+        )
+        .unwrap();
+
+        let pipeline =
+            compile_postprocess_shader(&device, &shader_path, format, &texture_bgl, &uniform_bgl)
+                .expect("Inversion shader should compile");
+
+        // --- Render pass ---
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        {
+            let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Test render pass"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &render_target_view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            rpass.set_pipeline(&pipeline);
+            rpass.set_bind_group(0, &texture_bind_group, &[]);
+            rpass.set_bind_group(1, &uniform_bind_group, &[]);
+            rpass.draw(0..3, 0..1);
+        }
+        queue.submit(std::iter::once(encoder.finish()));
+
+        // --- Readback: copy render target to staging buffer ---
+        let bytes_per_row_unaligned = tex_width * 4;
+        // wgpu requires rows aligned to COPY_BYTES_PER_ROW_ALIGNMENT
+        let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT;
+        let bytes_per_row = (bytes_per_row_unaligned + align - 1) / align * align;
+        let buffer_size = (bytes_per_row * tex_height) as u64;
+
+        let staging_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Test staging buffer"),
+            size: buffer_size,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let mut encoder =
+            device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &render_target,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging_buffer,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(bytes_per_row),
+                    rows_per_image: Some(tex_height),
+                },
+            },
+            wgpu::Extent3d {
+                width: tex_width,
+                height: tex_height,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit(std::iter::once(encoder.finish()));
+
+        // Map the buffer and read pixels
+        let buffer_slice = staging_buffer.slice(..);
+        let (sender, receiver) = std::sync::mpsc::channel();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            sender.send(result).unwrap();
+        });
+        device.poll(wgpu::PollType::Wait).expect("GPU poll failed");
+        receiver
+            .recv()
+            .expect("Failed to receive map result")
+            .expect("Buffer mapping failed");
+
+        let data = buffer_slice.get_mapped_range();
+
+        // Check every pixel in the output (accounting for row padding)
+        let tolerance = 2u8;
+        let expected: [u8; 4] = [0, 255, 255, 255]; // cyan = inverted red
+        for row in 0..tex_height {
+            for col in 0..tex_width {
+                let offset = (row * bytes_per_row + col * 4) as usize;
+                let pixel = &data[offset..offset + 4];
+                for (ch, (&got, &exp)) in pixel.iter().zip(expected.iter()).enumerate() {
+                    let diff = (got as i16 - exp as i16).unsigned_abs();
+                    assert!(
+                        diff <= tolerance as u16,
+                        "Pixel ({},{}) channel {}: expected {}, got {} (diff {} > tolerance {})",
+                        col, row, ch, exp, got, diff, tolerance
+                    );
+                }
+            }
+        }
+
+        drop(data);
+        staging_buffer.unmap();
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `custom_shaders` config option that accepts a list of `.wgsl` file paths, applied as post-processing passes over the rendered terminal output
- Implements a fullscreen-triangle WebGPU pipeline with `PostProcessUniform` (resolution, time, time_delta, frame) for animated effects
- User shaders only need to define `fn fs_postprocess` — bindings and structs are auto-prepended
- Pipeline rebuilds on config reload and window resize
- Includes an example CRT/scanline shader with barrel distortion, chromatic aberration, vignette, scanlines, and phosphor glow

## Motivation

Addresses long-standing community requests for custom shader support:
- #6985 — GPU Shader Effects
- #5182 — Cool Retro Term Shaders
- #2171 — Animation loop for real time rendering

Ghostty supports user-programmable GLSL shaders; this brings equivalent (native WGSL) capability to wezterm's WebGPU renderer with no runtime shader conversion needed.

## Test Plan

- [x] `cargo test -p config` passes (including `test_custom_shaders_default_empty`)
- [x] Built and tested on Windows with MSVC toolchain
- [x] CRT scanline example shader verified working via `--config 'custom_shaders={[[path]]}'`
- [ ] Linux build verification
- [ ] macOS build verification