### PR TITLE
fix: prevent stack overflow from process tree cycles in build_proc

### DIFF
--- a/procinfo/src/linux.rs
+++ b/procinfo/src/linux.rs
@@ -104,12 +104,17 @@ impl LocalProcessInfo {
 
         let procs: Vec<_> = all_pids().into_iter().filter_map(info_for_pid).collect();
 
-        fn build_proc(info: &LinuxStat, procs: &[LinuxStat]) -> LocalProcessInfo {
+        fn build_proc(
+            info: &LinuxStat,
+            procs: &[LinuxStat],
+            visited: &mut HashSet<u32>,
+        ) -> LocalProcessInfo {
             let mut children = HashMap::new();
 
             for kid in procs {
-                if kid.ppid == info.pid {
-                    children.insert(kid.pid as u32, build_proc(kid, procs));
+                if kid.ppid == info.pid && !visited.contains(&(kid.pid as u32)) {
+                    visited.insert(kid.pid as u32);
+                    children.insert(kid.pid as u32, build_proc(kid, procs, visited));
                 }
             }
 
@@ -131,7 +136,9 @@ impl LocalProcessInfo {
         }
 
         if let Some(info) = procs.iter().find(|info| info.pid == pid) {
-            Some(build_proc(info, &procs))
+            let mut visited = HashSet::new();
+            visited.insert(pid as u32);
+            Some(build_proc(info, &procs, &mut visited))
         } else {
             None
         }

--- a/procinfo/src/macos.rs
+++ b/procinfo/src/macos.rs
@@ -163,12 +163,17 @@ impl LocalProcessInfo {
 
         let procs: Vec<_> = all_pids().into_iter().filter_map(info_for_pid).collect();
 
-        fn build_proc(info: &libc::proc_bsdinfo, procs: &[libc::proc_bsdinfo]) -> LocalProcessInfo {
+        fn build_proc(
+            info: &libc::proc_bsdinfo,
+            procs: &[libc::proc_bsdinfo],
+            visited: &mut HashSet<u32>,
+        ) -> LocalProcessInfo {
             let mut children = HashMap::new();
 
             for kid in procs {
-                if kid.pbi_ppid == info.pbi_pid {
-                    children.insert(kid.pbi_pid, build_proc(kid, procs));
+                if kid.pbi_ppid == info.pbi_pid && !visited.contains(&kid.pbi_pid) {
+                    visited.insert(kid.pbi_pid);
+                    children.insert(kid.pbi_pid, build_proc(kid, procs, visited));
                 }
             }
 
@@ -192,7 +197,9 @@ impl LocalProcessInfo {
         }
 
         if let Some(info) = procs.iter().find(|info| info.pbi_pid == pid) {
-            Some(build_proc(info, &procs))
+            let mut visited = HashSet::new();
+            visited.insert(pid);
+            Some(build_proc(info, &procs, &mut visited))
         } else {
             None
         }

--- a/procinfo/src/windows.rs
+++ b/procinfo/src/windows.rs
@@ -361,12 +361,19 @@ impl LocalProcessInfo {
         let procs = Snapshot::entries();
         log::trace!("Got snapshot");
 
-        fn build_proc(info: &PROCESSENTRY32W, procs: &[PROCESSENTRY32W]) -> LocalProcessInfo {
+        fn build_proc(
+            info: &PROCESSENTRY32W,
+            procs: &[PROCESSENTRY32W],
+            visited: &mut HashSet<u32>,
+        ) -> LocalProcessInfo {
             let mut children = HashMap::new();
 
             for kid in procs {
-                if kid.th32ParentProcessID == info.th32ProcessID {
-                    children.insert(kid.th32ProcessID, build_proc(kid, procs));
+                if kid.th32ParentProcessID == info.th32ProcessID
+                    && !visited.contains(&kid.th32ProcessID)
+                {
+                    visited.insert(kid.th32ProcessID);
+                    children.insert(kid.th32ProcessID, build_proc(kid, procs, visited));
                 }
             }
 
@@ -411,7 +418,9 @@ impl LocalProcessInfo {
         }
 
         if let Some(info) = procs.iter().find(|info| info.th32ProcessID == pid) {
-            Some(build_proc(info, &procs))
+            let mut visited = HashSet::new();
+            visited.insert(pid);
+            Some(build_proc(info, &procs, &mut visited))
         } else {
             None
         }


### PR DESCRIPTION
## Summary

- Add cycle detection (`visited` HashSet) to `build_proc` in procinfo on all three platforms (Windows, Linux, macOS)
- Prevents infinite recursion when the process tree contains a cycle in parent PID chains

## Problem

`build_proc` recursively walks the process tree to build child process information. If a cycle exists in the parent PID chain (which can happen due to PID reuse or race conditions during process snapshot enumeration on Windows), the recursion never terminates and overflows the stack with exception `0xc00000fd`.

Crash dump stack trace showing the cycle:
```
wezterm_gui!procinfo::windows::impl$5::with_root_pid::build_proc(info=...428ac758) +0xf8
wezterm_gui!procinfo::windows::impl$5::with_root_pid::build_proc(info=...428ac2e8) +0xf8
wezterm_gui!procinfo::windows::impl$5::with_root_pid::build_proc(info=...428aba08) +0xf8
... (same PIDs repeat in a cycle until stack overflow)
```

Reproduced on Windows 11 with multiple terminal tabs running Claude Code (AI coding agent), which spawns many subprocesses.

## Fix

Track visited PIDs in a `HashSet` and skip already-visited processes:

```rust
fn build_proc(
    info: &PROCESSENTRY32W,
    procs: &[PROCESSENTRY32W],
    visited: &mut HashSet<u32>,
) -> LocalProcessInfo {
    for kid in procs {
        if kid.th32ParentProcessID == info.th32ProcessID
            && !visited.contains(&kid.th32ProcessID)
        {
            visited.insert(kid.th32ProcessID);
            children.insert(kid.th32ProcessID, build_proc(kid, procs, visited));
        }
    }
    // ...
}
```

## Related

- Fixes #7705
- Related to #6671 / #6704 (tmux -CC stack overflow worked around by avoiding the call, but did not fix the underlying cycle detection bug)