### PR TITLE
fix: preserve LruCache capacity in make_all_stale to prevent unbounded memory growth

### DIFF
--- a/wezterm-client/src/pane/renderable.rs
+++ b/wezterm-client/src/pane/renderable.rs
@@ -423,7 +423,7 @@ impl RenderableInner {
     }
 
     pub fn make_all_stale(&mut self) {
-        let mut lines = LruCache::unbounded();
+        let mut lines = LruCache::new(self.lines.cap());
         while let Some((stable_row, entry)) = self.lines.pop_lru() {
             let entry = match entry {
                 LineEntry::Stale(old) | LineEntry::Line(old) => LineEntry::Stale(old),


### PR DESCRIPTION
## Summary

`RenderableInner::make_all_stale()` replaces the bounded `LruCache` with `LruCache::unbounded()`, losing the original capacity limit. This causes the mux client's line cache to grow without bound when connected to a mux server.

The issue is triggered on every mux client connect (initial resize causes `make_all_stale` on all panes), and on subsequent resize, zoom toggle, or palette change events. After the cache becomes unbounded, every new line
received via `GetPaneRenderChanges` is cached indefinitely, leading to multi-gigabyte memory consumption over hours/days of use.

## Root cause

In `wezterm-client/src/pane/renderable.rs`, `make_all_stale()` creates a new `LruCache::unbounded()` to transfer entries into, then assigns it to `self.lines`. The original capacity (default: `scrollback_lines`, typically
3500) is not preserved.

```rust
// Before
pub fn make_all_stale(&mut self) {
    let mut lines = LruCache::unbounded();
    // ... transfer entries ...
    self.lines = lines; // cap is now usize::MAX
}
```

## Fix

Preserve the original capacity when creating the replacement cache:

```rust
// After (fixed)
pub fn make_all_stale(&mut self) {
    let mut lines = LruCache::new(self.lines.cap());
    // ... transfer entries (unchanged) ...
    self.lines = lines; // cap preserved
}
```

No logic changes — only the capacity of the new cache is changed from unbounded to the same value as the original.

## Reproduction

1. Start a mux server: `wezterm-mux-server --daemonize`
2. Connect: `wezterm connect unix`
3. In a pane, run something that produces continuous output (e.g. `while true; do seq 100; sleep 1; done`)
4. Observe RSS growing linearly over time; it never stabilizes

Profiling with heaptrack showed:
- **Before fix**: linear memory growth, ~80% of peak consumption in
  `GetPaneRenderChangesResponse` deserialization → `LruCache` → `Line` data.
- **After fix**: stable at ~80 MB with the same workload.

## Notes

- This only affects mux client connections (`connect unix`, SSHMUX).  Local panes use `LocalPane` and do not have this cache.
- Restarting wezterm-gui and reconnecting to the mux server releases the accumulated cache, so periodic GUI restarts can be used as a workaround.
- The accumulated entries beyond the intended cap are never displayed or used — they are stale cache entries for lines that have long since scrolled out of view. This fix introduces no performance penalty; it simply restores the originally intended eviction behavior.

Refs #7363
