### PR TITLE
feat: add per-pane title bars

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -506,6 +506,13 @@ pub struct Config {
     #[dynamic(default)]
     pub hide_tab_bar_if_only_one_tab: bool,
 
+    /// Controls whether a title bar is shown at the top or bottom of each
+    /// split pane.  When enabled, the `format-pane-title` event is called to
+    /// produce the title text.  Defaults to `Off`.
+    /// See <https://wezterm.org/config/lua/config/pane_border_status.html>
+    #[dynamic(default)]
+    pub pane_border_status: PaneBorderStatus,
+
     #[dynamic(default)]
     pub enable_scroll_bar: bool,
 
@@ -2141,6 +2148,18 @@ pub enum ImePreeditRendering {
     Builtin,
     /// IME preedit is rendered by system
     System,
+}
+
+/// Controls whether each split pane has a title bar, and where it is placed.
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PaneBorderStatus {
+    /// No pane title bars (default).
+    #[default]
+    Off,
+    /// Show a one-row title bar above each pane's content.
+    Top,
+    /// Show a one-row title bar below each pane's content.
+    Bottom,
 }
 
 #[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -513,6 +513,12 @@ pub struct Config {
     #[dynamic(default)]
     pub pane_border_status: PaneBorderStatus,
 
+    /// When `pane_border_status` is not `Off`, controls whether a close
+    /// button (`×`) is rendered at the right edge of each pane title bar.
+    /// Clicking it closes (kills) that pane.  Defaults to `true`.
+    #[dynamic(default = "default_true")]
+    pub show_close_pane_button_in_pane_bar: bool,
+
     #[dynamic(default)]
     pub enable_scroll_bar: bool,
 

--- a/docs/config/lua/window-events/format-pane-title.md
+++ b/docs/config/lua/window-events/format-pane-title.md
@@ -1,0 +1,130 @@
+# `format-pane-title`
+
+{{since('nightly')}}
+
+The `format-pane-title` event is emitted when the text for a pane title bar
+needs to be recomputed.  Pane title bars are enabled by setting
+[pane_border_status](../config/pane_border_status.md) to `"Top"` or
+`"Bottom"`.
+
+This event is *synchronous* and must return as quickly as possible in order
+to avoid blocking the GUI thread.  Avoid calling asynchronous functions such
+as [wezterm.run_child_process](../wezterm/run_child_process.md) from inside
+the handler.
+
+The parameters to the event are:
+
+* `pane` - a [PaneInformation](../PaneInformation.md) for the pane whose title is being computed
+* `panes` - an array of [PaneInformation](../PaneInformation.md) for each pane in the active tab
+* `tabs` - an array of [TabInformation](../TabInformation.md) for each tab in the window
+* `config` - the effective configuration for the window
+* `hover` - true if the mouse is hovering over the pane title bar
+* `focused` - true if this pane is the currently focused pane
+
+The return value must be a string.
+
+If the event is not handled, or returns something other than a string, the
+pane's window title (as set by the running program) is used instead.
+
+Only the first `format-pane-title` event handler registered with
+`wezterm.on("format-pane-title", ...)` will be executed.
+
+## Basic example
+
+```lua
+local wezterm = require 'wezterm'
+local config = wezterm.config_builder()
+
+config.pane_border_status = 'Top'
+
+wezterm.on('format-pane-title', function(pane, panes, tabs, config, hover, focused)
+  local indicator = focused and '● ' or '○ '
+  local cwd = ''
+  if pane.current_working_dir then
+    local path = pane.current_working_dir.file_path or tostring(pane.current_working_dir)
+    cwd = path:match('([^/]+)/?$') or path
+  end
+  return indicator .. cwd
+end)
+
+return config
+```
+
+## Persistent status messages via user variables
+
+Because the pane title bar is refreshed independently of the shell prompt, it
+is a natural place to display status information that should remain visible
+while a long-running command executes.  Shell precmd/preexec hooks can push
+status into the title bar by setting a [user variable](../pane/get_user_vars.md)
+via an OSC 1337 escape sequence.
+
+The value persists in the title bar until explicitly cleared, even as the
+shell redraws its prompt repeatedly.
+
+### Shell integration
+
+Add a helper to your shell's init file that encodes and sends the variable:
+
+```bash
+# ~/.zshrc or ~/.bashrc
+_wezterm_set_pane_status() {
+  # Requires base64; no-op outside WezTerm
+  [[ -z "$WEZTERM_PANE" ]] && return
+  printf "\033]1337;SetUserVar=%s=%s\007" "$1" "$(printf '%s' "$2" | base64)"
+}
+
+# Show the current task in the pane title bar
+_wezterm_set_pane_status STATUS "building…"
+# Clear it when the task finishes
+_wezterm_set_pane_status STATUS ""
+```
+
+With `precmd` / `PROMPT_COMMAND` integration you can automatically clear the
+status when the prompt returns:
+
+```bash
+# Zsh
+precmd() {
+  _wezterm_set_pane_status STATUS ""
+}
+
+preexec() {
+  # Show the command being run
+  _wezterm_set_pane_status STATUS "$1"
+}
+```
+
+### Lua handler
+
+Read the user variable in `format-pane-title` and display it when set:
+
+```lua
+wezterm.on('format-pane-title', function(pane, panes, tabs, config, hover, focused)
+  local indicator = focused and '● ' or '○ '
+
+  -- Persistent status set by the shell via OSC 1337 SetUserVar
+  local status = (pane.user_vars or {}).STATUS or ''
+  if status ~= '' then
+    return indicator .. status
+  end
+
+  -- Fall back to current working directory
+  local cwd = pane.title or ''
+  if pane.current_working_dir then
+    local path = pane.current_working_dir.file_path or tostring(pane.current_working_dir)
+    cwd = path:match('([^/]+)/?$') or path
+  end
+  return indicator .. cwd
+end)
+```
+
+The `user-var-changed` event fires whenever a variable is set, which
+immediately triggers a title bar refresh — there is no polling.
+
+## See also
+
+* [pane_border_status](../config/pane_border_status.md)
+* [PaneInformation](../PaneInformation.md)
+* [pane:get_user_vars()](../pane/get_user_vars.md)
+* [user-var-changed](user-var-changed.md)
+* [format-tab-title](format-tab-title.md)

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -103,6 +103,72 @@ fn call_format_tab_title(
     }
 }
 
+/// Compute the title `Line` for a pane title bar.
+///
+/// Build the default pane title `Line` from the pane's window title.
+///
+/// This is the fallback used when no `format-pane-title` Lua callback is
+/// registered.  It is a pure function with no Lua dependency, which makes
+/// it easy to unit-test independently.
+pub fn default_pane_title(pane: &PaneInformation) -> wezterm_term::Line {
+    parse_status_text(&pane.title, CellAttributes::default())
+}
+
+/// Compute the title `Line` for a pane title bar.
+///
+/// Calls the `format-pane-title` Lua event, which receives:
+///   * `pane`       – `PaneInformation` for the pane being titled
+///   * `panes`      – sequence of `PaneInformation` for every visible pane
+///   * `tabs`       – sequence of `TabInformation` for every tab
+///   * `config`     – the current configuration
+///
+/// The callback may return a string or a table of `wezterm.format` items.
+/// When no callback is registered `default_pane_title` is used as a fallback.
+pub fn compute_pane_title(
+    pane: &PaneInformation,
+    pane_info: &[PaneInformation],
+    tab_info: &[TabInformation],
+    config: &ConfigHandle,
+) -> wezterm_term::Line {
+    let custom = config::run_immediate_with_lua_config(|lua| {
+        if let Some(lua) = lua {
+            let panes = lua.create_sequence_from(pane_info.iter().cloned())?;
+            let tabs = lua.create_sequence_from(tab_info.iter().cloned())?;
+
+            let v = config::lua::emit_sync_callback(
+                &*lua,
+                (
+                    "format-pane-title".to_string(),
+                    (pane.clone(), panes, tabs, (**config).clone()),
+                ),
+            )?;
+            match v {
+                mlua::Value::Nil => Ok(None),
+                mlua::Value::Table(_) => {
+                    let items = <Vec<FormatItem>>::from_lua(v, &*lua)?;
+                    let esc = format_as_escapes(items)?;
+                    Ok(Some(parse_status_text(&esc, CellAttributes::default())))
+                }
+                _ => {
+                    let s = String::from_lua(v, &*lua)?;
+                    Ok(Some(parse_status_text(&s, CellAttributes::default())))
+                }
+            }
+        } else {
+            Ok(None)
+        }
+    });
+
+    match custom {
+        Ok(Some(line)) => line,
+        Ok(None) => default_pane_title(pane),
+        Err(err) => {
+            log::warn!("format-pane-title: {}", err);
+            default_pane_title(pane)
+        }
+    }
+}
+
 /// pct is a percentage in the range 0-100.
 /// We want to map it to one of the nerdfonts:
 ///
