### PR TITLE
docs: add build-from-source section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,20 @@ Yes please!
 
 If you are new to the Rust language check out <https://doc.rust-lang.org/rust-by-example/>.
 
+### Building from source
+
+To build wezterm from source, you will need `rustup`, a supported Rust
+toolchain (1.71 or later), and a few platform-specific dependencies.
+The full instructions, including Windows and macOS specifics, are in the
+[Install from Source](https://wezfurlong.org/wezterm/install/source.html)
+documentation.
+
+On Windows, make sure you select the MSVC toolchain when installing Rust
+and install [Strawberry Perl](https://strawberryperl.com) (needed for
+building OpenSSL). See the
+[Building on Windows](https://wezfurlong.org/wezterm/install/source.html#building-on-windows)
+section for details.
+
 ### Where to find things?
 
 The `term` directory holds the core terminal model code. This is agnostic

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,17 +41,8 @@ If you are new to the Rust language check out <https://doc.rust-lang.org/rust-by
 
 ### Building from source
 
-To build wezterm from source, you will need `rustup`, a supported Rust
-toolchain (1.71 or later), and a few platform-specific dependencies.
-The full instructions, including Windows and macOS specifics, are in the
-[Install from Source](https://wezfurlong.org/wezterm/install/source.html)
-documentation.
-
-On Windows, make sure you select the MSVC toolchain when installing Rust
-and install [Strawberry Perl](https://strawberryperl.com) (needed for
-building OpenSSL). See the
-[Building on Windows](https://wezfurlong.org/wezterm/install/source.html#building-on-windows)
-section for details.
+To build wezterm from source, you will need a local Rust toolchain, and a few platform-specific dependencies.
+Follow the [Install from Source](https://wezfurlong.org/wezterm/install/source.html) guide to get started!
 
 ### Where to find things?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,8 @@ If you are new to the Rust language check out <https://doc.rust-lang.org/rust-by
 To build wezterm from source, you will need a local Rust toolchain, and a few platform-specific dependencies.
 Follow the [Install from Source](https://wezfurlong.org/wezterm/install/source.html) guide to get started!
 
+Some platforms like Windows have a few specific steps, make sure to check the dedicated sections in the guide.
+
 ### Where to find things?
 
 The `term` directory holds the core terminal model code. This is agnostic


### PR DESCRIPTION
## Summary
- Adds a "Building from source" subsection under "Contributing code" in CONTRIBUTING.md
- Links to the existing Install from Source documentation page
- Highlights the Windows-specific prerequisites (MSVC toolchain, Strawberry Perl)

This helps new contributors find platform-specific build instructions without having to search through issues.

Closes #7003