### PR TITLE
ci: update nightly winget manifest after each nightly build

### DIFF
--- a/.github/workflows/gen_windows_continuous.yml
+++ b/.github/workflows/gen_windows_continuous.yml
@@ -118,3 +118,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: "bash ci/retry.sh gh release upload --clobber nightly WezTerm-*.zip WezTerm-*.exe *.sha256"
+      - name: "Checkout winget-pkgs"
+        uses: actions/checkout@v4
+        with:
+          repository: "wez/winget-pkgs"
+          path: "winget-pkgs"
+          token: "${{ secrets.GH_PAT }}"
+      - name: "Setup email for winget repo"
+        shell: bash
+        run: "cd winget-pkgs && git config user.email wez@wezfurlong.org"
+      - name: "Setup name for winget repo"
+        shell: bash
+        run: "cd winget-pkgs && git config user.name 'Wez Furlong'"
+      - name: "Update nightly winget manifest and push to fork"
+        shell: bash
+        run: "bash ci/make-winget-nightly-pr.sh winget-pkgs WezTerm-nightly-setup.exe"
+      - name: "Submit PR"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+        shell: bash
+        run: 'cd winget-pkgs && gh pr create --fill --body "Automated nightly winget manifest update from wezterm CI"'

--- a/ci/make-winget-nightly-pr.sh
+++ b/ci/make-winget-nightly-pr.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Updates the wez.wezterm.nightly winget manifest with the latest nightly build hash.
+# This script is called from the nightly CI workflow after uploading the new installer.
+#
+# Usage: bash ci/make-winget-nightly-pr.sh <winget_repo_path> <setup_exe>
+set -xe
+
+winget_repo=$1
+setup_exe=$2
+TAG_NAME="nightly"
+PACKAGE_ID="wez.wezterm.nightly"
+PACKAGE_VERSION=$(ci/tag-name.sh)
+
+cd "$winget_repo" || exit 1
+
+# Sync with upstream
+git remote add upstream https://github.com/microsoft/winget-pkgs.git || true
+git fetch upstream master --quiet
+git checkout -b "update-wezterm-nightly-${PACKAGE_VERSION}" upstream/master
+
+exehash=$(sha256sum -b "../$setup_exe" | cut -f1 -d' ' | tr a-f A-F)
+release_date=$(date +%Y-%m-%d)
+
+manifest_dir="manifests/w/wez/wezterm.nightly/${PACKAGE_VERSION}"
+mkdir -p "$manifest_dir"
+
+cat > "$manifest_dir/${PACKAGE_ID}.installer.yaml" <<-EOT
+PackageIdentifier: ${PACKAGE_ID}
+PackageVersion: ${PACKAGE_VERSION}
+MinimumOSVersion: 10.0.17763.0
+InstallerType: inno
+UpgradeBehavior: install
+ReleaseDate: ${release_date}
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/wezterm/wezterm/releases/download/${TAG_NAME}/WezTerm-nightly-setup.exe
+  InstallerSha256: ${exehash}
+  ProductCode: '{BCF6F0DA-5B9A-408D-8562-F680AE6E1EAF}_is1'
+ManifestType: installer
+ManifestVersion: 1.1.0
+EOT
+
+cat > "$manifest_dir/${PACKAGE_ID}.locale.en-US.yaml" <<-EOT
+PackageIdentifier: ${PACKAGE_ID}
+PackageVersion: ${PACKAGE_VERSION}
+PackageLocale: en-US
+Publisher: Wez Furlong
+PublisherUrl: https://wezfurlong.org/
+PublisherSupportUrl: https://github.com/wezterm/wezterm/issues
+Author: Wez Furlong
+PackageName: WezTerm (Nightly)
+PackageUrl: http://wezterm.org
+License: MIT
+LicenseUrl: https://github.com/wezterm/wezterm/blob/main/LICENSE.md
+ShortDescription: A GPU-accelerated cross-platform terminal emulator and multiplexer implemented in Rust (nightly build)
+ReleaseNotesUrl: https://wezterm.org/changelog.html
+ManifestType: defaultLocale
+ManifestVersion: 1.1.0
+EOT
+
+cat > "$manifest_dir/${PACKAGE_ID}.yaml" <<-EOT
+PackageIdentifier: ${PACKAGE_ID}
+PackageVersion: ${PACKAGE_VERSION}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.1.0
+EOT
+
+git add --all
+git diff --cached
+git commit -m "New version: ${PACKAGE_ID} version ${PACKAGE_VERSION}"
+git push --set-upstream origin "update-wezterm-nightly-${PACKAGE_VERSION}" --quiet


### PR DESCRIPTION
Fixes #7713

## Problem
The nightly CI uploads a new `WezTerm-nightly-setup.exe` on every build but never updates the `InstallerSha256` in the winget manifest, causing `winget install wez.wezterm.nightly` to always fail with "Installer hash does not match".

## Fix
- Add `ci/make-winget-nightly-pr.sh` to generate/update the `wez.wezterm.nightly` manifest with the correct hash
- Add winget update steps to the `upload` job in `gen_windows_continuous.yml`, mirroring what `gen_windows_tag.yml` already does for stable releases