### PR TITLE
Fix transparent window flash on Windows during initial rendering

### DIFF
--- a/window/src/os/windows/wgl.rs
+++ b/window/src/os/windows/wgl.rs
@@ -322,11 +322,13 @@ impl GlState {
             wgl.wgl.MakeCurrent(hdc as *mut _, rc);
         }
 
-        Ok(Self {
+        let state = Self {
             wgl: Some(wgl),
             rc,
             hdc,
-        })
+        };
+        state.pre_fill_black();
+        Ok(state)
     }
 
     fn create_basic(wgl: WglWrapper, window: HWND) -> anyhow::Result<Self> {
@@ -370,11 +372,43 @@ impl GlState {
             wgl.wgl.MakeCurrent(hdc as *mut _, rc);
         }
 
-        Ok(Self {
+        let state = Self {
             wgl: Some(wgl),
             rc,
             hdc,
-        })
+        };
+        state.pre_fill_black();
+        Ok(state)
+    }
+
+    /// Pre-fill both front and back buffers with opaque black.
+    /// Must be called while the WGL context is current (right after creation).
+    /// This prevents DWM from compositing a transparent/uninitialized surface
+    /// when the window first becomes visible, which causes a white flash.
+    fn pre_fill_black(&self) {
+        type GlClearColorFn = unsafe extern "system" fn(f32, f32, f32, f32);
+        type GlClearFn = unsafe extern "system" fn(u32);
+        const GL_COLOR_BUFFER_BIT: u32 = 0x00004000;
+
+        let wgl = self.wgl.as_ref().unwrap();
+        unsafe {
+            let clear_color: libloading::Symbol<GlClearColorFn> =
+                match wgl.lib.get(b"glClearColor\0") {
+                    Ok(f) => f,
+                    Err(_) => return,
+                };
+            let clear: libloading::Symbol<GlClearFn> = match wgl.lib.get(b"glClear\0") {
+                Ok(f) => f,
+                Err(_) => return,
+            };
+
+            clear_color(0.0, 0.0, 0.0, 1.0);
+            clear(GL_COLOR_BUFFER_BIT);
+            SwapBuffers(self.hdc);
+            // Clear and swap again so both front and back buffers are black
+            clear(GL_COLOR_BUFFER_BIT);
+            SwapBuffers(self.hdc);
+        }
     }
 
     fn make_not_current(&self) {

--- a/window/src/os/windows/wgl.rs
+++ b/window/src/os/windows/wgl.rs
@@ -404,10 +404,15 @@ impl GlState {
 
             clear_color(0.0, 0.0, 0.0, 1.0);
             clear(GL_COLOR_BUFFER_BIT);
-            SwapBuffers(self.hdc);
+            if SwapBuffers(self.hdc) == 0 {
+                log::warn!("pre_fill_black: first SwapBuffers failed");
+                return;
+            }
             // Clear and swap again so both front and back buffers are black
             clear(GL_COLOR_BUFFER_BIT);
-            SwapBuffers(self.hdc);
+            if SwapBuffers(self.hdc) == 0 {
+                log::warn!("pre_fill_black: second SwapBuffers failed");
+            }
         }
     }
 


### PR DESCRIPTION
 ## Summary

Fixes #7657

When a WezTerm window first appears on Windows, DWM composites the uninitialized GL surface, causing a brief transparent/white flash before the first frame renders.

This PR pre-fills both front and back GL buffers with opaque black (alpha=1.0) immediately after the WGL context is created and made current, in both the extended and basic GL context
paths. This ensures DWM always composites an opaque surface while the renderer prepares the first real frame.

 ## Approach
 
 I am not sure if this is the right approach but I got it **working on my machine** ™️

- Added `GlState::pre_fill_black()` which loads `glClearColor`/`glClear` from `opengl32.dll` and clears + swaps twice to fill both buffers
- Called right after `MakeCurrent` in `create_ext` and `create_basic` — this timing is critical; moving it later causes the window to render black until resized
- Gracefully degrades: silently returns if GL functions can't be loaded, logs warnings if `SwapBuffers` fails

 ## Test plan

- [x] Launch wezterm on Windows — no transparent/white flash on startup
- [x] Window renders correctly without needing resize


https://github.com/user-attachments/assets/7b7adcf2-d7d9-4ef9-a74e-882e5831edb8