@@ -726,4 +792,87 @@ pub fn parse_status_text(text: &str, default_cell: CellAttributes) -> Line {
     });
     flush_print(&mut print_buffer, &mut cells, &pen);
     Line::from_cells(cells, SEQ_ZERO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::termwindow::PaneInformation;
+    use std::collections::HashMap;
+
+    fn make_pane(title: &str) -> PaneInformation {
+        PaneInformation {
+            pane_id: 0,
+            pane_index: 0,
+            is_active: true,
+            is_zoomed: false,
+            has_unseen_output: false,
+            left: 0,
+            top: 0,
+            width: 80,
+            height: 24,
+            pixel_width: 800,
+            pixel_height: 240,
+            title: title.to_string(),
+            user_vars: HashMap::new(),
+            progress: wezterm_term::Progress::None,
+        }
+    }
+
+    fn line_to_string(line: &wezterm_term::Line) -> String {
+        line.as_str().into_owned()
+    }
+
+    /// parse_status_text must preserve plain ASCII text unchanged.
+    #[test]
+    fn parse_status_text_plain() {
+        let line = parse_status_text("hello world", CellAttributes::default());
+        assert_eq!(line_to_string(&line), "hello world");
+    }
+
+    /// parse_status_text stops at a newline so multi-line input only yields the
+    /// first line (matching the tab-bar behaviour for single-row rendering).
+    #[test]
+    fn parse_status_text_stops_at_newline() {
+        let line = parse_status_text("first\nsecond", CellAttributes::default());
+        assert_eq!(line_to_string(&line), "first");
+    }
+
+    /// parse_status_text must handle an SGR bold sequence without panicking and
+    /// produce the correct cell count.
+    #[test]
+    fn parse_status_text_sgr_bold() {
+        // ESC[1m  bold on  ESC[0m  reset
+        let line = parse_status_text("\x1b[1mhi\x1b[0m", CellAttributes::default());
+        assert_eq!(line.len(), 2);
+    }
+
+    /// The default fallback uses the pane's window title as-is.
+    #[test]
+    fn default_pane_title_uses_window_title() {
+        let pane = make_pane("my-pane-title");
+        let line = default_pane_title(&pane);
+        assert_eq!(line_to_string(&line), "my-pane-title");
+    }
+
+    /// An empty window title produces an empty line rather than panicking.
+    #[test]
+    fn default_pane_title_empty() {
+        let pane = make_pane("");
+        let line = default_pane_title(&pane);
+        assert_eq!(line.len(), 0);
+    }
+
+    /// default_pane_title is independent per-pane — two panes with different
+    /// titles produce distinct lines.
+    #[test]
+    fn default_pane_title_multiple_panes() {
+        let pane0 = make_pane("pane-0");
+        let mut pane1 = make_pane("pane-1");
+        pane1.pane_index = 1;
+        pane1.is_active = false;
+
+        assert_eq!(line_to_string(&default_pane_title(&pane0)), "pane-0");
+        assert_eq!(line_to_string(&default_pane_title(&pane1)), "pane-1");
+    }
 }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -36,7 +36,7 @@ use config::keyassignment::{
 use config::window::WindowLevel;
 use config::{
     configuration, AudibleBell, ConfigHandle, Dimension, DimensionContext, FrontEndSelection,
-    GeometryOrigin, GuiPosition, TermConfig, WindowCloseConfirmation,
+    GeometryOrigin, GuiPosition, PaneBorderStatus, TermConfig, WindowCloseConfirmation,
 };
 use lfucache::*;
 use mlua::{FromLua, LuaSerdeExt, UserData, UserDataFields};
@@ -3523,6 +3523,33 @@ impl TermWindow {
                     p.pane = Arc::clone(&overlay.pane);
                 }
             }
+
+            // When a pane title bar is active, each terminal process should
+            // see one fewer row than the cell area allocated to it by the
+            // split layout.  Resize here (lazily, only when the current size
+            // differs) so that the process never writes into the title bar row.
+            if self.config.pane_border_status != PaneBorderStatus::Off {
+                let cell_height = self.render_metrics.cell_size.height as usize;
+                let cell_width = self.render_metrics.cell_size.width as usize;
+                for p in &mut panes {
+                    if p.height > 1 {
+                        let target_rows = p.height - 1;
+                        let dims = p.pane.get_dimensions();
+                        if dims.viewport_rows != target_rows {
+                            let _ = p.pane.resize(TerminalSize {
+                                rows: target_rows,
+                                cols: p.width,
+                                pixel_height: target_rows * cell_height,
+                                pixel_width: p.width * cell_width,
+                                dpi: dims.dpi,
+                            });
+                        }
+                        p.height = target_rows;
+                        p.pixel_height = target_rows * cell_height;
+                    }
+                }
+            }
+
             panes
         }
     }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -155,6 +155,7 @@ pub enum TermWindowNotif {
 pub enum UIItemType {
     TabBar(TabBarItem),
     CloseTab(usize),
+    ClosePane(PaneId),
     AboveScrollThumb,
     ScrollThumb,
     BelowScrollThumb,
@@ -3231,6 +3232,25 @@ impl TermWindow {
             promise::spawn::spawn(future).detach();
         } else {
             mux.remove_pane(pane_id);
+        }
+    }
+
+    pub fn close_specific_pane(&mut self, pane_id: PaneId) {
+        let mux = Mux::get();
+        let pane = match mux.get_pane(pane_id) {
+            Some(p) => p,
+            None => return,
+        };
+        if pane.can_close_without_prompting(CloseReason::Pane) {
+            mux.remove_pane(pane_id);
+        } else {
+            let mux_window_id = self.mux_window_id;
+            let window = self.window.clone().unwrap();
+            let (overlay, future) = start_overlay_pane(self, &pane, move |pane_id, term| {
+                confirm_close_pane(pane_id, term, mux_window_id, window)
+            });
+            self.assign_overlay_for_pane(pane_id, overlay);
+            promise::spawn::spawn(future).detach();
         }
     }
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3544,28 +3544,22 @@ impl TermWindow {
                 }
             }
 
-            // When a pane title bar is active, each terminal process should
-            // see one fewer row than the cell area allocated to it by the
-            // split layout.  Resize here (lazily, only when the current size
-            // differs) so that the process never writes into the title bar row.
+            // When a pane title bar is active, reduce the displayed row count
+            // by one so the render loop clips the pane content to the rows
+            // below (Top) or above (Bottom) the title bar.
+            //
+            // We adjust only the local PositionedPane values used by the
+            // renderer; we do NOT call p.pane.resize() here.  Calling resize
+            // from the paint loop triggers rebuild_splits_sizes_from_contained_panes
+            // on the mux server, which updates the split tree to the reduced
+            // height, causing every subsequent frame to reduce by one more row
+            // until all panes collapse to a single row.
             if self.config.pane_border_status != PaneBorderStatus::Off {
                 let cell_height = self.render_metrics.cell_size.height as usize;
-                let cell_width = self.render_metrics.cell_size.width as usize;
                 for p in &mut panes {
                     if p.height > 1 {
-                        let target_rows = p.height - 1;
-                        let dims = p.pane.get_dimensions();
-                        if dims.viewport_rows != target_rows {
-                            let _ = p.pane.resize(TerminalSize {
-                                rows: target_rows,
-                                cols: p.width,
-                                pixel_height: target_rows * cell_height,
-                                pixel_width: p.width * cell_width,
-                                dpi: dims.dpi,
-                            });
-                        }
-                        p.height = target_rows;
-                        p.pixel_height = target_rows * cell_height;
+                        p.height -= 1;
+                        p.pixel_height = p.height * cell_height;
                     }
                 }
             }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3544,26 +3544,6 @@ impl TermWindow {
                 }
             }
 
