### PR TITLE
docs: fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img height="128" alt="WezTerm Icon" src="https://raw.githubusercontent.com/wezterm/wezterm/main/assets/icon/wezterm-icon.svg" align="left"> *A GPU-accelerated cross-platform terminal emulator and multiplexer written by <a href="https://github.com/wez">@wez</a> and implemented in <a href="https://www.rust-lang.org/">Rust</a>*
 
-User facing docs and guide at: https://wezterm.org/
+User-facing docs and guide at: https://wezterm.org/
 
 ![Screenshot](docs/screenshots/two.png)
 


### PR DESCRIPTION
## Summary
- Hyphenate “User-facing” in the README intro line.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/wez/wezterm/blob/main/CONTRIBUTING.md

## Validation/testing
- Not run (docs change only)