### PR TITLE
Add vertical tab bar with drag-to-resize and left/right positioning

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -476,8 +476,7 @@ pub struct Config {
     #[dynamic(default)]
     pub tab_bar_at_bottom: bool,
 
-    /// If true, render the tab bar vertically on the left side of the window
-    /// instead of horizontally at the top or bottom.
+    /// If true, render the tab bar vertically instead of horizontally.
     #[dynamic(default)]
     pub tab_bar_vertical: bool,
 
@@ -485,6 +484,10 @@ pub struct Config {
     /// Defaults to 200.
     #[dynamic(default = "default_tab_bar_vertical_width")]
     pub tab_bar_vertical_width: usize,
+
+    /// Position of the vertical tab bar: "Left" or "Right". Defaults to "Left".
+    #[dynamic(default)]
+    pub tab_bar_vertical_position: VerticalTabBarPosition,
 
     #[dynamic(default = "default_true")]
     pub mouse_wheel_scrolls_tabs: bool,
@@ -1988,6 +1991,13 @@ pub enum VerticalWindowContentAlignment {
     Top,
     Center,
     Bottom,
+}
+
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VerticalTabBarPosition {
+    #[default]
+    Left,
+    Right,
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, PartialEq, Eq)]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -476,6 +476,16 @@ pub struct Config {
     #[dynamic(default)]
     pub tab_bar_at_bottom: bool,
 
+    /// If true, render the tab bar vertically on the left side of the window
+    /// instead of horizontally at the top or bottom.
+    #[dynamic(default)]
+    pub tab_bar_vertical: bool,
+
+    /// The width in pixels of the vertical tab bar when tab_bar_vertical is true.
+    /// Defaults to 200.
+    #[dynamic(default = "default_tab_bar_vertical_width")]
+    pub tab_bar_vertical_width: usize,
+
     #[dynamic(default = "default_true")]
     pub mouse_wheel_scrolls_tabs: bool,
 
@@ -1866,6 +1876,10 @@ fn default_enq_answerback() -> String {
 
 fn default_tab_max_width() -> usize {
     16
+}
+
+fn default_tab_bar_vertical_width() -> usize {
+    200
 }
 
 fn default_update_interval() -> u64 {

--- a/wezterm-gui/src/resize_increment_calculator.rs
+++ b/wezterm-gui/src/resize_increment_calculator.rs
@@ -10,6 +10,7 @@ pub struct ResizeIncrementCalculator {
     pub padding_bottom: usize,
     pub border: Border,
     pub tab_bar_height: usize,
+    pub tab_bar_width: usize,
 }
 
 impl Into<ResizeIncrement> for ResizeIncrementCalculator {
@@ -19,7 +20,8 @@ impl Into<ResizeIncrement> for ResizeIncrementCalculator {
             y: self.y,
             base_width: (self.padding_left
                 + self.padding_right
-                + (self.border.left + self.border.right).get()) as u16,
+                + (self.border.left + self.border.right).get()
+                + self.tab_bar_width) as u16,
             base_height: (self.padding_top
                 + self.padding_bottom
                 + (self.border.top + self.border.bottom).get()

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -162,6 +162,13 @@ pub enum UIItemType {
     VerticalTabBarResize,
 }
 
+/// Minimum width (px) when drag-resizing the vertical tab bar.
+pub const MIN_VERTICAL_TAB_BAR_WIDTH: f32 = 80.;
+/// Maximum ratio of window width the vertical tab bar can occupy.
+pub const MAX_VERTICAL_TAB_BAR_WIDTH_RATIO: f32 = 0.5;
+/// Width (px) of the invisible resize handle hit area on the separator edge.
+pub const RESIZE_HANDLE_WIDTH: usize = 6;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct UIItem {
     pub x: usize,

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -159,6 +159,7 @@ pub enum UIItemType {
     ScrollThumb,
     BelowScrollThumb,
     Split(PositionedSplit),
+    VerticalTabBarResize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -391,6 +392,8 @@ pub struct TermWindow {
     show_scroll_bar: bool,
     tab_bar: TabBarState,
     fancy_tab_bar: Option<box_model::ComputedElement>,
+    /// Dynamic override for vertical tab bar width (set by drag-resize)
+    vertical_tab_bar_width_override: Option<f32>,
     pub right_status: String,
     pub left_status: String,
     last_ui_item: Option<UIItem>,
@@ -712,6 +715,7 @@ impl TermWindow {
             show_scroll_bar: config.enable_scroll_bar,
             tab_bar: TabBarState::default(),
             fancy_tab_bar: None,
+            vertical_tab_bar_width_override: None,
             right_status: String::new(),
             left_status: String::new(),
             last_mouse_coords: (0, -1),
@@ -869,6 +873,11 @@ impl TermWindow {
                         padding_bottom: padding_bottom,
                         border: border,
                         tab_bar_height: tab_bar_height,
+                        tab_bar_width: if config.tab_bar_vertical && show_tab_bar {
+                            config.tab_bar_vertical_width
+                        } else {
+                            0
+                        },
                     }
                     .into(),
                 );

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -87,7 +87,7 @@ impl super::TermWindow {
             .max(0)
             / self.render_metrics.cell_size.height) as i64;
 
-        let vertical_tab_bar_width = self.tab_bar_pixel_width();
+        let vertical_tab_bar_width = self.tab_bar_left_offset();
         let x = (event
             .coords
             .x
@@ -429,15 +429,28 @@ impl super::TermWindow {
         event: MouseEvent,
         context: &dyn WindowOps,
     ) {
-        let new_width = (event.coords.x as f32)
-            .max(80.)
-            .min(self.dimensions.pixel_width as f32 * 0.5);
+        let on_right = self.config.tab_bar_vertical_position
+            == config::VerticalTabBarPosition::Right;
+        let new_width = if on_right {
+            (self.dimensions.pixel_width as f32 - event.coords.x as f32)
+                .max(80.)
+                .min(self.dimensions.pixel_width as f32 * 0.5)
+        } else {
+            (event.coords.x as f32)
+                .max(80.)
+                .min(self.dimensions.pixel_width as f32 * 0.5)
+        };
         self.vertical_tab_bar_width_override = Some(new_width);
         self.invalidate_fancy_tab_bar();
 
         // Update the hit area to follow the new separator position
         let handle_width: usize = 6;
-        item.x = (new_width as usize).saturating_sub(handle_width / 2);
+        if on_right {
+            let bar_x = self.dimensions.pixel_width - new_width as usize;
+            item.x = bar_x.saturating_sub(handle_width / 2);
+        } else {
+            item.x = (new_width as usize).saturating_sub(handle_width / 2);
+        }
 
         self.dragging.replace((item, start_event));
         context.invalidate();

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -43,7 +43,8 @@ impl super::TermWindow {
             | UIItemType::AboveScrollThumb
             | UIItemType::BelowScrollThumb
             | UIItemType::ScrollThumb
-            | UIItemType::Split(_) => {}
+            | UIItemType::Split(_)
+            | UIItemType::VerticalTabBarResize => {}
         }
     }
 
@@ -54,7 +55,8 @@ impl super::TermWindow {
             | UIItemType::AboveScrollThumb
             | UIItemType::BelowScrollThumb
             | UIItemType::ScrollThumb
-            | UIItemType::Split(_) => {}
+            | UIItemType::Split(_)
+            | UIItemType::VerticalTabBarResize => {}
         }
     }
 
@@ -85,10 +87,11 @@ impl super::TermWindow {
             .max(0)
             / self.render_metrics.cell_size.height) as i64;
 
+        let vertical_tab_bar_width = self.tab_bar_pixel_width();
         let x = (event
             .coords
             .x
-            .sub((padding_left + border.left.get() as f32) as isize)
+            .sub((padding_left + border.left.get() as f32 + vertical_tab_bar_width) as isize)
             .max(0) as f32)
             / self.render_metrics.cell_size.width as f32;
         let x = if !pane.is_mouse_grabbed() {
@@ -112,7 +115,7 @@ impl super::TermWindow {
         let mut x_pixel_offset = event
             .coords
             .x
-            .sub((padding_left + border.left.get() as f32) as isize);
+            .sub((padding_left + border.left.get() as f32 + vertical_tab_bar_width) as isize);
         if x > 0 {
             x_pixel_offset = x_pixel_offset.max(0) % self.render_metrics.cell_size.width;
         }
@@ -348,6 +351,9 @@ impl super::TermWindow {
             UIItemType::ScrollThumb => {
                 self.drag_scroll_thumb(item, start_event, event, context);
             }
+            UIItemType::VerticalTabBarResize => {
+                self.drag_vertical_tab_bar_resize(item, start_event, event, context);
+            }
             _ => {
                 log::error!("drag not implemented for {:?}", item);
             }
@@ -382,6 +388,9 @@ impl super::TermWindow {
             UIItemType::CloseTab(idx) => {
                 self.mouse_event_close_tab(idx, event, context);
             }
+            UIItemType::VerticalTabBarResize => {
+                self.mouse_event_vertical_tab_bar_resize(item, event, context);
+            }
         }
     }
 
@@ -399,6 +408,40 @@ impl super::TermWindow {
             _ => {}
         }
         context.set_cursor(Some(MouseCursor::Arrow));
+    }
+
+    fn mouse_event_vertical_tab_bar_resize(
+        &mut self,
+        item: UIItem,
+        event: MouseEvent,
+        context: &dyn WindowOps,
+    ) {
+        context.set_cursor(Some(MouseCursor::SizeLeftRight));
+        if event.kind == WMEK::Press(MousePress::Left) {
+            self.dragging.replace((item, event));
+        }
+    }
+
+    fn drag_vertical_tab_bar_resize(
+        &mut self,
+        mut item: UIItem,
+        start_event: MouseEvent,
+        event: MouseEvent,
+        context: &dyn WindowOps,
+    ) {
+        let new_width = (event.coords.x as f32)
+            .max(80.)
+            .min(self.dimensions.pixel_width as f32 * 0.5);
+        self.vertical_tab_bar_width_override = Some(new_width);
+        self.invalidate_fancy_tab_bar();
+
+        // Update the hit area to follow the new separator position
+        let handle_width: usize = 6;
+        item.x = (new_width as usize).saturating_sub(handle_width / 2);
+
+        self.dragging.replace((item, start_event));
+        context.invalidate();
+        context.set_cursor(Some(MouseCursor::SizeLeftRight));
     }
 
     fn do_new_tab_button_click(&mut self, button: MousePress) {

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -431,20 +431,21 @@ impl super::TermWindow {
     ) {
         let on_right = self.config.tab_bar_vertical_position
             == config::VerticalTabBarPosition::Right;
+        let max_width = self.dimensions.pixel_width as f32 * super::MAX_VERTICAL_TAB_BAR_WIDTH_RATIO;
         let new_width = if on_right {
             (self.dimensions.pixel_width as f32 - event.coords.x as f32)
-                .max(80.)
-                .min(self.dimensions.pixel_width as f32 * 0.5)
+                .max(super::MIN_VERTICAL_TAB_BAR_WIDTH)
+                .min(max_width)
         } else {
             (event.coords.x as f32)
-                .max(80.)
-                .min(self.dimensions.pixel_width as f32 * 0.5)
+                .max(super::MIN_VERTICAL_TAB_BAR_WIDTH)
+                .min(max_width)
         };
         self.vertical_tab_bar_width_override = Some(new_width);
         self.invalidate_fancy_tab_bar();
 
         // Update the hit area to follow the new separator position
-        let handle_width: usize = 6;
+        let handle_width = super::RESIZE_HANDLE_WIDTH;
         if on_right {
             let bar_x = self.dimensions.pixel_width - new_width as usize;
             item.x = bar_x.saturating_sub(handle_width / 2);

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -702,9 +702,28 @@ impl crate::TermWindow {
         }
         .to_linear();
 
+        let on_right = self.config.tab_bar_vertical_position
+            == config::VerticalTabBarPosition::Right;
+
         // Work around box_model bug: right border rendering uses border.left width,
-        // so we set both left and right border to 1px. Left border is bg-colored
-        // (invisible), right border is the visible separator.
+        // so we set both left and right border to 1px. The separator side gets the
+        // visible color, the other side matches the background.
+        let border_colors = if on_right {
+            BorderColor {
+                left: separator_color,
+                top: bg_linear,
+                right: bg_linear,
+                bottom: bg_linear,
+            }
+        } else {
+            BorderColor {
+                left: bg_linear,
+                top: bg_linear,
+                right: separator_color,
+                bottom: bg_linear,
+            }
+        };
+
         let tabs = Element::new(&font, content)
             .display(DisplayType::Block)
             .item_type(UIItemType::TabBar(TabBarItem::None))
@@ -714,12 +733,7 @@ impl crate::TermWindow {
                 self.dimensions.pixel_height as f32,
             )))
             .colors(ElementColors {
-                border: BorderColor {
-                    left: bg_linear,
-                    top: bg_linear,
-                    right: separator_color,
-                    bottom: bg_linear,
-                },
+                border: border_colors,
                 bg: bar_colors.bg,
                 text: bar_colors.text,
             })
@@ -738,6 +752,13 @@ impl crate::TermWindow {
 
         let border = self.get_os_border();
 
+        // Position on left or right side of window
+        let bounds_x = if on_right {
+            self.dimensions.pixel_width as f32 - tab_bar_width - border.right.get() as f32
+        } else {
+            border.left.get() as f32
+        };
+
         let computed = self.compute_element(
             &LayoutContext {
                 height: DimensionContext {
@@ -751,7 +772,7 @@ impl crate::TermWindow {
                     pixel_cell: metrics.cell_size.width as f32,
                 },
                 bounds: euclid::rect(
-                    border.left.get() as f32,
+                    bounds_x,
                     border.top.get() as f32,
                     tab_bar_width,
                     self.dimensions.pixel_height as f32

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -56,6 +56,38 @@ impl crate::TermWindow {
         self.fancy_tab_bar.take();
     }
 
+    fn tab_bar_colors(&self) -> TabBarColors {
+        self.config
+            .colors
+            .as_ref()
+            .and_then(|c| c.tab_bar.as_ref())
+            .cloned()
+            .unwrap_or_else(TabBarColors::default)
+    }
+
+    fn titlebar_bg_linear(&self) -> LinearRgba {
+        if self.focused.is_some() {
+            self.config.window_frame.active_titlebar_bg
+        } else {
+            self.config.window_frame.inactive_titlebar_bg
+        }
+        .to_linear()
+    }
+
+    fn bar_element_colors(&self) -> ElementColors {
+        ElementColors {
+            border: BorderColor::default(),
+            bg: self.titlebar_bg_linear().into(),
+            text: if self.focused.is_some() {
+                self.config.window_frame.active_titlebar_fg
+            } else {
+                self.config.window_frame.inactive_titlebar_fg
+            }
+            .to_linear()
+            .into(),
+        }
+    }
+
     pub fn build_fancy_tab_bar(&self, palette: &ColorPalette) -> anyhow::Result<ComputedElement> {
         if self.config.tab_bar_vertical {
             return self.build_vertical_fancy_tab_bar(palette);
@@ -65,34 +97,12 @@ impl crate::TermWindow {
         let font = self.fonts.title_font()?;
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
         let items = self.tab_bar.items();
-        let colors = self
-            .config
-            .colors
-            .as_ref()
-            .and_then(|c| c.tab_bar.as_ref())
-            .cloned()
-            .unwrap_or_else(TabBarColors::default);
+        let colors = self.tab_bar_colors();
 
         let mut left_status = vec![];
         let mut left_eles = vec![];
         let mut right_eles = vec![];
-        let bar_colors = ElementColors {
-            border: BorderColor::default(),
-            bg: if self.focused.is_some() {
-                self.config.window_frame.active_titlebar_bg
-            } else {
-                self.config.window_frame.inactive_titlebar_bg
-            }
-            .to_linear()
-            .into(),
-            text: if self.focused.is_some() {
-                self.config.window_frame.active_titlebar_fg
-            } else {
-                self.config.window_frame.inactive_titlebar_fg
-            }
-            .to_linear()
-            .into(),
-        };
+        let bar_colors = self.bar_element_colors();
 
         let item_to_elem = |item: &TabEntry| -> Element {
             let element = Element::with_line(&font, &item.title, palette);
@@ -469,36 +479,12 @@ impl crate::TermWindow {
         &self,
         palette: &ColorPalette,
     ) -> anyhow::Result<ComputedElement> {
-        let tab_bar_width = self.vertical_tab_bar_width_override
-            .unwrap_or(self.config.tab_bar_vertical_width as f32);
+        let tab_bar_width = self.tab_bar_pixel_width();
         let font = self.fonts.title_font()?;
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
         let items = self.tab_bar.items();
-        let colors = self
-            .config
-            .colors
-            .as_ref()
-            .and_then(|c| c.tab_bar.as_ref())
-            .cloned()
-            .unwrap_or_else(TabBarColors::default);
-
-        let bar_colors = ElementColors {
-            border: BorderColor::default(),
-            bg: if self.focused.is_some() {
-                self.config.window_frame.active_titlebar_bg
-            } else {
-                self.config.window_frame.inactive_titlebar_bg
-            }
-            .to_linear()
-            .into(),
-            text: if self.focused.is_some() {
-                self.config.window_frame.active_titlebar_fg
-            } else {
-                self.config.window_frame.inactive_titlebar_fg
-            }
-            .to_linear()
-            .into(),
-        };
+        let colors = self.tab_bar_colors();
+        let bar_colors = self.bar_element_colors();
 
         let active_tab_colors = colors.active_tab();
         let new_tab_colors = colors.new_tab();
@@ -694,19 +680,14 @@ impl crate::TermWindow {
 
         // Separator color from theme (configurable via colors.tab_bar.inactive_tab_edge)
         let separator_color = colors.inactive_tab_edge().to_linear();
-        let bg_linear = if self.focused.is_some() {
-            self.config.window_frame.active_titlebar_bg
-        } else {
-            self.config.window_frame.inactive_titlebar_bg
-        }
-        .to_linear();
+        let bg_linear = self.titlebar_bg_linear();
 
         let on_right = self.config.tab_bar_vertical_position
             == config::VerticalTabBarPosition::Right;
 
-        // Work around box_model bug: right border rendering uses border.left width,
-        // so we set both left and right border to 1px. The separator side gets the
-        // visible color, the other side matches the background.
+        // Work around box_model bug (box_model.rs:1236): right border rendering
+        // uses border.left width, so both sides must be 1px. The separator side
+        // gets the visible color; the other side matches the background.
         let border_colors = if on_right {
             BorderColor {
                 left: separator_color,

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -529,7 +529,7 @@ impl crate::TermWindow {
                     let mut elem = element
                         .item_type(UIItemType::TabBar(item.item.clone()))
                         .display(DisplayType::Block)
-                        .max_width(Some(Dimension::Pixels(tab_bar_width)))
+                        .max_width(Some(Dimension::Pixels(tab_bar_width - 10.)))
                         .padding(BoxDimension {
                             left: Dimension::Cells(0.5),
                             right: Dimension::Cells(0.5),
@@ -656,7 +656,6 @@ impl crate::TermWindow {
                     )
                     .display(DisplayType::Block)
                     .item_type(UIItemType::TabBar(item.item.clone()))
-                    .max_width(Some(Dimension::Pixels(tab_bar_width)))
                     .margin(BoxDimension {
                         left: Dimension::Pixels(0.),
                         right: Dimension::Pixels(0.),
@@ -752,14 +751,9 @@ impl crate::TermWindow {
 
         let border = self.get_os_border();
 
-        // Position on left or right side of window
-        let bounds_x = if on_right {
-            self.dimensions.pixel_width as f32 - tab_bar_width - border.right.get() as f32
-        } else {
-            border.left.get() as f32
-        };
-
-        let computed = self.compute_element(
+        // Always compute layout at x=0 (left edge), then translate if Right.
+        // This ensures internal layout is identical to the working Left case.
+        let mut computed = self.compute_element(
             &LayoutContext {
                 height: DimensionContext {
                     dpi: self.dimensions.dpi as f32,
@@ -772,7 +766,7 @@ impl crate::TermWindow {
                     pixel_cell: metrics.cell_size.width as f32,
                 },
                 bounds: euclid::rect(
-                    bounds_x,
+                    border.left.get() as f32,
                     border.top.get() as f32,
                     tab_bar_width,
                     self.dimensions.pixel_height as f32
@@ -784,6 +778,15 @@ impl crate::TermWindow {
             },
             &tabs,
         )?;
+
+        // Translate to right side if needed
+        if on_right {
+            let right_x = self.dimensions.pixel_width as f32
+                - tab_bar_width
+                - border.right.get() as f32
+                - border.left.get() as f32;
+            computed.translate(euclid::vec2(right_x, 0.));
+        }
 
         Ok(computed)
     }

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -10,6 +10,7 @@ use config::{Dimension, DimensionContext, TabBarColors};
 use std::rc::Rc;
 use wezterm_font::LoadedFont;
 use wezterm_term::color::{ColorAttribute, ColorPalette};
+use window::color::LinearRgba;
 use window::{IntegratedTitleButtonAlignment, IntegratedTitleButtonStyle};
 
 const X_BUTTON: &[Poly] = &[
@@ -56,6 +57,10 @@ impl crate::TermWindow {
     }
 
     pub fn build_fancy_tab_bar(&self, palette: &ColorPalette) -> anyhow::Result<ComputedElement> {
+        if self.config.tab_bar_vertical {
+            return self.build_vertical_fancy_tab_bar(palette);
+        }
+
         let tab_bar_height = self.tab_bar_pixel_height()?;
         let font = self.fonts.title_font()?;
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
@@ -458,6 +463,310 @@ impl crate::TermWindow {
         Ok(computed)
     }
 
+    /// Build a vertical tab bar rendered on the left side of the window.
+    /// Each tab is a Block element so they stack vertically.
+    fn build_vertical_fancy_tab_bar(
+        &self,
+        palette: &ColorPalette,
+    ) -> anyhow::Result<ComputedElement> {
+        let tab_bar_width = self.vertical_tab_bar_width_override
+            .unwrap_or(self.config.tab_bar_vertical_width as f32);
+        let font = self.fonts.title_font()?;
+        let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+        let items = self.tab_bar.items();
+        let colors = self
+            .config
+            .colors
+            .as_ref()
+            .and_then(|c| c.tab_bar.as_ref())
+            .cloned()
+            .unwrap_or_else(TabBarColors::default);
+
+        let bar_colors = ElementColors {
+            border: BorderColor::default(),
+            bg: if self.focused.is_some() {
+                self.config.window_frame.active_titlebar_bg
+            } else {
+                self.config.window_frame.inactive_titlebar_bg
+            }
+            .to_linear()
+            .into(),
+            text: if self.focused.is_some() {
+                self.config.window_frame.active_titlebar_fg
+            } else {
+                self.config.window_frame.inactive_titlebar_fg
+            }
+            .to_linear()
+            .into(),
+        };
+
+        let active_tab_colors = colors.active_tab();
+        let new_tab_colors = colors.new_tab();
+        let new_tab_hover_colors = colors.new_tab_hover();
+
+        let mut tab_children = vec![];
+
+        for item in items {
+            let element = Element::with_line(&font, &item.title, palette);
+
+            let bg_color = item
+                .title
+                .get_cell(0)
+                .and_then(|c| match c.attrs().background() {
+                    ColorAttribute::Default => None,
+                    col => Some(palette.resolve_bg(col)),
+                });
+            let fg_color = item
+                .title
+                .get_cell(0)
+                .and_then(|c| match c.attrs().foreground() {
+                    ColorAttribute::Default => None,
+                    col => Some(palette.resolve_fg(col)),
+                });
+
+            match item.item {
+                TabBarItem::Tab { tab_idx, active } => {
+                    let mut elem = element
+                        .item_type(UIItemType::TabBar(item.item.clone()))
+                        .display(DisplayType::Block)
+                        .max_width(Some(Dimension::Pixels(tab_bar_width)))
+                        .padding(BoxDimension {
+                            left: Dimension::Cells(0.5),
+                            right: Dimension::Cells(0.5),
+                            top: Dimension::Cells(0.2),
+                            bottom: Dimension::Cells(0.2),
+                        })
+                        .margin(BoxDimension {
+                            left: Dimension::Pixels(0.),
+                            right: Dimension::Pixels(0.),
+                            top: Dimension::Pixels(1.),
+                            bottom: Dimension::Pixels(0.),
+                        })
+                        .border(BoxDimension::new(Dimension::Pixels(1.)));
+
+                    if active {
+                        // Active tab: highlighted with a left border accent
+                        elem = elem.border_corners(Some(Corners {
+                            top_left: SizedPoly {
+                                width: Dimension::Cells(0.3),
+                                height: Dimension::Cells(0.3),
+                                poly: TOP_LEFT_ROUNDED_CORNER,
+                            },
+                            top_right: SizedPoly::none(),
+                            bottom_left: SizedPoly {
+                                width: Dimension::Cells(0.3),
+                                height: Dimension::Cells(0.3),
+                                poly: BOTTOM_LEFT_ROUNDED_CORNER,
+                            },
+                            bottom_right: SizedPoly::none(),
+                        }))
+                        .colors(ElementColors {
+                            border: BorderColor::new(
+                                bg_color
+                                    .unwrap_or_else(|| active_tab_colors.bg_color.into())
+                                    .to_linear(),
+                            ),
+                            bg: bg_color
+                                .unwrap_or_else(|| active_tab_colors.bg_color.into())
+                                .to_linear()
+                                .into(),
+                            text: fg_color
+                                .unwrap_or_else(|| active_tab_colors.fg_color.into())
+                                .to_linear()
+                                .into(),
+                        });
+                    } else {
+                        let inactive_tab = colors.inactive_tab();
+                        let inactive_tab_hover = colors.inactive_tab_hover();
+                        let bg = bg_color
+                            .unwrap_or_else(|| inactive_tab.bg_color.into())
+                            .to_linear();
+                        elem = elem.colors(ElementColors {
+                            border: BorderColor::new(bg),
+                            bg: bg.into(),
+                            text: fg_color
+                                .unwrap_or_else(|| inactive_tab.fg_color.into())
+                                .to_linear()
+                                .into(),
+                        })
+                        .hover_colors(Some(ElementColors {
+                            border: BorderColor::new(
+                                bg_color
+                                    .unwrap_or_else(|| inactive_tab_hover.bg_color.into())
+                                    .to_linear(),
+                            ),
+                            bg: bg_color
+                                .unwrap_or_else(|| inactive_tab_hover.bg_color.into())
+                                .to_linear()
+                                .into(),
+                            text: fg_color
+                                .unwrap_or_else(|| inactive_tab_hover.fg_color.into())
+                                .to_linear()
+                                .into(),
+                        }));
+                    }
+
+                    // Add close button (hidden by default, visible on hover)
+                    let tab_bg_linear = if active {
+                        bg_color
+                            .unwrap_or_else(|| active_tab_colors.bg_color.into())
+                            .to_linear()
+                    } else {
+                        bg_color
+                            .unwrap_or_else(|| colors.inactive_tab().bg_color.into())
+                            .to_linear()
+                    };
+                    elem.content = match elem.content {
+                        ElementContent::Children(mut kids) => {
+                            if self.config.show_close_tab_button_in_tabs {
+                                kids.push(make_vertical_x_button(
+                                    &font, &metrics, &colors, tab_idx, active,
+                                    tab_bg_linear,
+                                ));
+                            }
+                            ElementContent::Children(kids)
+                        }
+                        other => other,
+                    };
+
+                    tab_children.push(elem);
+                }
+                TabBarItem::NewTabButton => {
+                    // Wrap the + icon in a full-width block so it centers
+                    let icon = Element::new(
+                        &font,
+                        ElementContent::Poly {
+                            line_width: metrics.underline_height.max(2),
+                            poly: SizedPoly {
+                                poly: PLUS_BUTTON,
+                                width: Dimension::Pixels(
+                                    metrics.cell_size.height as f32 / 2.,
+                                ),
+                                height: Dimension::Pixels(
+                                    metrics.cell_size.height as f32 / 2.,
+                                ),
+                            },
+                        },
+                    )
+                    .vertical_align(VerticalAlign::Middle);
+
+                    let elem = Element::new(
+                        &font,
+                        ElementContent::Children(vec![icon]),
+                    )
+                    .display(DisplayType::Block)
+                    .item_type(UIItemType::TabBar(item.item.clone()))
+                    .max_width(Some(Dimension::Pixels(tab_bar_width)))
+                    .margin(BoxDimension {
+                        left: Dimension::Pixels(0.),
+                        right: Dimension::Pixels(0.),
+                        top: Dimension::Pixels(4.),
+                        bottom: Dimension::Pixels(0.),
+                    })
+                    .padding(BoxDimension {
+                        left: Dimension::Cells(0.5),
+                        right: Dimension::Cells(0.5),
+                        top: Dimension::Cells(0.2),
+                        bottom: Dimension::Cells(0.25),
+                    })
+                    .border(BoxDimension::new(Dimension::Pixels(1.)))
+                    .colors(ElementColors {
+                        border: BorderColor::new(
+                            new_tab_colors.bg_color.to_linear(),
+                        ),
+                        bg: new_tab_colors.bg_color.to_linear().into(),
+                        text: new_tab_colors.fg_color.to_linear().into(),
+                    })
+                    .hover_colors(Some(ElementColors {
+                        border: BorderColor::new(
+                            new_tab_hover_colors.bg_color.to_linear(),
+                        ),
+                        bg: new_tab_hover_colors.bg_color.to_linear().into(),
+                        text: new_tab_hover_colors.fg_color.to_linear().into(),
+                    }));
+                    tab_children.push(elem);
+                }
+                // Skip status items and window buttons in vertical mode
+                _ => {}
+            }
+        }
+
+        let content = ElementContent::Children(tab_children);
+
+        // Separator color from theme (configurable via colors.tab_bar.inactive_tab_edge)
+        let separator_color = colors.inactive_tab_edge().to_linear();
+        let bg_linear = if self.focused.is_some() {
+            self.config.window_frame.active_titlebar_bg
+        } else {
+            self.config.window_frame.inactive_titlebar_bg
+        }
+        .to_linear();
+
+        // Work around box_model bug: right border rendering uses border.left width,
+        // so we set both left and right border to 1px. Left border is bg-colored
+        // (invisible), right border is the visible separator.
+        let tabs = Element::new(&font, content)
+            .display(DisplayType::Block)
+            .item_type(UIItemType::TabBar(TabBarItem::None))
+            .min_width(Some(Dimension::Pixels(tab_bar_width)))
+            .max_width(Some(Dimension::Pixels(tab_bar_width)))
+            .min_height(Some(Dimension::Pixels(
+                self.dimensions.pixel_height as f32,
+            )))
+            .colors(ElementColors {
+                border: BorderColor {
+                    left: bg_linear,
+                    top: bg_linear,
+                    right: separator_color,
+                    bottom: bg_linear,
+                },
+                bg: bar_colors.bg,
+                text: bar_colors.text,
+            })
+            .border(BoxDimension {
+                left: Dimension::Pixels(1.),
+                right: Dimension::Pixels(1.),
+                top: Dimension::Pixels(0.),
+                bottom: Dimension::Pixels(0.),
+            })
+            .padding(BoxDimension {
+                left: Dimension::Pixels(3.),
+                right: Dimension::Pixels(3.),
+                top: Dimension::Pixels(4.),
+                bottom: Dimension::Pixels(4.),
+            });
+
+        let border = self.get_os_border();
+
+        let computed = self.compute_element(
+            &LayoutContext {
+                height: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: self.dimensions.pixel_height as f32,
+                    pixel_cell: metrics.cell_size.height as f32,
+                },
+                width: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: tab_bar_width,
+                    pixel_cell: metrics.cell_size.width as f32,
+                },
+                bounds: euclid::rect(
+                    border.left.get() as f32,
+                    border.top.get() as f32,
+                    tab_bar_width,
+                    self.dimensions.pixel_height as f32
+                        - (border.top + border.bottom).get() as f32,
+                ),
+                metrics: &metrics,
+                gl_state: self.render_state.as_ref().unwrap(),
+                zindex: 10,
+            },
+            &tabs,
+        )?;
+
+        Ok(computed)
+    }
+
     pub fn paint_fancy_tab_bar(&self) -> anyhow::Result<Vec<UIItem>> {
         let computed = self.fancy_tab_bar.as_ref().ok_or_else(|| {
             anyhow::anyhow!("paint_fancy_tab_bar called but fancy_tab_bar is None")
@@ -495,6 +804,73 @@ fn make_x_button(
     .vertical_align(VerticalAlign::Middle)
     .float(Float::Right)
     .item_type(UIItemType::CloseTab(tab_idx))
+    .hover_colors({
+        let inactive_tab_hover = colors.inactive_tab_hover();
+        let active_tab = colors.active_tab();
+
+        Some(ElementColors {
+            border: BorderColor::default(),
+            bg: (if active {
+                inactive_tab_hover.bg_color
+            } else {
+                active_tab.bg_color
+            })
+            .to_linear()
+            .into(),
+            text: (if active {
+                inactive_tab_hover.fg_color
+            } else {
+                active_tab.fg_color
+            })
+            .to_linear()
+            .into(),
+        })
+    })
+    .padding(BoxDimension {
+        left: Dimension::Cells(0.25),
+        right: Dimension::Cells(0.25),
+        top: Dimension::Cells(0.25),
+        bottom: Dimension::Cells(0.25),
+    })
+    .margin(BoxDimension {
+        left: Dimension::Cells(0.5),
+        right: Dimension::Cells(0.),
+        top: Dimension::Cells(0.),
+        bottom: Dimension::Cells(0.),
+    })
+}
+
+/// Close button for vertical tabs: hidden by default, visible on hover.
+fn make_vertical_x_button(
+    font: &Rc<LoadedFont>,
+    metrics: &RenderMetrics,
+    colors: &TabBarColors,
+    tab_idx: usize,
+    active: bool,
+    tab_bg: LinearRgba,
+) -> Element {
+    Element::new(
+        &font,
+        ElementContent::Poly {
+            line_width: metrics.underline_height.max(2),
+            poly: SizedPoly {
+                poly: X_BUTTON,
+                width: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+                height: Dimension::Pixels(metrics.cell_size.height as f32 / 2.),
+            },
+        },
+    )
+    .zindex(1)
+    .vertical_align(VerticalAlign::Middle)
+    .float(Float::Right)
+    .item_type(UIItemType::CloseTab(tab_idx))
+    // Default: invisible (text and bg match the tab background)
+    .colors(ElementColors {
+        border: BorderColor::default(),
+        bg: tab_bg.into(),
+        text: tab_bg.into(),
+    })
+    // Hover: reveal the X button
     .hover_colors({
         let inactive_tab_hover = colors.inactive_tab_hover();
         let active_tab = colors.active_tab();

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -366,7 +366,7 @@ impl crate::TermWindow {
         let horizontal_gap = self.dimensions.pixel_width as f32
             - self.terminal_size.pixel_width as f32
             - padding_left
-            - self.tab_bar_pixel_width()
+            - self.tab_bar_pixel_width()  // always subtract full width from gap regardless of side
             - if self.show_scroll_bar && padding_right.is_zero() {
                 h_context.pixel_cell
             } else {

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -366,7 +366,7 @@ impl crate::TermWindow {
         let horizontal_gap = self.dimensions.pixel_width as f32
             - self.terminal_size.pixel_width as f32
             - padding_left
-            - self.tab_bar_pixel_width()  // always subtract full width from gap regardless of side
+            - self.tab_bar_pixel_width()
             - if self.show_scroll_bar && padding_right.is_zero() {
                 h_context.pixel_cell
             } else {

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -366,6 +366,7 @@ impl crate::TermWindow {
         let horizontal_gap = self.dimensions.pixel_width as f32
             - self.terminal_size.pixel_width as f32
             - padding_left
+            - self.tab_bar_pixel_width()
             - if self.show_scroll_bar && padding_right.is_zero() {
                 h_context.pixel_cell
             } else {

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -337,8 +337,10 @@ impl crate::TermWindow {
                 error: Option<anyhow::Error>,
             }
 
+            let vertical_tab_bar_offset = self.tab_bar_pixel_width();
             let left_pixel_x = padding_left
                 + border.left.get() as f32
+                + vertical_tab_bar_offset
                 + (pos.left as f32 * self.render_metrics.cell_size.width as f32);
 
             let mut render = LineRender {
@@ -647,7 +649,8 @@ impl crate::TermWindow {
 
         // Bounds for the terminal cells
         let content_rect = euclid::rect(
-            padding_left + border.left.get() as f32 - (cell_width / 2.0)
+            padding_left + border.left.get() as f32 + self.tab_bar_pixel_width()
+                - (cell_width / 2.0)
                 + (pos.left as f32 * cell_width),
             top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),
             pos.width as f32 * cell_width,

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -337,7 +337,7 @@ impl crate::TermWindow {
                 error: Option<anyhow::Error>,
             }
 
-            let vertical_tab_bar_offset = self.tab_bar_pixel_width();
+            let vertical_tab_bar_offset = self.tab_bar_left_offset();
             let left_pixel_x = padding_left
                 + border.left.get() as f32
                 + vertical_tab_bar_offset
@@ -649,7 +649,7 @@ impl crate::TermWindow {
 
         // Bounds for the terminal cells
         let content_rect = euclid::rect(
-            padding_left + border.left.get() as f32 + self.tab_bar_pixel_width()
+            padding_left + border.left.get() as f32 + self.tab_bar_left_offset()
                 - (cell_width / 2.0)
                 + (pos.left as f32 * cell_width),
             top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),

--- a/wezterm-gui/src/termwindow/render/split.rs
+++ b/wezterm-gui/src/termwindow/render/split.rs
@@ -25,8 +25,10 @@ impl crate::TermWindow {
 
         let (padding_left, padding_top) = self.padding_left_top();
 
+        let vertical_tab_bar_width = self.tab_bar_pixel_width();
         let pos_y = split.top as f32 * cell_height + first_row_offset + padding_top;
-        let pos_x = split.left as f32 * cell_width + padding_left + border.left.get() as f32;
+        let pos_x = split.left as f32 * cell_width + padding_left + border.left.get() as f32
+            + vertical_tab_bar_width;
 
         if split.direction == SplitDirection::Horizontal {
             self.filled_rectangle(
@@ -43,6 +45,7 @@ impl crate::TermWindow {
             self.ui_items.push(UIItem {
                 x: border.left.get() as usize
                     + padding_left as usize
+                    + vertical_tab_bar_width as usize
                     + (split.left * cell_width as usize),
                 width: cell_width as usize,
                 y: padding_top as usize
@@ -66,6 +69,7 @@ impl crate::TermWindow {
             self.ui_items.push(UIItem {
                 x: border.left.get() as usize
                     + padding_left as usize
+                    + vertical_tab_bar_width as usize
                     + (split.left * cell_width as usize),
                 width: split.size * cell_width as usize,
                 y: padding_top as usize

--- a/wezterm-gui/src/termwindow/render/split.rs
+++ b/wezterm-gui/src/termwindow/render/split.rs
@@ -25,7 +25,7 @@ impl crate::TermWindow {
 
         let (padding_left, padding_top) = self.padding_left_top();
 
-        let vertical_tab_bar_width = self.tab_bar_pixel_width();
+        let vertical_tab_bar_width = self.tab_bar_left_offset();
         let pos_y = split.top as f32 * cell_height + first_row_offset + padding_top;
         let pos_x = split.left as f32 * cell_width + padding_left + border.left.get() as f32
             + vertical_tab_bar_width;

--- a/wezterm-gui/src/termwindow/render/tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/tab_bar.rs
@@ -1,5 +1,6 @@
 use crate::quad::TripleLayerQuadAllocator;
 use crate::termwindow::render::RenderScreenLineParams;
+use crate::termwindow::UIItemType;
 use crate::utilsprites::RenderMetrics;
 use config::ConfigHandle;
 use mux::renderable::RenderableDimensions;
@@ -16,6 +17,20 @@ impl crate::TermWindow {
             }
 
             self.ui_items.append(&mut self.paint_fancy_tab_bar()?);
+
+            // Register resize handle for vertical tab bar
+            if self.config.tab_bar_vertical {
+                let tab_bar_width = self.tab_bar_pixel_width();
+                let handle_width: usize = 6;
+                self.ui_items.push(crate::termwindow::UIItem {
+                    x: (tab_bar_width as usize).saturating_sub(handle_width / 2),
+                    y: 0,
+                    width: handle_width,
+                    height: self.dimensions.pixel_height,
+                    item_type: UIItemType::VerticalTabBarResize,
+                });
+            }
+
             return Ok(());
         }
 
@@ -105,6 +120,10 @@ impl crate::TermWindow {
         fontconfig: &wezterm_font::FontConfiguration,
         render_metrics: &RenderMetrics,
     ) -> anyhow::Result<f32> {
+        // When vertical, tab bar doesn't consume vertical space
+        if config.tab_bar_vertical {
+            return Ok(0.);
+        }
         if config.use_fancy_tab_bar {
             let font = fontconfig.title_font()?;
             Ok((font.metrics().cell_height.get() as f32 * 1.75).ceil())
@@ -116,4 +135,23 @@ impl crate::TermWindow {
     pub fn tab_bar_pixel_height(&self) -> anyhow::Result<f32> {
         Self::tab_bar_pixel_height_impl(&self.config, &self.fonts, &self.render_metrics)
     }
+
+    /// Returns the pixel width consumed by the vertical tab bar, or 0 if not vertical.
+    pub fn tab_bar_pixel_width(&self) -> f32 {
+        if self.config.tab_bar_vertical && self.show_tab_bar {
+            self.vertical_tab_bar_width_override
+                .unwrap_or(self.config.tab_bar_vertical_width as f32)
+        } else {
+            0.
+        }
+    }
+
+    pub fn tab_bar_pixel_width_impl(config: &ConfigHandle, show_tab_bar: bool) -> f32 {
+        if config.tab_bar_vertical && show_tab_bar {
+            config.tab_bar_vertical_width as f32
+        } else {
+            0.
+        }
+    }
+
 }

--- a/wezterm-gui/src/termwindow/render/tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/tab_bar.rs
@@ -21,7 +21,7 @@ impl crate::TermWindow {
             // Register resize handle for vertical tab bar
             if self.config.tab_bar_vertical {
                 let tab_bar_width = self.tab_bar_pixel_width();
-                let handle_width: usize = 6;
+                let handle_width = crate::termwindow::RESIZE_HANDLE_WIDTH;
                 let on_right = self.config.tab_bar_vertical_position
                     == config::VerticalTabBarPosition::Right;
                 let handle_x = if on_right {

--- a/wezterm-gui/src/termwindow/render/tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/tab_bar.rs
@@ -22,8 +22,16 @@ impl crate::TermWindow {
             if self.config.tab_bar_vertical {
                 let tab_bar_width = self.tab_bar_pixel_width();
                 let handle_width: usize = 6;
+                let on_right = self.config.tab_bar_vertical_position
+                    == config::VerticalTabBarPosition::Right;
+                let handle_x = if on_right {
+                    let bar_x = self.dimensions.pixel_width - tab_bar_width as usize;
+                    bar_x.saturating_sub(handle_width / 2)
+                } else {
+                    (tab_bar_width as usize).saturating_sub(handle_width / 2)
+                };
                 self.ui_items.push(crate::termwindow::UIItem {
-                    x: (tab_bar_width as usize).saturating_sub(handle_width / 2),
+                    x: handle_x,
                     y: 0,
                     width: handle_width,
                     height: self.dimensions.pixel_height,
@@ -141,6 +149,16 @@ impl crate::TermWindow {
         if self.config.tab_bar_vertical && self.show_tab_bar {
             self.vertical_tab_bar_width_override
                 .unwrap_or(self.config.tab_bar_vertical_width as f32)
+        } else {
+            0.
+        }
+    }
+
+    /// Returns the left-side pixel offset for content caused by the vertical tab bar.
+    /// Returns tab_bar_pixel_width when position is Left, 0 when Right.
+    pub fn tab_bar_left_offset(&self) -> f32 {
+        if self.config.tab_bar_vertical_position == config::VerticalTabBarPosition::Left {
+            self.tab_bar_pixel_width()
         } else {
             0.
         }

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -206,9 +206,15 @@ impl super::TermWindow {
                 + (border.top + border.bottom).get() as usize
                 + tab_bar_height as usize;
 
+            let vertical_tab_bar_width = if self.config.tab_bar_vertical && self.show_tab_bar {
+                self.config.tab_bar_vertical_width
+            } else {
+                0
+            };
             let pixel_width = (cols * self.render_metrics.cell_size.width as usize)
                 + (padding_left + padding_right)
-                + (border.left + border.right).get() as usize;
+                + (border.left + border.right).get() as usize
+                + vertical_tab_bar_width;
 
             let dims = Dimensions {
                 pixel_width: pixel_width as usize,
@@ -225,6 +231,7 @@ impl super::TermWindow {
                 padding_bottom: padding_bottom,
                 border: border,
                 tab_bar_height: tab_bar_height as usize,
+                tab_bar_width: vertical_tab_bar_width,
             };
 
             (size, dims, ri_calc)
@@ -247,10 +254,18 @@ impl super::TermWindow {
                 config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
             let padding_right = effective_right_padding(&config, h_context);
 
-            let avail_width = dimensions.pixel_width.saturating_sub(
-                (padding_left + padding_right) as usize
-                    + (border.left + border.right).get() as usize,
-            );
+            let vertical_tab_bar_width = if self.config.tab_bar_vertical && self.show_tab_bar {
+                self.config.tab_bar_vertical_width
+            } else {
+                0
+            };
+            let avail_width = dimensions
+                .pixel_width
+                .saturating_sub(
+                    (padding_left + padding_right) as usize
+                        + (border.left + border.right).get() as usize,
+                )
+                .saturating_sub(vertical_tab_bar_width);
             let avail_height = dimensions
                 .pixel_height
                 .saturating_sub(
@@ -283,6 +298,7 @@ impl super::TermWindow {
                 padding_bottom: padding_bottom,
                 border: border,
                 tab_bar_height: tab_bar_height as usize,
+                tab_bar_width: vertical_tab_bar_width,
             };
 
             (size, *dimensions, ri_calc)
@@ -509,10 +525,16 @@ impl super::TermWindow {
         let padding_top = config.window_padding.top.evaluate_as_pixels(v_context) as usize;
         let padding_bottom = config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
 
+        let vertical_tab_bar_width = if config.tab_bar_vertical && show_tab_bar {
+            config.tab_bar_vertical_width
+        } else {
+            0
+        };
         let dimensions = Dimensions {
             pixel_width: ((terminal_size.cols as usize * render_metrics.cell_size.width as usize)
                 + padding_left
-                + effective_right_padding(&config, h_context)),
+                + effective_right_padding(&config, h_context))
+                + vertical_tab_bar_width,
             pixel_height: ((terminal_size.rows as usize * render_metrics.cell_size.height as usize)
                 + padding_top
                 + padding_bottom) as usize

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -206,11 +206,8 @@ impl super::TermWindow {
                 + (border.top + border.bottom).get() as usize
                 + tab_bar_height as usize;
 
-            let vertical_tab_bar_width = if self.config.tab_bar_vertical && self.show_tab_bar {
-                self.config.tab_bar_vertical_width
-            } else {
-                0
-            };
+            let vertical_tab_bar_width =
+                Self::tab_bar_pixel_width_impl(&self.config, self.show_tab_bar) as usize;
             let pixel_width = (cols * self.render_metrics.cell_size.width as usize)
                 + (padding_left + padding_right)
                 + (border.left + border.right).get() as usize
@@ -254,11 +251,8 @@ impl super::TermWindow {
                 config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
             let padding_right = effective_right_padding(&config, h_context);
 
-            let vertical_tab_bar_width = if self.config.tab_bar_vertical && self.show_tab_bar {
-                self.config.tab_bar_vertical_width
-            } else {
-                0
-            };
+            let vertical_tab_bar_width =
+                Self::tab_bar_pixel_width_impl(&self.config, self.show_tab_bar) as usize;
             let avail_width = dimensions
                 .pixel_width
                 .saturating_sub(
@@ -525,11 +519,8 @@ impl super::TermWindow {
         let padding_top = config.window_padding.top.evaluate_as_pixels(v_context) as usize;
         let padding_bottom = config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
 
-        let vertical_tab_bar_width = if config.tab_bar_vertical && show_tab_bar {
-            config.tab_bar_vertical_width
-        } else {
-            0
-        };
+        let vertical_tab_bar_width =
+            Self::tab_bar_pixel_width_impl(&config, show_tab_bar) as usize;
         let dimensions = Dimensions {
             pixel_width: ((terminal_size.cols as usize * render_metrics.cell_size.width as usize)
                 + padding_left


### PR DESCRIPTION
## Summary

- Adds a vertical tab bar that renders on the left or right side of the window
- Supports drag-to-resize via a separator edge handle (min 80px, max 50% of window width)
- Close button on tabs hidden by default, revealed on hover for a cleaner look
- Separator line color follows theme via `inactive_tab_edge`
- Full mouse event handling: click tabs, hover cursor changes, drag resize

## Configuration

```lua
config.tab_bar_vertical = true
config.tab_bar_vertical_width = 200  -- pixels, default 200
config.tab_bar_vertical_position = "Left"  -- "Left" or "Right"
```

## Implementation Details

- New `build_vertical_fancy_tab_bar` method renders tabs as stacked `Block` elements
- `VerticalTabBarPosition` enum controls left/right placement
- Right positioning uses `translate()` approach (compute at x=0, translate after) to ensure identical internal layout
- Content area (panes, splits, mouse coordinates) properly offset via `tab_bar_left_offset()`
- Resize increments account for vertical tab bar width
- Box model border workaround for separator line (documented at `box_model.rs:1236`)
- Extracted shared helpers: `tab_bar_colors()`, `bar_element_colors()`, `titlebar_bg_linear()`
- Constants: `MIN_VERTICAL_TAB_BAR_WIDTH`, `MAX_VERTICAL_TAB_BAR_WIDTH_RATIO`, `RESIZE_HANDLE_WIDTH`

## Files Changed (10 files, +590 -33)

- `config/src/config.rs` — New config fields and `VerticalTabBarPosition` enum
- `wezterm-gui/src/termwindow/mod.rs` — `UIItemType::VerticalTabBarResize`, constants, state
- `wezterm-gui/src/termwindow/mouseevent.rs` — Resize drag handling, cursor changes
- `wezterm-gui/src/termwindow/render/fancy_tab_bar.rs` — Vertical tab bar builder + helpers
- `wezterm-gui/src/termwindow/render/tab_bar.rs` — Height/width methods, resize handle registration
- `wezterm-gui/src/termwindow/render/pane.rs` — Content offset for vertical bar
- `wezterm-gui/src/termwindow/render/split.rs` — Split offset for vertical bar
- `wezterm-gui/src/termwindow/render/mod.rs` — Horizontal gap calculation
- `wezterm-gui/src/termwindow/resize.rs` — Terminal size accounting
- `wezterm-gui/src/resize_increment_calculator.rs` — Resize increment base width

## Test plan

- [ ] Verify vertical tab bar renders on left (default) and right
- [ ] Verify drag-to-resize works in both positions
- [ ] Verify close button appears on hover, hidden by default
- [ ] Verify pane content, splits, and mouse clicks are properly offset
- [ ] Verify hot-reload of `tab_bar_vertical_position` between Left/Right
- [ ] Verify horizontal tab bar still works when `tab_bar_vertical = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)