-            // When a pane title bar is active, reduce the displayed row count
-            // by one so the render loop clips the pane content to the rows
-            // below (Top) or above (Bottom) the title bar.
-            //
-            // We adjust only the local PositionedPane values used by the
-            // renderer; we do NOT call p.pane.resize() here.  Calling resize
-            // from the paint loop triggers rebuild_splits_sizes_from_contained_panes
-            // on the mux server, which updates the split tree to the reduced
-            // height, causing every subsequent frame to reduce by one more row
-            // until all panes collapse to a single row.
-            if self.config.pane_border_status != PaneBorderStatus::Off {
-                let cell_height = self.render_metrics.cell_size.height as usize;
-                for p in &mut panes {
-                    if p.height > 1 {
-                        p.height -= 1;
-                        p.pixel_height = p.height * cell_height;
-                    }
-                }
-            }
-
             panes
         }
     }

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -8,7 +8,7 @@ use ::window::{
 };
 use config::keyassignment::{KeyAssignment, MouseEventTrigger, SpawnTabDomain};
 use config::MouseEventAltScreen;
-use mux::pane::{Pane, WithPaneLines};
+use mux::pane::{Pane, PaneId, WithPaneLines};
 use mux::tab::SplitDirection;
 use mux::Mux;
 use mux_lua::MuxPane;
@@ -40,6 +40,7 @@ impl super::TermWindow {
                 self.update_title_post_status();
             }
             UIItemType::CloseTab(_)
+            | UIItemType::ClosePane(_)
             | UIItemType::AboveScrollThumb
             | UIItemType::BelowScrollThumb
             | UIItemType::ScrollThumb
