### PR TITLE
feat: allow matching windows paths in Quick Select Mode

### DIFF
--- a/wezterm-gui/src/overlay/quickselect.rs
+++ b/wezterm-gui/src/overlay/quickselect.rs
@@ -23,7 +23,7 @@ use wezterm_term::{
 };
 use window::WindowOps;
 
-const PATTERNS: [&str; 14] = [
+const PATTERNS: [&str; 15] = [
     // markdown_url
     r"\[[^]]*\]\(([^)]+)\)",
     // url
@@ -36,6 +36,8 @@ const PATTERNS: [&str; 14] = [
     r"sha256:([0-9a-f]{64})",
     // path
     r"(?:[.\w\-@~]+)?(?:/+[.\w\-@]+)+",
+    // windows path
+    r#"(?:[a-zA-Z]:|.)\\(?:(?:(?![<>:"/\\|?*]).)+(?:(?<![ .])\\)?)*"#,
     // color
     r"#[0-9a-fA-F]{6}",
     // uuid


### PR DESCRIPTION
## Summary
Adds abilitiy to match windows paths in Quick Select Mode (currently it doesn't match them at all).

### Demo
<img width="591" height="165" alt="paths" src="https://github.com/user-attachments/assets/43ba4679-f432-4612-89b7-c3a1e277bba4" />

Before
<img width="593" height="151" alt="before" src="https://github.com/user-attachments/assets/905e6e68-8a0a-4001-8202-c6e189c04efa" />

After
<img width="578" height="144" alt="after" src="https://github.com/user-attachments/assets/55b25632-8aaf-4ff7-a547-a83f7f438e8b" />

### Disclaimer
I couldn't get it to capture backticks and quotes around the path correctly without freezing, so it matches the closing `'` or `` ` ``, if found at the end. It does that because `` C:\Users\xyz\test\` `` is a valid Windows path.

```powershell
C:\Users\xyz\test> ls


    Directory: C:\Users\xyz\test


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----         3/29/2026   8:56 PM                '
d-----         3/29/2026   8:56 PM                `


C:\Users\xyz\test> cd C:\Users\xyz\test\`
C:\Users\xyz\test\`>
```