### PR TITLE
fix(pty): handle TerminateProcess return code correctly

### DIFF
--- a/pty/src/win/mod.rs
+++ b/pty/src/win/mod.rs
@@ -42,7 +42,7 @@ impl WinChild {
         let proc = self.proc.lock().unwrap().try_clone().unwrap();
         let res = unsafe { TerminateProcess(proc.as_raw_handle() as _, 1) };
         let err = IoError::last_os_error();
-        if res != 0 {
+        if res == 0 {
             Err(err)
         } else {
             Ok(())
@@ -71,7 +71,7 @@ impl ChildKiller for WinChildKiller {
     fn kill(&mut self) -> IoResult<()> {
         let res = unsafe { TerminateProcess(self.proc.as_raw_handle() as _, 1) };
         let err = IoError::last_os_error();
-        if res != 0 {
+        if res == 0 {
             Err(err)
         } else {
             Ok(())


### PR DESCRIPTION
On Windows, TerminateProcess use nonzero return value for success.