@@ -51,6 +52,7 @@ impl super::TermWindow {
         match item.item_type {
             UIItemType::TabBar(_) => {}
             UIItemType::CloseTab(_)
+            | UIItemType::ClosePane(_)
             | UIItemType::AboveScrollThumb
             | UIItemType::BelowScrollThumb
             | UIItemType::ScrollThumb
@@ -382,7 +384,22 @@ impl super::TermWindow {
             UIItemType::CloseTab(idx) => {
                 self.mouse_event_close_tab(idx, event, context);
             }
+            UIItemType::ClosePane(pane_id) => {
+                self.mouse_event_close_pane(pane_id, event, context);
+            }
         }
+    }
+
+    pub fn mouse_event_close_pane(
+        &mut self,
+        pane_id: PaneId,
+        event: MouseEvent,
+        context: &dyn WindowOps,
+    ) {
+        if let WMEK::Press(MousePress::Left) = event.kind {
+            self.close_specific_pane(pane_id);
+        }
+        context.set_cursor(Some(MouseCursor::Arrow));
     }
 
     pub fn mouse_event_close_tab(

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -723,10 +723,18 @@ impl super::TermWindow {
                 }
                 column = column.saturating_sub(pos.left);
                 row = row.saturating_sub(pos.top as i64);
+                // The title bar occupies row 0 of the pane's visual area;
+                // subtract it so that row 0 maps to the first terminal line.
+                if self.config.pane_border_status != config::PaneBorderStatus::Off {
+                    row = row.saturating_sub(1);
+                }
                 break;
             } else if is_already_captured && pane.pane_id() == pos.pane.pane_id() {
                 column = column.saturating_sub(pos.left);
                 row = row.saturating_sub(pos.top as i64).max(0);
+                if self.config.pane_border_status != config::PaneBorderStatus::Off {
+                    row = row.saturating_sub(1);
+                }
 
                 if position.column < pos.left {
                     x_pixel_offset -= self.render_metrics.cell_size.width

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -40,6 +40,7 @@ pub mod draw;
 pub mod fancy_tab_bar;
 pub mod paint;
 pub mod pane;
+pub mod pane_bar;
 pub mod screen_line;
 pub mod split;
 pub mod tab_bar;

--- a/wezterm-gui/src/termwindow/render/paint.rs
+++ b/wezterm-gui/src/termwindow/render/paint.rs
@@ -2,6 +2,7 @@ use crate::termwindow::{RenderFrame, TermWindowNotif};
 use ::window::bitmaps::atlas::OutOfTextureSpace;
 use ::window::WindowOps;
 use anyhow::Context;
+use config::PaneBorderStatus;
 use smol::Timer;
 use std::time::{Duration, Instant};
 use wezterm_font::ClearShapeCache;
@@ -246,15 +247,15 @@ impl crate::TermWindow {
             .context("filled_rectangle for window background")?;
         }
 
-        for pos in panes {
+        for pos in &panes {
             if pos.is_active {
-                self.update_text_cursor(&pos);
+                self.update_text_cursor(pos);
                 if focused {
                     pos.pane.advise_focus();
                     mux::Mux::get().record_focus_for_current_identity(pos.pane.pane_id());
                 }
             }
-            self.paint_pane(&pos, &mut layers).context("paint_pane")?;
+            self.paint_pane(pos, &mut layers).context("paint_pane")?;
         }
 
         if let Some(pane) = self.get_active_pane_or_overlay() {
@@ -262,6 +263,17 @@ impl crate::TermWindow {
             for split in &splits {
                 self.paint_split(&mut layers, split, &pane)
                     .context("paint_split")?;
+            }
+        }
+
+        // Paint pane title bars after pane content and splits so they are
+        // drawn on top (higher z-order within the same layer).
+        if self.config.pane_border_status != PaneBorderStatus::Off {
+            let pane_info = self.get_pane_information();
+            let tab_info = self.get_tab_information();
+            for pos in &panes {
+                self.paint_pane_title_bar(pos, &pane_info, &tab_info, &mut layers)
+                    .context("paint_pane_title_bar")?;
             }
         }
 

--- a/wezterm-gui/src/termwindow/render/paint.rs
+++ b/wezterm-gui/src/termwindow/render/paint.rs
@@ -272,8 +272,10 @@ impl crate::TermWindow {
             let pane_info = self.get_pane_information();
             let tab_info = self.get_tab_information();
             for pos in &panes {
-                self.paint_pane_title_bar(pos, &pane_info, &tab_info, &mut layers)
+                let items = self
+                    .paint_pane_title_bar(pos, &pane_info, &tab_info, &mut layers)
                     .context("paint_pane_title_bar")?;
+                self.ui_items.extend(items);
             }
         }
 

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -9,7 +9,7 @@ use crate::termwindow::{ScrollHit, UIItem, UIItemType};
 use ::window::bitmaps::TextureRect;
 use ::window::DeadKeyStatus;
 use anyhow::Context;
-use config::VisualBellTarget;
+use config::{PaneBorderStatus, VisualBellTarget};
 use mux::pane::{PaneId, WithPaneLines};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
 use mux::tab::PositionedPane;
@@ -107,6 +107,17 @@ impl crate::TermWindow {
 
         let cell_width = self.render_metrics.cell_size.width as f32;
         let cell_height = self.render_metrics.cell_size.height as f32;
+
+        // When a pane title bar is shown at the top, push terminal content down
+        // one row so it does not overlap the bar.  The terminal process has
+        // already been resized to height-1 rows by get_pos_panes_for_tab, so
+        // no row-count adjustment is needed here.
+        let top_pixel_y_extra = if self.config.pane_border_status == PaneBorderStatus::Top {
+            cell_height
+        } else {
+            0.0f32
+        };
+
         let background_rect = {
             // We want to fill out to the edges of the splits
             let (x, width_delta) = if pos.left == 0 {
@@ -317,6 +328,9 @@ impl crate::TermWindow {
                 rectangular: bool,
                 dims: RenderableDimensions,
                 top_pixel_y: f32,
+                /// Extra pixel offset added to `top_pixel_y` when the title bar is
+                /// at the top of the pane, pushing terminal content down one row.
+                top_pixel_y_extra: f32,
                 left_pixel_x: f32,
                 pos: &'a PositionedPane,
                 pane_id: PaneId,
@@ -347,6 +361,7 @@ impl crate::TermWindow {
                 rectangular,
                 dims,
                 top_pixel_y,
+                top_pixel_y_extra,
                 left_pixel_x,
                 pos,
                 pane_id,
@@ -434,7 +449,8 @@ impl crate::TermWindow {
                         selection: selrange.clone(),
                         cursor,
                         shape_hash,
-                        top_pixel_y: NotNan::new(self.top_pixel_y).unwrap()
+                        top_pixel_y: NotNan::new(self.top_pixel_y + self.top_pixel_y_extra)
+                            .unwrap()
                             + (line_idx + self.pos.top) as f32
                                 * self.term_window.render_metrics.cell_size.height as f32,
                         left_pixel_x: NotNan::new(self.left_pixel_x).unwrap(),

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -118,6 +118,7 @@ impl crate::TermWindow {
             0.0f32
         };
 
+
         let background_rect = {
             // We want to fill out to the edges of the splits
             let (x, width_delta) = if pos.left == 0 {
@@ -138,6 +139,11 @@ impl crate::TermWindow {
                     (top_pixel_y - padding_top),
                     padding_top + (cell_height / 2.0),
                 )
+            } else if self.config.pane_border_status != PaneBorderStatus::Off {
+                // pos.top has been rank-adjusted: the title bar sits exactly
+                // at pos.top*cell_height. Start the background there with no
+                // bleed into the pane above.
+                (top_pixel_y + (pos.top as f32 * cell_height), 0.0)
             } else {
                 (
                     top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),
@@ -153,11 +159,14 @@ impl crate::TermWindow {
                 } else {
                     (pos.width as f32 * cell_width) + width_delta
                 },
-                // Go all the way to the bottom if we're bottom-most
+                // Go all the way to the bottom if we're bottom-most.
+                // When title bars are active, top_pixel_y_extra accounts for
+                // the title bar row so content starts one cell lower.
                 if pos.top + pos.height >= self.terminal_size.rows as usize {
                     self.dimensions.pixel_height as f32 - y
                 } else {
                     (pos.height as f32 * cell_height) + height_delta as f32
+                        + top_pixel_y_extra
                 },
             )
         };
@@ -617,6 +626,11 @@ impl crate::TermWindow {
 
         let border = self.get_os_border();
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;
+        let top_pixel_y_extra = if self.config.pane_border_status == PaneBorderStatus::Top {
+            cell_height
+        } else {
+            0.0f32
+        };
 
         // We want to fill out to the edges of the splits
         let (x, width_delta) = if pos.left == 0 {
@@ -637,6 +651,11 @@ impl crate::TermWindow {
                 (top_pixel_y - padding_top),
                 padding_top + (cell_height / 2.0),
             )
+        } else if self.config.pane_border_status != PaneBorderStatus::Off {
+            // pos.top has been rank-adjusted: the title bar sits exactly at
+            // pos.top*cell_height. Start the background there with no bleed
+            // into the pane above.
+            (top_pixel_y + (pos.top as f32 * cell_height), 0.0)
         } else {
             (
                 top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),
@@ -653,11 +672,14 @@ impl crate::TermWindow {
             } else {
                 (pos.width as f32 * cell_width) + width_delta
             },
-            // Go all the way to the bottom if we're bottom-most
+            // Go all the way to the bottom if we're bottom-most.
+            // When title bars are active, top_pixel_y_extra accounts for
+            // the title bar row so content starts one cell lower.
             if pos.top + pos.height >= self.terminal_size.rows as usize {
                 self.dimensions.pixel_height as f32 - y
             } else {
                 (pos.height as f32 * cell_height) + height_delta as f32
+                    + top_pixel_y_extra
             },
         );
 

--- a/wezterm-gui/src/termwindow/render/pane_bar.rs
+++ b/wezterm-gui/src/termwindow/render/pane_bar.rs
@@ -1,10 +1,10 @@
 use crate::tabbar::compute_pane_title;
 use crate::termwindow::render::{RenderScreenLineParams, TripleLayerQuadAllocator};
-use crate::termwindow::{PaneInformation, TabInformation};
-use config::PaneBorderStatus;
+use crate::termwindow::{PaneInformation, TabInformation, UIItem, UIItemType};
+use config::{PaneBorderStatus, TabBarColors};
 use mux::renderable::RenderableDimensions;
 use mux::tab::PositionedPane;
-use wezterm_term::color::ColorAttribute;
+use wezterm_term::CellAttributes;
 use window::color::LinearRgba;
 
 impl crate::TermWindow {
@@ -18,13 +18,15 @@ impl crate::TermWindow {
     /// The text content comes from the `format-pane-title` Lua event (see
     /// `compute_pane_title`).  When no callback is registered the pane's
     /// window title is used as a fallback.
+    ///
+    /// Returns `UIItem` records for any clickable regions (e.g. close button).
     pub fn paint_pane_title_bar(
         &mut self,
         pos: &PositionedPane,
         pane_info: &[PaneInformation],
         tab_info: &[TabInformation],
         layers: &mut TripleLayerQuadAllocator,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<UIItem>> {
         let config = self.config.clone();
 
         let cell_width = self.render_metrics.cell_size.width as f32;
@@ -54,7 +56,7 @@ impl crate::TermWindow {
         let title_y = match config.pane_border_status {
             PaneBorderStatus::Top => top_pixel_y + pos.top as f32 * cell_height,
             PaneBorderStatus::Bottom => top_pixel_y + (pos.top + pos.height) as f32 * cell_height,
-            PaneBorderStatus::Off => return Ok(()),
+            PaneBorderStatus::Off => return Ok(vec![]),
         };
 
         // Left edge of this pane in pixels.
@@ -64,23 +66,34 @@ impl crate::TermWindow {
         // Look up the PaneInformation so we can call the Lua callback.
         let pane_info_item = match pane_info.iter().find(|p| p.pane_id == pos.pane.pane_id()) {
             Some(p) => p,
-            None => return Ok(()),
+            None => return Ok(vec![]),
         };
 
         let title_line = compute_pane_title(pane_info_item, pane_info, tab_info, &config);
 
         let palette = pos.pane.palette();
-        let foreground = palette.foreground.to_linear();
         let window_is_transparent =
             !self.window_background.is_empty() || config.window_background_opacity != 1.0;
-        let default_bg = palette
-            .resolve_bg(ColorAttribute::Default)
+
+        // Use the tab bar's active/inactive colors so the pane title bar is
+        // visually distinct from the terminal content and consistent with the
+        // tab bar styling.
+        let tab_colors = config
+            .resolved_palette
+            .tab_bar
+            .as_ref()
+            .cloned()
+            .unwrap_or_else(TabBarColors::default);
+        let bar_color = if pos.is_active {
+            tab_colors.active_tab()
+        } else {
+            tab_colors.inactive_tab()
+        };
+        let foreground = bar_color.fg_color.to_linear();
+        let default_bg = bar_color
+            .bg_color
             .to_linear()
-            .mul_alpha(if window_is_transparent {
-                0.
-            } else {
-                config.text_background_opacity
-            });
+            .mul_alpha(if window_is_transparent { 0. } else { 1.0 });
 
         // Draw a solid background strip behind the title text so it is
         // legible even when a window background image is configured.
@@ -97,25 +110,37 @@ impl crate::TermWindow {
 
         let dims = pos.pane.get_dimensions();
 
+        // Reserve the rightmost cell for the close button when enabled.
+        let show_close = config.show_close_pane_button_in_pane_bar && pos.width >= 2;
+        let title_pixel_width = if show_close {
+            pixel_width - cell_width
+        } else {
+            pixel_width
+        };
+
         self.render_screen_line(
             RenderScreenLineParams {
                 top_pixel_y: title_y,
                 left_pixel_x: title_x,
-                pixel_width,
+                pixel_width: title_pixel_width,
                 stable_line_idx: None,
                 line: &title_line,
                 selection: 0..0,
                 cursor: &Default::default(),
                 palette: &palette,
                 dims: &RenderableDimensions {
-                    cols: pos.width,
+                    cols: if show_close { pos.width - 1 } else { pos.width },
                     physical_top: 0,
                     scrollback_rows: 0,
                     scrollback_top: 0,
                     viewport_rows: 1,
                     dpi: dims.dpi,
                     pixel_height: self.render_metrics.cell_size.height as usize,
-                    pixel_width: pos.pixel_width,
+                    pixel_width: if show_close {
+                        pos.pixel_width - self.render_metrics.cell_size.width as usize
+                    } else {
+                        pos.pixel_width
+                    },
                     reverse_video: false,
                 },
                 config: &config,
@@ -142,6 +167,73 @@ impl crate::TermWindow {
             layers,
         )?;
 
-        Ok(())
+        let mut ui_items = vec![];
+
+        if show_close {
+            let close_x = title_x + pixel_width - cell_width;
+            let close_line = {
+                use wezterm_term::color::AnsiColor;
+                let mut attr = CellAttributes::default();
+                attr.set_foreground(wezterm_term::color::ColorAttribute::PaletteIndex(
+                    AnsiColor::White as u8,
+                ));
+                crate::tabbar::parse_status_text("\u{00d7}", attr)
+            };
+
+            self.render_screen_line(
+                RenderScreenLineParams {
+                    top_pixel_y: title_y,
+                    left_pixel_x: close_x,
+                    pixel_width: cell_width,
+                    stable_line_idx: None,
+                    line: &close_line,
+                    selection: 0..0,
+                    cursor: &Default::default(),
+                    palette: &palette,
+                    dims: &RenderableDimensions {
+                        cols: 1,
+                        physical_top: 0,
+                        scrollback_rows: 0,
+                        scrollback_top: 0,
+                        viewport_rows: 1,
+                        dpi: dims.dpi,
+                        pixel_height: self.render_metrics.cell_size.height as usize,
+                        pixel_width: self.render_metrics.cell_size.width as usize,
+                        reverse_video: false,
+                    },
+                    config: &config,
+                    cursor_border_color: LinearRgba::default(),
+                    foreground,
+                    pane: None,
+                    is_active: pos.is_active,
+                    selection_fg: LinearRgba::default(),
+                    selection_bg: LinearRgba::default(),
+                    cursor_fg: LinearRgba::default(),
+                    cursor_bg: LinearRgba::default(),
+                    cursor_is_default_color: true,
+                    white_space,
+                    filled_box,
+                    window_is_transparent,
+                    default_bg,
+                    style: None,
+                    font: None,
+                    use_pixel_positioning: config.experimental_pixel_positioning,
+                    render_metrics: self.render_metrics,
+                    shape_key: None,
+                    password_input: false,
+                },
+                layers,
+            )?;
+
+            ui_items.push(UIItem {
+                x: close_x as usize,
+                y: title_y as usize,
+                width: cell_width as usize,
+                height: cell_height as usize,
+                item_type: UIItemType::ClosePane(pos.pane.pane_id()),
+            });
+        }
+
+        Ok(ui_items)
     }
 }

--- a/wezterm-gui/src/termwindow/render/pane_bar.rs
+++ b/wezterm-gui/src/termwindow/render/pane_bar.rs
@@ -11,10 +11,9 @@ impl crate::TermWindow {
     /// Paint a one-row title bar for a single split pane.
     ///
     /// The bar is drawn at the top or bottom of the pane's allocated cell
-    /// space (controlled by `config.pane_border_status`).  Terminal content
-    /// is rendered on top of it in `paint_pane`; this function draws the
-    /// background and text before the pane content so that on the default
-    /// `Top` position the title sits above the scrollback.
+    /// space (controlled by `config.pane_border_status`).  `paint_pane`
+    /// reserves this row by shifting terminal content down (Top) or
+    /// truncating the last visible row (Bottom), so there is no overlap.
     ///
     /// The text content comes from the `format-pane-title` Lua event (see
     /// `compute_pane_title`).  When no callback is registered the pane's
@@ -47,11 +46,14 @@ impl crate::TermWindow {
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;
 
         // Pixel y-coordinate of the title bar row.
+        //
+        // pos.height has already been reduced by one by get_pos_panes_for_tab
+        // so that it equals the number of terminal rows.  The title bar
+        // therefore sits at pos.top (Top) or pos.top + pos.height (Bottom),
+        // which is the row immediately adjacent to the terminal content.
         let title_y = match config.pane_border_status {
             PaneBorderStatus::Top => top_pixel_y + pos.top as f32 * cell_height,
-            PaneBorderStatus::Bottom => {
-                top_pixel_y + (pos.top + pos.height.saturating_sub(1)) as f32 * cell_height
-            }
+            PaneBorderStatus::Bottom => top_pixel_y + (pos.top + pos.height) as f32 * cell_height,
             PaneBorderStatus::Off => return Ok(()),
         };
 

--- a/wezterm-gui/src/termwindow/render/pane_bar.rs
+++ b/wezterm-gui/src/termwindow/render/pane_bar.rs
@@ -130,26 +130,10 @@ impl crate::TermWindow {
 
         // Draw a solid background strip behind the title text so it is
         // legible even when a window background image is configured.
-        //
-        // Extend the fill by half a cell toward the adjacent split line to
-        // close the visual gap between the split border and the title bar.
-        // The split line is drawn at pos_y ± cell_height/2, so reaching out
-        // by that amount makes them flush.  Clamp to top_pixel_y so we never
-        // overdraw into the tab-bar area.
-        let (fill_y, fill_height) = match config.pane_border_status {
-            PaneBorderStatus::Top => {
-                let extend = cell_height / 2.0;
-                let y_start = (title_y - extend).max(top_pixel_y);
-                let h = cell_height + (title_y - y_start);
-                (y_start, h)
-            }
-            PaneBorderStatus::Bottom => (title_y, cell_height + cell_height / 2.0),
-            PaneBorderStatus::Off => return Ok(vec![]),
-        };
         self.filled_rectangle(
             layers,
             0,
-            euclid::rect(title_x, fill_y, pixel_width, fill_height),
+            euclid::rect(title_x, title_y, pixel_width, cell_height),
             default_bg,
         )?;
 

--- a/wezterm-gui/src/termwindow/render/pane_bar.rs
+++ b/wezterm-gui/src/termwindow/render/pane_bar.rs
@@ -1,11 +1,35 @@
+use crate::customglyph::*;
 use crate::tabbar::compute_pane_title;
+use crate::termwindow::box_model::*;
 use crate::termwindow::render::{RenderScreenLineParams, TripleLayerQuadAllocator};
+use crate::termwindow::resize;
 use crate::termwindow::{PaneInformation, TabInformation, UIItem, UIItemType};
-use config::{PaneBorderStatus, TabBarColors};
+use crate::utilsprites::RenderMetrics;
+use config::{Dimension, DimensionContext, PaneBorderStatus, TabBarColors};
 use mux::renderable::RenderableDimensions;
 use mux::tab::PositionedPane;
-use wezterm_term::CellAttributes;
 use window::color::LinearRgba;
+
+/// The X drawn in each pane close button — identical to the one used by the
+/// fancy tab bar in `fancy_tab_bar.rs`.
+const X_BUTTON: &[Poly] = &[
+    Poly {
+        path: &[
+            PolyCommand::MoveTo(BlockCoord::One, BlockCoord::Zero),
+            PolyCommand::LineTo(BlockCoord::Zero, BlockCoord::One),
+        ],
+        intensity: BlockAlpha::Full,
+        style: PolyStyle::Outline,
+    },
+    Poly {
+        path: &[
+            PolyCommand::MoveTo(BlockCoord::Zero, BlockCoord::Zero),
+            PolyCommand::LineTo(BlockCoord::One, BlockCoord::One),
+        ],
+        intensity: BlockAlpha::Full,
+        style: PolyStyle::Outline,
+    },
+];
 
 impl crate::TermWindow {
     /// Paint a one-row title bar for a single split pane.
@@ -32,6 +56,15 @@ impl crate::TermWindow {
         let cell_width = self.render_metrics.cell_size.width as f32;
         let cell_height = self.render_metrics.cell_size.height as f32;
         let (padding_left, padding_top) = self.padding_left_top();
+
+        // Compute right padding so the close button doesn't spill into the OS
+        // border or window padding on the right side.
+        let h_context = DimensionContext {
+            dpi: self.dimensions.dpi as f32,
+            pixel_max: self.terminal_size.pixel_width as f32,
+            pixel_cell: cell_width,
+        };
+        let padding_right = resize::effective_right_padding(&config, h_context) as f32;
 
         let tab_bar_height = if self.show_tab_bar {
             self.tab_bar_pixel_height()?
@@ -97,10 +130,26 @@ impl crate::TermWindow {
 
         // Draw a solid background strip behind the title text so it is
         // legible even when a window background image is configured.
+        //
+        // Extend the fill by half a cell toward the adjacent split line to
+        // close the visual gap between the split border and the title bar.
+        // The split line is drawn at pos_y ± cell_height/2, so reaching out
+        // by that amount makes them flush.  Clamp to top_pixel_y so we never
+        // overdraw into the tab-bar area.
+        let (fill_y, fill_height) = match config.pane_border_status {
+            PaneBorderStatus::Top => {
+                let extend = cell_height / 2.0;
+                let y_start = (title_y - extend).max(top_pixel_y);
+                let h = cell_height + (title_y - y_start);
+                (y_start, h)
+            }
+            PaneBorderStatus::Bottom => (title_y, cell_height + cell_height / 2.0),
+            PaneBorderStatus::Off => return Ok(vec![]),
+        };
         self.filled_rectangle(
             layers,
             0,
-            euclid::rect(title_x, title_y, pixel_width, cell_height),
+            euclid::rect(title_x, fill_y, pixel_width, fill_height),
             default_bg,
         )?;
 
@@ -110,37 +159,148 @@ impl crate::TermWindow {
 
         let dims = pos.pane.get_dimensions();
 
-        // Reserve the rightmost cell for the close button when enabled.
+        // The close button uses the same Poly-based X as the fancy tab bar.
+        // We know the exact right-edge pixel position, so we place it
+        // absolutely rather than relying on Float::Right.  The container
+        // element is fully transparent so it never overwrites the title text
+        // rendered by render_screen_line below.
         let show_close = config.show_close_pane_button_in_pane_bar && pos.width >= 2;
-        let title_pixel_width = if show_close {
-            pixel_width - cell_width
+
+        let mut ui_items = vec![];
+
+        if show_close {
+            let font = self.fonts.title_font()?;
+            let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+
+            let inactive_tab_hover = tab_colors.inactive_tab_hover();
+            let active_tab_color = tab_colors.active_tab();
+
+            // Button width: 0.5 left margin + 0.25 left pad + poly + 0.25 right pad + 0.25 right margin
+            let close_btn_width = cell_width * 1.75;
+            // Clamp the button's right edge so it never overflows into the OS
+            // border or window padding on the right side of the screen.
+            let window_right = self.dimensions.pixel_width as f32
+                - border.right.get() as f32
+                - padding_right;
+            let close_x = (title_x + pixel_width - close_btn_width).min(window_right - close_btn_width);
+
+            let x_btn = Element::new(
+                &font,
+                ElementContent::Poly {
+                    line_width: metrics.underline_height.max(2),
+                    poly: SizedPoly {
+                        poly: X_BUTTON,
+                        width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+                        height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+                    },
+                },
+            )
+            .zindex(1)
+            .vertical_align(VerticalAlign::Middle)
+            .item_type(UIItemType::ClosePane(pos.pane.pane_id()))
+            .hover_colors(Some(ElementColors {
+                border: BorderColor::default(),
+                bg: (if pos.is_active {
+                    inactive_tab_hover.bg_color
+                } else {
+                    active_tab_color.bg_color
+                })
+                .to_linear()
+                .into(),
+                text: (if pos.is_active {
+                    inactive_tab_hover.fg_color
+                } else {
+                    active_tab_color.fg_color
+                })
+                .to_linear()
+                .into(),
+            }))
+            .colors(ElementColors {
+                border: BorderColor::default(),
+                bg: default_bg.into(),
+                text: foreground.into(),
+            })
+            .padding(BoxDimension {
+                left: Dimension::Cells(0.25),
+                right: Dimension::Cells(0.25),
+                top: Dimension::Cells(0.25),
+                bottom: Dimension::Cells(0.25),
+            })
+            .margin(BoxDimension {
+                left: Dimension::Cells(0.5),
+                right: Dimension::Cells(0.25),
+                top: Dimension::Cells(0.),
+                bottom: Dimension::Cells(0.),
+            });
+
+            // Wrap in a transparent container positioned at the right edge.
+            // The container has no background so it never covers the title
+            // text rendered by render_screen_line.
+            let container = Element::new(&font, ElementContent::Children(vec![x_btn]))
+                .colors(ElementColors {
+                    border: BorderColor::default(),
+                    bg: LinearRgba(0., 0., 0., 0.).into(),
+                    text: foreground.into(),
+                })
+                .min_width(Some(Dimension::Pixels(close_btn_width)))
+                .min_height(Some(Dimension::Pixels(cell_height)));
+
+            let mut computed = self.compute_element(
+                &LayoutContext {
+                    height: DimensionContext {
+                        dpi: self.dimensions.dpi as f32,
+                        pixel_max: self.dimensions.pixel_height as f32,
+                        pixel_cell: metrics.cell_size.height as f32,
+                    },
+                    width: DimensionContext {
+                        dpi: self.dimensions.dpi as f32,
+                        pixel_max: self.dimensions.pixel_width as f32,
+                        pixel_cell: metrics.cell_size.width as f32,
+                    },
+                    bounds: euclid::rect(close_x, 0., close_btn_width, cell_height),
+                    metrics: &metrics,
+                    gl_state,
+                    zindex: 1,
+                },
+                &container,
+            )?;
+
+            // translate y into screen coordinates
+            computed.translate(euclid::vec2(0., title_y));
+
+            ui_items.extend(computed.ui_items());
+            self.render_element(&computed, gl_state, None)?;
+        }
+
+        // Title text — shrink by the exact close-button pixel width so the
+        // text clips precisely without leaving a visible gap or overlapping.
+        let close_btn_width = cell_width * 1.75;
+        let text_pixel_width = if show_close {
+            (pixel_width - close_btn_width).max(cell_width)
         } else {
             pixel_width
         };
+        let text_cols = (text_pixel_width / cell_width) as usize;
 
         self.render_screen_line(
             RenderScreenLineParams {
                 top_pixel_y: title_y,
                 left_pixel_x: title_x,
-                pixel_width: title_pixel_width,
+                pixel_width: text_pixel_width,
                 stable_line_idx: None,
                 line: &title_line,
                 selection: 0..0,
                 cursor: &Default::default(),
                 palette: &palette,
                 dims: &RenderableDimensions {
-                    cols: if show_close { pos.width - 1 } else { pos.width },
+                    cols: text_cols,
                     physical_top: 0,
                     scrollback_rows: 0,
                     scrollback_top: 0,
                     viewport_rows: 1,
                     dpi: dims.dpi,
                     pixel_height: self.render_metrics.cell_size.height as usize,
-                    pixel_width: if show_close {
-                        pos.pixel_width - self.render_metrics.cell_size.width as usize
-                    } else {
-                        pos.pixel_width
-                    },
+                    pixel_width: text_pixel_width as usize,
                     reverse_video: false,
                 },
                 config: &config,
@@ -166,73 +326,6 @@ impl crate::TermWindow {
             },
             layers,
         )?;
-
-        let mut ui_items = vec![];
-
-        if show_close {
-            let close_x = title_x + pixel_width - cell_width;
-            let close_line = {
-                use wezterm_term::color::AnsiColor;
-                let mut attr = CellAttributes::default();
-                attr.set_foreground(wezterm_term::color::ColorAttribute::PaletteIndex(
-                    AnsiColor::White as u8,
-                ));
-                crate::tabbar::parse_status_text("\u{00d7}", attr)
-            };
-
-            self.render_screen_line(
-                RenderScreenLineParams {
-                    top_pixel_y: title_y,
-                    left_pixel_x: close_x,
-                    pixel_width: cell_width,
-                    stable_line_idx: None,
-                    line: &close_line,
-                    selection: 0..0,
-                    cursor: &Default::default(),
-                    palette: &palette,
-                    dims: &RenderableDimensions {
-                        cols: 1,
-                        physical_top: 0,
-                        scrollback_rows: 0,
-                        scrollback_top: 0,
-                        viewport_rows: 1,
-                        dpi: dims.dpi,
-                        pixel_height: self.render_metrics.cell_size.height as usize,
-                        pixel_width: self.render_metrics.cell_size.width as usize,
-                        reverse_video: false,
-                    },
-                    config: &config,
-                    cursor_border_color: LinearRgba::default(),
-                    foreground,
-                    pane: None,
-                    is_active: pos.is_active,
-                    selection_fg: LinearRgba::default(),
-                    selection_bg: LinearRgba::default(),
-                    cursor_fg: LinearRgba::default(),
-                    cursor_bg: LinearRgba::default(),
-                    cursor_is_default_color: true,
-                    white_space,
-                    filled_box,
-                    window_is_transparent,
-                    default_bg,
-                    style: None,
-                    font: None,
-                    use_pixel_positioning: config.experimental_pixel_positioning,
-                    render_metrics: self.render_metrics,
-                    shape_key: None,
-                    password_input: false,
-                },
-                layers,
-            )?;
-
-            ui_items.push(UIItem {
-                x: close_x as usize,
-                y: title_y as usize,
-                width: cell_width as usize,
-                height: cell_height as usize,
-                item_type: UIItemType::ClosePane(pos.pane.pane_id()),
-            });
-        }
 
         Ok(ui_items)
     }

--- a/wezterm-gui/src/termwindow/render/pane_bar.rs
+++ b/wezterm-gui/src/termwindow/render/pane_bar.rs
@@ -1,0 +1,145 @@
+use crate::tabbar::compute_pane_title;
+use crate::termwindow::render::{RenderScreenLineParams, TripleLayerQuadAllocator};
+use crate::termwindow::{PaneInformation, TabInformation};
+use config::PaneBorderStatus;
+use mux::renderable::RenderableDimensions;
+use mux::tab::PositionedPane;
+use wezterm_term::color::ColorAttribute;
+use window::color::LinearRgba;
+
+impl crate::TermWindow {
+    /// Paint a one-row title bar for a single split pane.
+    ///
+    /// The bar is drawn at the top or bottom of the pane's allocated cell
+    /// space (controlled by `config.pane_border_status`).  Terminal content
+    /// is rendered on top of it in `paint_pane`; this function draws the
+    /// background and text before the pane content so that on the default
+    /// `Top` position the title sits above the scrollback.
+    ///
+    /// The text content comes from the `format-pane-title` Lua event (see
+    /// `compute_pane_title`).  When no callback is registered the pane's
+    /// window title is used as a fallback.
+    pub fn paint_pane_title_bar(
+        &mut self,
+        pos: &PositionedPane,
+        pane_info: &[PaneInformation],
+        tab_info: &[TabInformation],
+        layers: &mut TripleLayerQuadAllocator,
+    ) -> anyhow::Result<()> {
+        let config = self.config.clone();
+
+        let cell_width = self.render_metrics.cell_size.width as f32;
+        let cell_height = self.render_metrics.cell_size.height as f32;
+        let (padding_left, padding_top) = self.padding_left_top();
+
+        let tab_bar_height = if self.show_tab_bar {
+            self.tab_bar_pixel_height()?
+        } else {
+            0.
+        };
+        let (top_bar_height, _bottom_bar_height) = if config.tab_bar_at_bottom {
+            (0.0, tab_bar_height)
+        } else {
+            (tab_bar_height, 0.0)
+        };
+
+        let border = self.get_os_border();
+        let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;
+
+        // Pixel y-coordinate of the title bar row.
+        let title_y = match config.pane_border_status {
+            PaneBorderStatus::Top => top_pixel_y + pos.top as f32 * cell_height,
+            PaneBorderStatus::Bottom => {
+                top_pixel_y + (pos.top + pos.height.saturating_sub(1)) as f32 * cell_height
+            }
+            PaneBorderStatus::Off => return Ok(()),
+        };
+
+        // Left edge of this pane in pixels.
+        let title_x = padding_left + border.left.get() as f32 + pos.left as f32 * cell_width;
+        let pixel_width = pos.width as f32 * cell_width;
+
+        // Look up the PaneInformation so we can call the Lua callback.
+        let pane_info_item = match pane_info.iter().find(|p| p.pane_id == pos.pane.pane_id()) {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        let title_line = compute_pane_title(pane_info_item, pane_info, tab_info, &config);
+
+        let palette = pos.pane.palette();
+        let foreground = palette.foreground.to_linear();
+        let window_is_transparent =
+            !self.window_background.is_empty() || config.window_background_opacity != 1.0;
+        let default_bg = palette
+            .resolve_bg(ColorAttribute::Default)
+            .to_linear()
+            .mul_alpha(if window_is_transparent {
+                0.
+            } else {
+                config.text_background_opacity
+            });
+
+        // Draw a solid background strip behind the title text so it is
+        // legible even when a window background image is configured.
+        self.filled_rectangle(
+            layers,
+            0,
+            euclid::rect(title_x, title_y, pixel_width, cell_height),
+            default_bg,
+        )?;
+
+        let gl_state = self.render_state.as_ref().unwrap();
+        let white_space = gl_state.util_sprites.white_space.texture_coords();
+        let filled_box = gl_state.util_sprites.filled_box.texture_coords();
+
+        let dims = pos.pane.get_dimensions();
+
+        self.render_screen_line(
+            RenderScreenLineParams {
+                top_pixel_y: title_y,
+                left_pixel_x: title_x,
+                pixel_width,
+                stable_line_idx: None,
+                line: &title_line,
+                selection: 0..0,
+                cursor: &Default::default(),
+                palette: &palette,
+                dims: &RenderableDimensions {
+                    cols: pos.width,
+                    physical_top: 0,
+                    scrollback_rows: 0,
+                    scrollback_top: 0,
+                    viewport_rows: 1,
+                    dpi: dims.dpi,
+                    pixel_height: self.render_metrics.cell_size.height as usize,
+                    pixel_width: pos.pixel_width,
+                    reverse_video: false,
+                },
+                config: &config,
+                cursor_border_color: LinearRgba::default(),
+                foreground,
+                pane: None,
+                is_active: pos.is_active,
+                selection_fg: LinearRgba::default(),
+                selection_bg: LinearRgba::default(),
+                cursor_fg: LinearRgba::default(),
+                cursor_bg: LinearRgba::default(),
+                cursor_is_default_color: true,
+                white_space,
+                filled_box,
+                window_is_transparent,
+                default_bg,
+                style: None,
+                font: None,
+                use_pixel_positioning: config.experimental_pixel_positioning,
+                render_metrics: self.render_metrics,
+                shape_key: None,
+                password_input: false,
+            },
+            layers,
+        )?;
+
+        Ok(())
+    }
+}

--- a/wezterm-gui/src/termwindow/render/split.rs
+++ b/wezterm-gui/src/termwindow/render/split.rs
@@ -28,6 +28,14 @@ impl crate::TermWindow {
         let pos_y = split.top as f32 * cell_height + first_row_offset + padding_top;
         let pos_x = split.left as f32 * cell_width + padding_left + border.left.get() as f32;
 
+        // When pane title bars are shown, the title bar of each lower pane
+        // already serves as the visual separator between stacked panes.
+        // For vertical (top/bottom) splits: skip the split line but register
+        // the resize hit-target at the title bar row so the user can still
+        // drag to resize.
+        let suppress_line = self.config.pane_border_status != config::PaneBorderStatus::Off
+            && split.direction != SplitDirection::Horizontal;
+
         if split.direction == SplitDirection::Horizontal {
             self.filled_rectangle(
                 layers,
@@ -52,25 +60,35 @@ impl crate::TermWindow {
                 item_type: UIItemType::Split(split.clone()),
             });
         } else {
-            self.filled_rectangle(
-                layers,
-                2,
-                euclid::rect(
-                    pos_x - (cell_width / 2.0),
-                    pos_y + (cell_height / 2.0),
-                    (1.0 + split.size as f32) * cell_width,
-                    self.render_metrics.underline_height as f32,
-                ),
-                foreground,
-            )?;
+            if !suppress_line {
+                self.filled_rectangle(
+                    layers,
+                    2,
+                    euclid::rect(
+                        pos_x - (cell_width / 2.0),
+                        pos_y + (cell_height / 2.0),
+                        (1.0 + split.size as f32) * cell_width,
+                        self.render_metrics.underline_height as f32,
+                    ),
+                    foreground,
+                )?;
+            }
+            // Hit-target is the title bar row (one cell below split.top).
+            let hit_y = if suppress_line {
+                padding_top as usize
+                    + first_row_offset as usize
+                    + (split.top + 1) * cell_height as usize
+            } else {
+                padding_top as usize
+                    + first_row_offset as usize
+                    + split.top * cell_height as usize
+            };
             self.ui_items.push(UIItem {
                 x: border.left.get() as usize
                     + padding_left as usize
                     + (split.left * cell_width as usize),
                 width: split.size * cell_width as usize,
-                y: padding_top as usize
-                    + first_row_offset as usize
-                    + split.top * cell_height as usize,
+                y: hit_y,
                 height: cell_height as usize,
                 item_type: UIItemType::Split(split.clone()),
             });

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -2,6 +2,7 @@ use crate::resize_increment_calculator::ResizeIncrementCalculator;
 use crate::utilsprites::RenderMetrics;
 use ::window::{Dimensions, ResizeIncrement, Window, WindowOps, WindowState};
 use config::{ConfigHandle, DimensionContext};
+use config::PaneBorderStatus;
 use mux::Mux;
 use std::rc::Rc;
 use wezterm_font::FontConfiguration;
@@ -171,7 +172,7 @@ impl super::TermWindow {
 
         let border = self.get_os_border();
 
-        let (size, dims, ri_calc) = if let Some(cell_dims) = scale_changed_cells {
+        let (size, dims, ri_calc, window_base_rows) = if let Some(cell_dims) = scale_changed_cells {
             // Scaling preserves existing terminal dimensions, yielding a new
             // overall set of window dimensions
             let size = TerminalSize {
@@ -227,7 +228,7 @@ impl super::TermWindow {
                 tab_bar_height: tab_bar_height as usize,
             };
 
-            (size, dims, ri_calc)
+            (size, dims, ri_calc, None)
         } else {
             // Resize of the window dimensions may result in changed terminal dimensions
 
@@ -259,8 +260,22 @@ impl super::TermWindow {
                 )
                 .saturating_sub(tab_bar_height as usize);
 
-            let rows = avail_height / self.render_metrics.cell_size.height as usize;
             let cols = avail_width / self.render_metrics.cell_size.width as usize;
+
+            // Total rows available across the whole window (no title-bar deduction yet).
+            let base_rows = avail_height / self.render_metrics.cell_size.height as usize;
+
+            // When pane title bars are shown each pane loses one row to its title
+            // bar.  For terminal_size (used when spawning new single-pane tabs)
+            // subtract one row.  Per-tab resizes below subtract the exact number of
+            // title-bar rows needed for that tab's split layout.
+            let default_title_bar_rows =
+                if self.config.pane_border_status != PaneBorderStatus::Off {
+                    1usize
+                } else {
+                    0usize
+                };
+            let rows = base_rows.saturating_sub(default_title_bar_rows);
 
             let size = TerminalSize {
                 rows,
@@ -285,7 +300,7 @@ impl super::TermWindow {
                 tab_bar_height: tab_bar_height as usize,
             };
 
-            (size, *dimensions, ri_calc)
+            (size, *dimensions, ri_calc, Some(base_rows))
         };
 
         log::trace!("apply_dimensions computed size {:?}, dims {:?}", size, dims);


### PR DESCRIPTION
## Summary

Adds a `pane_border_status` configuration option that renders a one-row title bar at the top or bottom of each split pane, with proper layout so terminal content never overlaps the bar and the terminal process sees the correct dimensions.

### Motivation

When working with multiple split panes it can be hard to identify what each pane is doing at a glance.  Many terminal multiplexers (tmux, Zellij, etc.) solve this with per-pane title bars; WezTerm currently has no equivalent.

### What this PR does

* **New config field** `pane_border_status: PaneBorderStatus` (enum `Off` | `Top` | `Bottom`, defaults to `Off`).  Existing configs are unaffected.

* **New Lua event** `format-pane-title` fired for each pane on every frame, mirroring `format-tab-title`.  The callback receives `(pane, panes, tabs, config)` and may return a plain string or a `FormatItem` table.  Falls back to the pane's window title when no callback is registered.

* **`paint_pane_title_bar()`** in a new `termwindow/render/pane_bar.rs` draws a filled background rect and calls `render_screen_line()` at the title bar's pixel row.

* **Correct layout — no overlap, correct terminal dimensions:**
  * `get_pos_panes_for_tab()` resizes each terminal process to `height - 1` rows (lazily, only when the current size differs).  The process therefore never writes into the title bar row.
  * For `Top`, `paint_pane` adds one cell of pixel offset so terminal lines render starting at the row below the title bar.
  * For `Bottom`, the title bar sits at `pos.top + pos.height` (the row immediately below the terminal content).
  * `PositionedPane.height` is updated to `height - 1` so all downstream rendering uses the correct cell count.

* **Close button** — a `×` rendered at the right edge of each pane title bar closes (kills) that pane on click.  Controlled by the new `show_close_pane_button_in_pane_bar` config option (defaults to `true`).  Implemented via a new `UIItemType::ClosePane(PaneId)` variant that plugs into the existing UI hit-test and mouse-dispatch infrastructure used by the tab close button.

* **6 unit tests** covering `parse_status_text` and `default_pane_title`.

### Example config

```lua
config.pane_border_status = "Top"

wezterm.on("format-pane-title", function(pane, panes, tabs, config)
  local zoomed = pane.is_zoomed and " [Z]" or ""
  local active = pane.is_active and " *" or ""
  return pane.title .. zoomed .. active
end)

-- optional: disable the close button
-- config.show_close_pane_button_in_pane_bar = false
```

### Testing

```
cargo test -p wezterm-gui
```

All 18 tests pass (6 new, 12 existing).