### PR TITLE
Fix wgpu/Vulkan rendering on Wayland compositors (like Niri)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3327,13 +3327,13 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+checksum = "00c15a6f673ff72ddcc22394663290f870fb224c1bfce55734a75c414150e605"
 dependencies = [
  "bitflags 2.10.0",
  "block",
- "core-graphics-types 0.1.3",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
  "log",
  "objc",
@@ -3521,25 +3521,26 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "25.0.1"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
+checksum = "066cf25f0e8b11ee0df221219010f213ad429855f57c494f995590c861a9a7d8"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bitflags 2.10.0",
+ "cfg-if",
  "cfg_aliases",
  "codespan-reporting",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "hexf-parse",
  "indexmap 2.12.0",
+ "libm",
  "log",
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
  "spirv",
- "strum",
  "thiserror 2.0.17",
  "unicode-ident",
 ]
@@ -3581,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -5504,28 +5505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.110",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7165,15 +7144,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "25.0.2"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
+checksum = "bfe68bac7cde125de7a731c3400723cadaaf1703795ad3f4805f187459cd7a77"
 dependencies = [
  "arrayvec",
  "bitflags 2.10.0",
+ "cfg-if",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "js-sys",
  "log",
  "naga",
@@ -7193,17 +7173,18 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "25.0.2"
+version = "27.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
+checksum = "27a75de515543b1897b26119f93731b385a19aea165a1ec5f0e3acecc229cae7"
 dependencies = [
  "arrayvec",
  "bit-set",
  "bit-vec",
  "bitflags 2.10.0",
+ "bytemuck",
  "cfg_aliases",
  "document-features",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "indexmap 2.12.0",
  "log",
  "naga",
@@ -7224,36 +7205,36 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core-deps-apple"
-version = "25.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd488b3239b6b7b185c3b045c39ca6bf8af34467a4c5de4e0b1a564135d093d"
+checksum = "0772ae958e9be0c729561d5e3fd9a19679bcdfb945b8b1a1969d9bfe8056d233"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-emscripten"
-version = "25.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09ad7aceb3818e52539acc679f049d3475775586f3f4e311c30165cf2c00445"
+checksum = "b06ac3444a95b0813ecfd81ddb2774b66220b264b3e2031152a4a29fda4da6b5"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
-version = "25.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
+checksum = "71197027d61a71748e4120f05a9242b2ad142e3c01f8c1b47707945a879a03c3"
 dependencies = [
  "wgpu-hal",
 ]
 
 [[package]]
 name = "wgpu-hal"
-version = "25.0.2"
+version = "27.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f968767fe4d3d33747bbd1473ccd55bf0f6451f55d733b5597e67b5deab4ad17"
+checksum = "5b21cb61c57ee198bc4aff71aeadff4cbb80b927beb912506af9c780d64313ce"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -7264,13 +7245,13 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "cfg_aliases",
- "core-graphics-types 0.1.3",
+ "core-graphics-types 0.2.0",
  "glow",
  "glutin_wgl_sys",
  "gpu-alloc",
  "gpu-allocator",
  "gpu-descriptor",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "js-sys",
  "khronos-egl",
  "libc",
@@ -7280,9 +7261,11 @@ dependencies = [
  "naga",
  "ndk-sys",
  "objc",
+ "once_cell",
  "ordered-float 4.6.0",
  "parking_lot",
  "portable-atomic",
+ "portable-atomic-util",
  "profiling",
  "range-alloc",
  "raw-window-handle",
@@ -7298,9 +7281,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "25.0.0"
+version = "27.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
+checksum = "afdcf84c395990db737f2dd91628706cb31e86d72e53482320d368e52b5da5eb"
 dependencies = [
  "bitflags 2.10.0",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,7 +260,7 @@ wezterm-term = { path = "term" }
 wezterm-toast-notification = { path = "wezterm-toast-notification" }
 wezterm-uds = { path = "wezterm-uds" }
 wezterm-version = { path = "wezterm-version" }
-wgpu = "25.0.2"
+wgpu = "27.0.1"
 whoami = "1.5"
 winapi = "0.3.9"
 window = {path="window"}

--- a/wezterm-gui/src/renderstate.rs
+++ b/wezterm-gui/src/renderstate.rs
@@ -191,7 +191,7 @@ pub struct MappedQuads<'a> {
 }
 
 pub struct WebGpuMappedVertexBuffer {
-    mapping: wgpu::BufferViewMut<'static>,
+    mapping: wgpu::BufferViewMut,
     // Owner mapping, must be dropped after mapping
     _slice: wgpu::BufferSlice<'static>,
 }

--- a/wezterm-gui/src/termwindow/render/draw.rs
+++ b/wezterm-gui/src/termwindow/render/draw.rs
@@ -99,6 +99,7 @@ impl crate::TermWindow {
                         label: Some("Render Pass"),
                         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
                             view: &view,
+                            depth_slice: None,
                             resolve_target: None,
                             ops: wgpu::Operations {
                                 load: if cleared {

--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -333,6 +333,7 @@ impl WebGpuState {
                 label: None,
                 memory_hints: Default::default(),
                 trace: wgpu::Trace::Off,
+                experimental_features: wgpu::ExperimentalFeatures::disabled(),
             })
             .await?;
 

--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -360,12 +360,28 @@ impl WebGpuState {
             vec![]
         };
 
+        // Prefer Mailbox over Fifo when available. On Wayland, Mailbox
+        // is always supported (Wayland is inherently a mailbox system)
+        // and does not block in get_current_texture(), which prevents
+        // multi-window stalls on a single-threaded event loop. The
+        // compositor still handles vsync so there is no tearing.
+        // Fifo blocks for up to one vsync interval per window, which
+        // serializes rendering across windows.
+        let present_mode = if caps
+            .present_modes
+            .contains(&wgpu::PresentMode::Mailbox)
+        {
+            wgpu::PresentMode::Mailbox
+        } else {
+            wgpu::PresentMode::Fifo
+        };
+
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format,
             width: dimensions.pixel_width as u32,
             height: dimensions.pixel_height as u32,
-            present_mode: wgpu::PresentMode::Fifo,
+            present_mode,
             alpha_mode: if caps
                 .alpha_modes
                 .contains(&wgpu::CompositeAlphaMode::PostMultiplied)
@@ -380,7 +396,7 @@ impl WebGpuState {
                 wgpu::CompositeAlphaMode::Auto
             },
             view_formats,
-            desired_maximum_frame_latency: 2,
+            desired_maximum_frame_latency: 1,
         };
         surface.configure(&device, &config);
 

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -1004,6 +1004,17 @@ impl WaylandWindowInner {
         self.do_paint().unwrap();
     }
 
+    /// Whether to use wl_surface frame callbacks for paint throttling.
+    /// For OpenGL/EGL, eglSwapBuffers commits the wl_surface synchronously
+    /// and reliably fires frame callbacks. For WebGPU/Vulkan, the driver's
+    /// WSI layer manages surface commits independently and may conflict
+    /// with SCTK-registered frame callbacks (e.g. NVIDIA Vulkan on
+    /// Wayland). In that case, wgpu's FIFO present mode provides vsync
+    /// throttling via get_current_texture() blocking.
+    fn use_frame_callbacks(&self) -> bool {
+        self.gl_state.is_some()
+    }
+
     fn set_text_cursor_position(&mut self, rect: Rect) {
         let conn = WaylandConnection::get().unwrap().wayland();
         let state = conn.wayland_state.borrow();
@@ -1075,38 +1086,39 @@ impl WaylandWindowInner {
 
     fn do_paint(&mut self) -> anyhow::Result<()> {
         if self.window.is_none() {
-            // We're likely in the middle of closing/destroying
-            // the window; we've nothing to do here.
             return Ok(());
         }
 
-        if self.frame_callback.is_some() {
-            // Painting now won't be productive, so skip it but
-            // remember that we need to be painted so that when
-            // the compositor is ready for us, we can paint then.
-            self.invalidated = true;
-            return Ok(());
+        if self.use_frame_callbacks() {
+            // OpenGL/EGL path: use frame callbacks for throttling.
+            // eglSwapBuffers commits the wl_surface synchronously,
+            // which reliably fires SCTK-registered frame callbacks.
+            if self.frame_callback.is_some() {
+                self.invalidated = true;
+                return Ok(());
+            }
+
+            self.invalidated = false;
+
+            let conn = WaylandConnection::get().unwrap().wayland();
+            let qh = conn.event_queue.borrow().handle();
+            let callback = self.surface().frame(&qh, self.surface().clone());
+            log::trace!("do_paint - callback: {:?}", callback);
+            self.frame_callback.replace(callback);
+
+            // <https://github.com/wezterm/wezterm/issues/3468>
+            // <https://github.com/wezterm/wezterm/issues/3126>
+            self.events.dispatch(WindowEvent::NeedRepaint);
+        } else {
+            // WebGPU/Vulkan path: skip frame callbacks entirely.
+            // The Vulkan WSI layer manages surface commits independently
+            // and may conflict with SCTK-registered frame callbacks
+            // (observed on NVIDIA Vulkan). wgpu's FIFO present mode
+            // provides natural vsync throttling via get_current_texture()
+            // blocking when no swapchain image is available.
+            self.invalidated = false;
+            self.events.dispatch(WindowEvent::NeedRepaint);
         }
-
-        self.invalidated = false;
-
-        // Ask the compositor to wake us up when its time to paint the next frame,
-        // note that this only happens _after_ the next commit
-        let conn = WaylandConnection::get().unwrap().wayland();
-        let qh = conn.event_queue.borrow().handle();
-
-        let callback = self.surface().frame(&qh, self.surface().clone());
-
-        log::trace!("do_paint - callback: {:?}", callback);
-        self.frame_callback.replace(callback);
-
-        // The repaint has the side of effect of committing the surface,
-        // which is necessary for the frame callback to get triggered.
-        // Ordering the repaint after requesting the callback ensures that
-        // we will get woken at the appropriate time.
-        // <https://github.com/wezterm/wezterm/issues/3468>
-        // <https://github.com/wezterm/wezterm/issues/3126>
-        self.events.dispatch(WindowEvent::NeedRepaint);
 
         Ok(())
     }


### PR DESCRIPTION
Two fixes for the wgpu/Vulkan renderer on Wayland. Without these, wezterm windows freeze on launch or become unresponsive when using the WebGPU frontend. The freeze is immediate on tiling compositors like Niri, where the window never gets a chance to recover via a user-initiated resize.

## Frame callback bypass

WezTerm registers wl_surface.frame() callbacks via SCTK for paint throttling. This works for OpenGL/EGL because eglSwapBuffers commits the surface and drives the callback lifecycle.

For wgpu/Vulkan, vkQueuePresentKHR goes through the Vulkan WSI layer, which manages buffer attachment and surface commits on its own. The two systems conflict over the same wl_surface, and the SCTK-registered callback stops firing after a few initial frames. Since invalidate() defers to the pending callback, the paint loop deadlocks and the window freezes.

The fix splits do_paint() by renderer type. OpenGL continues using frame callbacks; wgpu skips them entirely and dispatches NeedRepaint directly. Detection is simple: gl_state.is_some() indicates OpenGL.

## Mailbox present mode

PresentMode::Fifo blocks in get_current_texture() for up to one vsync interval per window. On a single-threaded event loop with multiple windows, this serializes rendering and stalls input processing.

Wayland is inherently a mailbox system, and all Vulkan implementations on Wayland must support Mailbox present mode (gfx-rs/wgpu#2937). Mailbox does not block in get_current_texture(), while the compositor still controls presentation timing, so there is no tearing. Also reduces desired_maximum_frame_latency from 2 to 1 for lower input latency, which matters more than throughput for a terminal emulator.

## Testing

Tested on FreeBSD 15 + Niri compositor + NVIDIA Vulkan (RTX 3070 Ti):
- Window no longer freezes on launch (previously froze immediately on Niri)
- Single and multiple windows remain responsive
- Maximize, fullscreen, and tiled transitions all work
- OpenGL path is unchanged (frame callbacks still used)