### PR TITLE
feat: add opt-in cursor trail and smear effects (closes #7387)

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -653,6 +653,53 @@ pub struct Config {
     #[dynamic(default = "default_reverse_video_cursor_min_contrast")]
     pub reverse_video_cursor_min_contrast: f32,
 
+    /// Enables the cursor smear effect: a fading parallelogram trail drawn between
+    /// the previous and current cursor positions during animated movement.
+    #[dynamic(default)]
+    pub cursor_smear: bool,
+    /// When `true`, the cursor smear fades from fully transparent at the tail to
+    /// the full cursor colour at the head, giving a comet-like gradient effect.
+    /// When `false`, the smear is rendered at a uniform opacity along its length.
+    #[dynamic(default = "default_cursor_smear_gradient")]
+    pub cursor_smear_gradient: bool,
+    /// Determines the time it takes for the cursor smear to complete its animation
+    /// on large moves (>= `cursor_trail_min_distance` cells), in seconds.
+    /// Set to `0.0` to snap the cursor instantly on large moves.
+    #[dynamic(default = "default_cursor_animation_length")]
+    pub cursor_animation_length: f32,
+    /// Controls how much the tail of the cursor trails the head during the smear
+    /// effect. `1.0` gives the maximum trail — the head jumps immediately to the
+    /// destination while the tail catches up. Lower values produce a shorter, less
+    /// dramatic trail. `0.0` disables the visible trail entirely.
+    #[dynamic(default = "default_cursor_trail_size")]
+    pub cursor_trail_size: f32,
+    /// Selects the particle / highlight style for the cursor VFX trail.
+    /// When unset (the default) no particles are spawned; cursor smearing is
+    /// still available independently via `cursor_smear`.
+    #[dynamic(default)]
+    pub cursor_trail_style: Option<CursorTrailStyle>,
+    #[dynamic(default = "default_cursor_trail_min_distance")]
+    pub cursor_trail_min_distance: usize,
+    /// Controls the opacity of cursor VFX particles and highlights.
+    /// `1.0` is fully opaque, `0.0` is invisible.
+    #[dynamic(default = "default_cursor_vfx_opacity")]
+    pub cursor_vfx_opacity: f32,
+    /// Controls how long cursor VFX particles persist, in seconds.
+    /// Higher values create longer-lasting trails.
+    #[dynamic(default = "default_cursor_vfx_particle_lifetime")]
+    pub cursor_vfx_particle_lifetime: f32,
+    /// Controls how many particles are spawned per cell of cursor movement.
+    /// Higher values create denser trails.
+    #[dynamic(default = "default_cursor_vfx_particle_density")]
+    pub cursor_vfx_particle_density: f32,
+    /// Controls the initial speed of cursor VFX particles (in cells per second).
+    /// Higher values make particles fly further and faster from the cursor.
+    #[dynamic(default = "default_cursor_vfx_particle_speed")]
+    pub cursor_vfx_particle_speed: f32,
+    /// Controls the maximum diameter of cursor VFX particles as a fraction of
+    /// the cell width.  1.0 = one full cell wide.  Default 0.5.
+    #[dynamic(default = "default_cursor_vfx_particle_size")]
+    pub cursor_vfx_particle_size: f32,
     /// Specifies the default cursor style.  various escape sequences
     /// can override the default style in different situations (eg:
     /// an editor can change it depending on the mode), but this value
@@ -1675,6 +1722,42 @@ fn default_cursor_blink_rate() -> u64 {
     800
 }
 
+fn default_cursor_trail_min_distance() -> usize {
+    4
+}
+
+fn default_cursor_smear_gradient() -> bool {
+    false
+}
+
+fn default_cursor_animation_length() -> f32 {
+    0.150
+}
+
+fn default_cursor_trail_size() -> f32 {
+    1.0
+}
+
+fn default_cursor_vfx_opacity() -> f32 {
+    0.6
+}
+
+fn default_cursor_vfx_particle_lifetime() -> f32 {
+    0.35
+}
+
+fn default_cursor_vfx_particle_density() -> f32 {
+    0.7
+}
+
+fn default_cursor_vfx_particle_speed() -> f32 {
+    8.0
+}
+
+fn default_cursor_vfx_particle_size() -> f32 {
+    0.5
+}
+
 fn default_text_blink_rate() -> u64 {
     500
 }
@@ -1892,6 +1975,25 @@ fn default_inactive_pane_hsb() -> HsbTransform {
         saturation: 0.9,
         hue: 1.0,
     }
+}
+
+/// Particle / highlight style for the cursor trail animation.
+/// Used as `cursor_trail_style` in config; leave unset for no particles
+/// (cursor smearing is controlled separately by `cursor_smear`).
+#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, PartialEq)]
+pub enum CursorTrailStyle {
+    /// Railgun: sinusoidal particle stream along the movement vector.
+    Railgun,
+    /// Torpedo: particles that scatter opposing the travel direction.
+    Torpedo,
+    /// PixieDust: small squares that fall with gravity.
+    PixieDust,
+    /// SonicBoom: an expanding filled square at the cursor destination.
+    SonicBoom,
+    /// Ripple: an expanding hollow ring at the cursor destination.
+    Ripple,
+    /// Wireframe: an expanding hollow rectangle at the cursor destination.
+    Wireframe,
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, Default)]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -665,8 +665,8 @@ pub struct Config {
     /// Determines the time it takes for the cursor smear to complete its animation
     /// on large moves (>= `cursor_trail_min_distance` cells), in seconds.
     /// Set to `0.0` to snap the cursor instantly on large moves.
-    #[dynamic(default = "default_cursor_animation_length")]
-    pub cursor_animation_length: f32,
+    #[dynamic(default = "default_cursor_animation_duration")]
+    pub cursor_animation_duration: f32,
     /// Controls how much the tail of the cursor trails the head during the smear
     /// effect. `1.0` gives the maximum trail — the head jumps immediately to the
     /// destination while the tail catches up. Lower values produce a shorter, less
@@ -1730,7 +1730,7 @@ fn default_cursor_smear_gradient() -> bool {
     false
 }
 
-fn default_cursor_animation_length() -> f32 {
+fn default_cursor_animation_duration() -> f32 {
     0.150
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,6 +72,24 @@ As features stabilize some brief notes about them will accumulate here.
   @mgpinf! #6801
 
 #### New
+* Opt-in cursor trail and smear effects, inspired by
+  [Neovide](https://github.com/neovide/neovide). Enable the Neovide-style
+  4-corner deforming smear with
+  [cursor_smear](config/lua/config/cursor_smear.md), or choose a particle /
+  highlight style via
+  [cursor_trail_style](config/lua/config/cursor_trail_style.md) (`Torpedo`,
+  `PixieDust`, `Railgun`, `SonicBoom`, `Ripple`, `Wireframe`). All effects
+  are disabled by default. See also
+  [cursor_animation_length](config/lua/config/cursor_animation_length.md),
+  [cursor_trail_size](config/lua/config/cursor_trail_size.md),
+  [cursor_smear_gradient](config/lua/config/cursor_smear_gradient.md),
+  [cursor_trail_min_distance](config/lua/config/cursor_trail_min_distance.md),
+  [cursor_vfx_opacity](config/lua/config/cursor_vfx_opacity.md),
+  [cursor_vfx_particle_lifetime](config/lua/config/cursor_vfx_particle_lifetime.md),
+  [cursor_vfx_particle_density](config/lua/config/cursor_vfx_particle_density.md),
+  [cursor_vfx_particle_speed](config/lua/config/cursor_vfx_particle_speed.md),
+  [cursor_vfx_particle_size](config/lua/config/cursor_vfx_particle_size.md).
+  Thanks to @mathugoat! #7387
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,24 +72,6 @@ As features stabilize some brief notes about them will accumulate here.
   @mgpinf! #6801
 
 #### New
-* Opt-in cursor trail and smear effects, inspired by
-  [Neovide](https://github.com/neovide/neovide). Enable the Neovide-style
-  4-corner deforming smear with
-  [cursor_smear](config/lua/config/cursor_smear.md), or choose a particle /
-  highlight style via
-  [cursor_trail_style](config/lua/config/cursor_trail_style.md) (`Torpedo`,
-  `PixieDust`, `Railgun`, `SonicBoom`, `Ripple`, `Wireframe`). All effects
-  are disabled by default. See also
-  [cursor_animation_length](config/lua/config/cursor_animation_length.md),
-  [cursor_trail_size](config/lua/config/cursor_trail_size.md),
-  [cursor_smear_gradient](config/lua/config/cursor_smear_gradient.md),
-  [cursor_trail_min_distance](config/lua/config/cursor_trail_min_distance.md),
-  [cursor_vfx_opacity](config/lua/config/cursor_vfx_opacity.md),
-  [cursor_vfx_particle_lifetime](config/lua/config/cursor_vfx_particle_lifetime.md),
-  [cursor_vfx_particle_density](config/lua/config/cursor_vfx_particle_density.md),
-  [cursor_vfx_particle_speed](config/lua/config/cursor_vfx_particle_speed.md),
-  [cursor_vfx_particle_size](config/lua/config/cursor_vfx_particle_size.md).
-  Thanks to @mathugoat! #7387
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345
@@ -158,6 +140,12 @@ As features stabilize some brief notes about them will accumulate here.
   Thanks to @masriomarm! #6895
 * Indicate support for OSC 52 (clipboard extensions) in Primary DA Response.
   Thanks to @j4james! #7046
+* Opt-in cursor trail and smear effects, inspired by
+  [Neovide](https://github.com/neovide/neovide): a Neovide-style 4-corner
+  deforming smear plus optional particle / highlight styles (`Torpedo`,
+  `PixieDust`, `Railgun`, `SonicBoom`, `Ripple`, `Wireframe`). All effects are
+  disabled by default; see [cursor_smear](config/lua/config/cursor_smear.md)
+  for details and related options. Thanks to @MathurinV! #7387
 
 #### Fixed
 * Race condition when very quickly adjusting font scale, and other improvements

--- a/docs/config/lua/config/cursor_animation_duration.md
+++ b/docs/config/lua/config/cursor_animation_duration.md
@@ -3,7 +3,7 @@ tags:
   - appearance
   - text_cursor
 ---
-# `cursor_animation_length`
+# `cursor_animation_duration`
 
 {{since('nightly')}}
 
@@ -18,7 +18,7 @@ cursor moves instantaneous even when `cursor_smear = true`.
 
 ```lua
 config.cursor_smear = true
-config.cursor_animation_length = 0.15
+config.cursor_animation_duration = 0.15
 ```
 
 The relative lag between the leading and trailing edges of the smear is

--- a/docs/config/lua/config/cursor_animation_length.md
+++ b/docs/config/lua/config/cursor_animation_length.md
@@ -1,0 +1,25 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_animation_length`
+
+{{since('nightly')}}
+
+Specifies the duration of the [cursor_smear](cursor_smear.md) animation in
+seconds. This is the time it takes for the trailing edge of the smear to reach
+the destination after a multi-cell cursor jump.
+
+The default value is `0.15` (150 ms).
+
+Setting this to `0.0` disables the position animation entirely, making all
+cursor moves instantaneous even when `cursor_smear = true`.
+
+```lua
+config.cursor_smear = true
+config.cursor_animation_length = 0.15
+```
+
+The relative lag between the leading and trailing edges of the smear is
+controlled separately by [cursor_trail_size](cursor_trail_size.md).

--- a/docs/config/lua/config/cursor_smear.md
+++ b/docs/config/lua/config/cursor_smear.md
@@ -1,0 +1,35 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_smear`
+
+{{since('nightly')}}
+
+When set to `true`, enables a Neovide-style deforming smear effect on the
+cursor. As the cursor moves across multiple cells, its four corners animate
+independently: leading corners race ahead to the destination while trailing
+corners lag behind, stretching the cursor body into a parallelogram that
+gives a sense of motion and speed.
+
+The smear activates only on multi-cell jumps (e.g. `gg`/`G`, `Ctrl-f`,
+mouse clicks). Single-cell moves such as typing or `hjkl` navigation snap
+the cursor instantly so the effect is not distracting during normal editing.
+
+All cursor shapes are supported: block, bar, and underline.
+
+```lua
+config.cursor_smear = true
+```
+
+The animation duration is controlled by
+[cursor_animation_length](cursor_animation_length.md), and the relative lag
+between the leading and trailing edges is set by
+[cursor_trail_size](cursor_trail_size.md).
+
+An optional gradient mode (tail fades to transparent) is available via
+[cursor_smear_gradient](cursor_smear_gradient.md).
+
+See also the particle-based trail effects available through
+[cursor_trail_style](cursor_trail_style.md).

--- a/docs/config/lua/config/cursor_smear.md
+++ b/docs/config/lua/config/cursor_smear.md
@@ -24,7 +24,7 @@ config.cursor_smear = true
 ```
 
 The animation duration is controlled by
-[cursor_animation_length](cursor_animation_length.md), and the relative lag
+[cursor_animation_duration](cursor_animation_duration.md), and the relative lag
 between the leading and trailing edges is set by
 [cursor_trail_size](cursor_trail_size.md).
 
@@ -33,3 +33,27 @@ An optional gradient mode (tail fades to transparent) is available via
 
 See also the particle-based trail effects available through
 [cursor_trail_style](cursor_trail_style.md).
+
+## Related options
+
+These options tune the cursor animation and particle effects:
+
+* [cursor_animation_duration](cursor_animation_duration.md) — smear animation
+  duration, in seconds.
+* [cursor_trail_size](cursor_trail_size.md) — how far the trailing edge lags
+  behind the leading edge.
+* [cursor_smear_gradient](cursor_smear_gradient.md) — fade the smear tail to
+  transparent for a comet-like look.
+* [cursor_trail_min_distance](cursor_trail_min_distance.md) — minimum cursor
+  movement, in cells, before effects trigger.
+* [cursor_trail_style](cursor_trail_style.md) — particle / highlight style
+  (`Torpedo`, `PixieDust`, `Railgun`, `SonicBoom`, `Ripple`, `Wireframe`).
+* [cursor_vfx_opacity](cursor_vfx_opacity.md) — particle opacity.
+* [cursor_vfx_particle_lifetime](cursor_vfx_particle_lifetime.md) — how long
+  particles persist, in seconds.
+* [cursor_vfx_particle_density](cursor_vfx_particle_density.md) — particles
+  spawned per cell of movement.
+* [cursor_vfx_particle_speed](cursor_vfx_particle_speed.md) — initial particle
+  speed, in cells/sec.
+* [cursor_vfx_particle_size](cursor_vfx_particle_size.md) — particle diameter
+  as a fraction of cell width.

--- a/docs/config/lua/config/cursor_smear_gradient.md
+++ b/docs/config/lua/config/cursor_smear_gradient.md
@@ -1,0 +1,22 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_smear_gradient`
+
+{{since('nightly')}}
+
+Controls whether the [cursor_smear](cursor_smear.md) effect uses a gradient.
+
+* `false` (default) — the smear body is rendered at a uniform opacity, giving
+  a solid stretched-cursor look.
+* `true` — the tail of the smear fades from fully transparent to the full
+  cursor colour at the head, giving a comet-like effect.
+
+Has no effect when `cursor_smear = false`.
+
+```lua
+config.cursor_smear = true
+config.cursor_smear_gradient = true
+```

--- a/docs/config/lua/config/cursor_trail_min_distance.md
+++ b/docs/config/lua/config/cursor_trail_min_distance.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_trail_min_distance`
+
+{{since('nightly')}}
+
+Specifies the minimum cursor movement in cells required to trigger the
+[cursor_trail_style](cursor_trail_style.md) particle or highlight effect.
+
+The default is `4`.
+
+Increasing this value means effects only fire on large jumps (e.g. search
+results, `gg`/`G`, `Ctrl-f`), keeping the display quiet during normal
+navigation. Decreasing it towards `1` fires the effect on nearly every move.
+
+Has no effect when `cursor_trail_style` is not set.
+
+```lua
+config.cursor_trail_style = 'Torpedo'
+config.cursor_trail_min_distance = 4
+```

--- a/docs/config/lua/config/cursor_trail_size.md
+++ b/docs/config/lua/config/cursor_trail_size.md
@@ -1,0 +1,28 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_trail_size`
+
+{{since('nightly')}}
+
+Controls how much the trailing edge of the [cursor_smear](cursor_smear.md)
+lags behind the leading edge, determining the visible length of the stretched
+cursor body.
+
+* `1.0` (default) — maximum trail. The leading corners jump immediately to
+  the destination while the trailing corners animate at the full
+  [cursor_animation_length](cursor_animation_length.md) duration, producing
+  the longest and most dramatic smear.
+* `0.5` — moderate trail. Leading and trailing corners meet somewhere between
+  the start and the full animation duration.
+* `0.0` — no visible trail. All four corners animate at the same speed,
+  moving the cursor as a rigid body.
+
+Has no effect when `cursor_smear = false`.
+
+```lua
+config.cursor_smear = true
+config.cursor_trail_size = 1.0
+```

--- a/docs/config/lua/config/cursor_trail_size.md
+++ b/docs/config/lua/config/cursor_trail_size.md
@@ -13,7 +13,7 @@ cursor body.
 
 * `1.0` (default) — maximum trail. The leading corners jump immediately to
   the destination while the trailing corners animate at the full
-  [cursor_animation_length](cursor_animation_length.md) duration, producing
+  [cursor_animation_duration](cursor_animation_duration.md) duration, producing
   the longest and most dramatic smear.
 * `0.5` — moderate trail. Leading and trailing corners meet somewhere between
   the start and the full animation duration.

--- a/docs/config/lua/config/cursor_trail_style.md
+++ b/docs/config/lua/config/cursor_trail_style.md
@@ -1,0 +1,57 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_trail_style`
+
+{{since('nightly')}}
+
+Selects a particle or highlight effect that plays when the cursor moves at
+least [cursor_trail_min_distance](cursor_trail_min_distance.md) cells.
+
+The default is `nil` (no particles). The smear effect
+([cursor_smear](cursor_smear.md)) is available independently and can be used
+with or without a `cursor_trail_style`.
+
+## Available styles
+
+### Particle styles
+
+These spawn particles along the travel path on each qualifying move.
+
+| Value | Description |
+|---|---|
+| `"Torpedo"` | Particles scatter opposing the direction of travel. Recommended. |
+| `"PixieDust"` | Small squares that fall under gravity. Recommended. |
+| `"Railgun"` | Sinusoidal particle stream fanning along the movement vector. |
+
+### Highlight styles
+
+These spawn a single expanding shape at the cursor destination.
+
+| Value | Description |
+|---|---|
+| `"SonicBoom"` | Expanding filled square. |
+| `"Ripple"` | Expanding hollow ring. |
+| `"Wireframe"` | Expanding hollow rectangle. |
+
+## Example
+
+```lua
+config.cursor_trail_style = 'Torpedo'
+```
+
+## Related options
+
+* [cursor_trail_min_distance](cursor_trail_min_distance.md) — minimum
+  movement required to trigger the effect.
+* [cursor_vfx_opacity](cursor_vfx_opacity.md) — particle/highlight opacity.
+* [cursor_vfx_particle_lifetime](cursor_vfx_particle_lifetime.md) — how long
+  particles persist.
+* [cursor_vfx_particle_density](cursor_vfx_particle_density.md) — particles
+  spawned per cell of movement.
+* [cursor_vfx_particle_speed](cursor_vfx_particle_speed.md) — initial
+  particle speed.
+* [cursor_vfx_particle_size](cursor_vfx_particle_size.md) — particle
+  diameter.

--- a/docs/config/lua/config/cursor_vfx_opacity.md
+++ b/docs/config/lua/config/cursor_vfx_opacity.md
@@ -1,0 +1,21 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_vfx_opacity`
+
+{{since('nightly')}}
+
+Controls the opacity of the particles and highlights produced by
+[cursor_trail_style](cursor_trail_style.md).
+
+* `1.0` — fully opaque.
+* `0.0` — invisible.
+
+The default is `0.6`.
+
+```lua
+config.cursor_trail_style = 'Torpedo'
+config.cursor_vfx_opacity = 0.6
+```

--- a/docs/config/lua/config/cursor_vfx_particle_density.md
+++ b/docs/config/lua/config/cursor_vfx_particle_density.md
@@ -1,0 +1,22 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_vfx_particle_density`
+
+{{since('nightly')}}
+
+Controls how many particles are spawned per cell of cursor movement for
+[cursor_trail_style](cursor_trail_style.md) particle effects.
+
+Higher values produce a denser trail; lower values are more sparse. The
+default is `0.7`.
+
+A hard cap of 256 simultaneous live particles per pane is always enforced
+regardless of this value.
+
+```lua
+config.cursor_trail_style = 'Torpedo'
+config.cursor_vfx_particle_density = 0.7
+```

--- a/docs/config/lua/config/cursor_vfx_particle_lifetime.md
+++ b/docs/config/lua/config/cursor_vfx_particle_lifetime.md
@@ -1,0 +1,19 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_vfx_particle_lifetime`
+
+{{since('nightly')}}
+
+Controls how long particles produced by
+[cursor_trail_style](cursor_trail_style.md) persist on screen, in seconds.
+
+Higher values create longer-lasting trails; lower values make particles
+disappear quickly. The default is `0.35`.
+
+```lua
+config.cursor_trail_style = 'Torpedo'
+config.cursor_vfx_particle_lifetime = 0.35
+```

--- a/docs/config/lua/config/cursor_vfx_particle_size.md
+++ b/docs/config/lua/config/cursor_vfx_particle_size.md
@@ -1,0 +1,25 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_vfx_particle_size`
+
+{{since('nightly')}}
+
+Controls the maximum diameter of particles produced by
+[cursor_trail_style](cursor_trail_style.md), expressed as a fraction of the
+cell width.
+
+* `1.0` — particles are as wide as one full cell.
+* `0.5` (default) — particles are half a cell wide.
+* `0.0` — invisible.
+
+For `Torpedo` and `Railgun`, particle size shrinks proportionally to
+remaining lifetime, so particles appear to fade out as they age. For
+`PixieDust`, size is constant throughout the particle's lifetime.
+
+```lua
+config.cursor_trail_style = 'PixieDust'
+config.cursor_vfx_particle_size = 0.5
+```

--- a/docs/config/lua/config/cursor_vfx_particle_speed.md
+++ b/docs/config/lua/config/cursor_vfx_particle_speed.md
@@ -1,0 +1,19 @@
+---
+tags:
+  - appearance
+  - text_cursor
+---
+# `cursor_vfx_particle_speed`
+
+{{since('nightly')}}
+
+Controls the initial speed of particles produced by
+[cursor_trail_style](cursor_trail_style.md), in cells per second.
+
+Higher values make particles fly further and faster from the cursor; lower
+values keep the effect more contained. The default is `8.0`.
+
+```lua
+config.cursor_trail_style = 'Torpedo'
+config.cursor_vfx_particle_speed = 8.0
+```

--- a/wezterm-gui/src/quad.rs
+++ b/wezterm-gui/src/quad.rs
@@ -368,6 +368,7 @@ impl TripleLayerQuadAllocatorTrait for HeapQuadAllocator {
         let src_quads: &[[Vertex; VERTICES_PER_CELL]] =
             unsafe { std::slice::from_raw_parts(vertices.as_ptr().cast(), vertices.len() / 4) };
 
+        dest_quads.reserve(src_quads.len());
         for quad in src_quads {
             dest_quads.push(Box::new(BoxedQuad::from_vertices(quad)));
         }

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -205,6 +205,10 @@ pub struct CursorTrailState {
     /// False until the first update(); skips spawning on the first frame
     /// to avoid a bogus trail from (0,0) to the real cursor position.
     prev_initialized: bool,
+    /// True when the cursor did not move in the previous frame.
+    /// Used to suppress smear on rapid programmatic cursor movement (e.g. btop
+    /// redraws), which never lets the cursor settle between frames.
+    cursor_was_stable: bool,
 }
 
 impl CursorTrailState {
@@ -219,6 +223,7 @@ impl CursorTrailState {
             count_remainder: 0.0,
             rng: Rng::new(),
             prev_initialized: false,
+            cursor_was_stable: false,
         }
     }
 
@@ -416,7 +421,12 @@ impl CursorTrailState {
             //
             // Only activate for multi-cell jumps (dx+dy > 1) to avoid distracting
             // smear when typing or using single-cell hjkl navigation.
-            if dx + dy > 1 {
+            //
+            // Also require that the cursor was stable (not moving) in the previous
+            // frame. Apps like btop continuously move the cursor across the screen to
+            // redraw their TUI; those rapid programmatic moves never let the cursor
+            // settle, so `cursor_was_stable` stays false and no smear is triggered.
+            if dx + dy > 1 && self.cursor_was_stable {
                 let prev_cx = self.prev_pos.x as f32 * cell_width + cell_width * 0.5;
                 let prev_cy = self.prev_pos.y as f32 * cell_height + cell_height * 0.5;
                 let cur_cx = target_x + cell_width * 0.5;
@@ -482,6 +492,7 @@ impl CursorTrailState {
             }
         }
 
+        self.cursor_was_stable = dx + dy == 0;
         self.prev_pos = *current;
     }
 

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -483,8 +483,7 @@ impl CursorTrailState {
 
             let phase = if let Some(pending) = self.pending_jump {
                 let returned = pending.from.x == current.x && pending.from.y == current.y;
-                let timed_out =
-                    now.duration_since(pending.started_at).as_secs_f32() >= anim_length;
+                let timed_out = now.duration_since(pending.started_at).as_secs_f32() >= anim_length;
                 if returned {
                     self.pending_jump = None;
                     Phase::Snap

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -289,6 +289,27 @@ impl CursorTrailState {
         false
     }
 
+    /// Called when the cursor is hidden (`CursorVisibility::Hidden`).
+    ///
+    /// Silently tracks the new cursor position without spawning any effects and
+    /// clears all in-flight animation state (particles, highlight, smear corners,
+    /// pending jump) so that nothing is rendered while the cursor is invisible.
+    ///
+    /// `prev_initialized` is reset to `false` so that when the cursor becomes
+    /// visible again it snaps immediately to its position rather than triggering
+    /// a smear from the last known location.  This is O(1) — far cheaper than a
+    /// full `update()` call.
+    pub fn advance_hidden(&mut self, current: &StableCursorPosition) {
+        self.prev_pos = *current;
+        self.prev_initialized = false;
+        self.particles.clear();
+        self.highlight = None;
+        self.pending_jump = None;
+        for corner in self.smear_corners.iter_mut() {
+            corner.initialized = false;
+        }
+    }
+
     /// Called once per frame from `paint_pane`.
     ///
     /// - Ticks existing particles / highlight forward by `dt`.

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -205,10 +205,31 @@ pub struct CursorTrailState {
     /// False until the first update(); skips spawning on the first frame
     /// to avoid a bogus trail from (0,0) to the real cursor position.
     prev_initialized: bool,
-    /// True when the cursor did not move in the previous frame.
-    /// Used to suppress smear on rapid programmatic cursor movement (e.g. btop
-    /// redraws), which never lets the cursor settle between frames.
-    cursor_was_stable: bool,
+    /// A multi-cell jump that we've deferred for one or more update cycles
+    /// to see whether the cursor immediately bounces back to its anchor.
+    ///
+    /// Apps like btop in tmux keep the cursor parked at a fixed cell and
+    /// only briefly move it elsewhere during a redraw before snapping it
+    /// back. If we armed the smear the moment we observed the jump, every
+    /// such redraw would draw a flying cursor across the screen.
+    ///
+    /// Instead, on a multi-cell jump we record the source position here and
+    /// freeze the smear corners. On each subsequent frame:
+    ///   - if the cursor returns to `from`, we cancel the deferral (no smear);
+    ///   - if the cursor stabilises elsewhere, or we've held longer than the
+    ///     configured smear duration, we arm the smear belatedly;
+    ///   - otherwise (cursor still moving multi-cell) we keep holding.
+    ///
+    /// The hold timeout is `cursor_animation_length` itself: holding longer
+    /// than the smear's own duration is pointless because the smear we'd
+    /// eventually play would already have completed.
+    pending_jump: Option<PendingJump>,
+}
+
+#[derive(Copy, Clone)]
+pub struct PendingJump {
+    from: StableCursorPosition,
+    started_at: Instant,
 }
 
 impl CursorTrailState {
@@ -223,8 +244,18 @@ impl CursorTrailState {
             count_remainder: 0.0,
             rng: Rng::new(),
             prev_initialized: false,
-            cursor_was_stable: false,
+            pending_jump: None,
         }
+    }
+
+    /// True while a multi-cell jump is being deferred to detect bouncing.
+    /// During this state the smear corners are frozen at the pre-jump cell
+    /// so the cursor visually appears to *not* have moved yet — the render
+    /// path uses this to suppress the "cap" rectangle that would otherwise
+    /// betray the deferred destination.
+    #[inline]
+    pub fn is_smear_deferred(&self) -> bool {
+        self.pending_jump.is_some()
     }
 
     /// Returns true if there is anything to render this frame (particles / highlights).
@@ -412,27 +443,76 @@ impl CursorTrailState {
         }
 
         // ── Smear corners (Neovide-style 4-corner deforming smear) ───────────
+        //
+        // The interesting question is how to tell a real cursor jump (vim `G`,
+        // user click) from a btop-in-tmux redraw bounce. Both look the same in
+        // a single frame: the cursor moved several cells. The difference is
+        // what happens *next*: a real jump stays put for a while, while btop's
+        // redraw bounces the cursor back to its anchor within one or two
+        // frames.
+        //
+        // So instead of arming the smear immediately, we *defer* the first
+        // multi-cell jump for one update cycle. The corners are frozen at the
+        // pre-jump cell. The render path uses `is_smear_deferred()` to also
+        // suppress the cap rectangle, so the cursor visually appears to *not*
+        // have moved yet. On the next call we know how to resolve:
+        //
+        //   • cursor returned to the anchor → the bounce was an artefact,
+        //     cancel without ever drawing motion;
+        //   • cursor stabilised somewhere new → arm the smear belatedly,
+        //     1 frame of wall-clock latency;
+        //   • cursor still wandering → keep holding (handles multi-frame
+        //     bursts where tmux splits one btop redraw across several pushes);
+        //   • we've held longer than `cursor_animation_length` already →
+        //     give up and arm. Holding longer than the smear's own duration
+        //     makes no sense because the smear would already have completed.
         if cursor_smear {
             let offsets = self.cached_corner_offsets;
 
-            // On a cursor jump: assign per-corner speeds based on direction alignment.
-            // Leading corners (most aligned with movement) use a shorter duration so
-            // they race ahead, matching Neovide's `leading = animation_length * (1-trail_size)`.
-            //
-            // Only activate for multi-cell jumps (dx+dy > 1) to avoid distracting
-            // smear when typing or using single-cell hjkl navigation.
-            //
-            // Also require that the cursor was stable (not moving) in the previous
-            // frame. Apps like btop continuously move the cursor across the screen to
-            // redraw their TUI; those rapid programmatic moves never let the cursor
-            // settle, so `cursor_was_stable` stays false and no smear is triggered.
-            if dx + dy > 1 && self.cursor_was_stable {
-                let prev_cx = self.prev_pos.x as f32 * cell_width + cell_width * 0.5;
-                let prev_cy = self.prev_pos.y as f32 * cell_height + cell_height * 0.5;
+            #[derive(Copy, Clone)]
+            enum Phase {
+                Hold,
+                Snap,
+                Arm(StableCursorPosition),
+                Tick,
+            }
+
+            let phase = if let Some(pending) = self.pending_jump {
+                let returned = pending.from.x == current.x && pending.from.y == current.y;
+                let timed_out =
+                    now.duration_since(pending.started_at).as_secs_f32() >= anim_length;
+                if returned {
+                    self.pending_jump = None;
+                    Phase::Snap
+                } else if timed_out || dx + dy <= 1 {
+                    self.pending_jump = None;
+                    Phase::Arm(pending.from)
+                } else {
+                    Phase::Hold
+                }
+            } else if dx + dy > 1 {
+                self.pending_jump = Some(PendingJump {
+                    from: self.prev_pos,
+                    started_at: now,
+                });
+                Phase::Hold
+            } else if dx + dy > 0 {
+                Phase::Snap
+            } else {
+                Phase::Tick
+            };
+
+            // Compute per-corner speeds when arming from a deferred jump.
+            // The corners are still sitting at `from` (we never ticked them
+            // during the hold), so the smear naturally animates from there to
+            // the current cell as the corners tick toward it below.
+            if let Phase::Arm(from) = phase {
+                let from_cx = from.x as f32 * cell_width + cell_width * 0.5;
+                let from_cy = from.y as f32 * cell_height + cell_height * 0.5;
                 let cur_cx = target_x + cell_width * 0.5;
                 let cur_cy = target_y + cell_height * 0.5;
-                let move_dx = cur_cx - prev_cx;
-                let move_dy = cur_cy - prev_cy;
+                let move_dx = cur_cx - from_cx;
+                let move_dy = cur_cy - from_cy;
                 let move_dist = move_dx.hypot(move_dy);
 
                 if move_dist > 0.0 {
@@ -470,18 +550,23 @@ impl CursorTrailState {
                 }
             }
 
-            // Snap corners for single-cell moves (typing, hjkl) so no smear appears.
-            // Only let corners animate when we actually kicked off a multi-cell jump above.
-            if dx + dy > 0 && dx + dy <= 1 {
-                for (i, corner) in self.smear_corners.iter_mut().enumerate() {
-                    let (ox, oy) = offsets[i];
-                    corner.snap_to(target_x + ox * cell_width, target_y + oy * cell_height);
+            match phase {
+                Phase::Hold => {
+                    // Corners frozen at the pre-jump position. The render path
+                    // sees `is_smear_deferred() == true` and suppresses the cap
+                    // rect, so visually the cursor appears unmoved.
                 }
-            } else {
-                // Tick every corner toward its target (the 4 corners of the target cell).
-                for (i, corner) in self.smear_corners.iter_mut().enumerate() {
-                    let (ox, oy) = offsets[i];
-                    corner.tick(target_x + ox * cell_width, target_y + oy * cell_height, dt);
+                Phase::Snap => {
+                    for (i, corner) in self.smear_corners.iter_mut().enumerate() {
+                        let (ox, oy) = offsets[i];
+                        corner.snap_to(target_x + ox * cell_width, target_y + oy * cell_height);
+                    }
+                }
+                Phase::Arm(_) | Phase::Tick => {
+                    for (i, corner) in self.smear_corners.iter_mut().enumerate() {
+                        let (ox, oy) = offsets[i];
+                        corner.tick(target_x + ox * cell_width, target_y + oy * cell_height, dt);
+                    }
                 }
             }
         } else {
@@ -490,9 +575,9 @@ impl CursorTrailState {
             for corner in self.smear_corners.iter_mut() {
                 corner.initialized = false;
             }
+            self.pending_jump = None;
         }
 
-        self.cursor_was_stable = dx + dy == 0;
         self.prev_pos = *current;
     }
 

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -1,0 +1,620 @@
+use config::CursorTrailStyle;
+use mux::renderable::StableCursorPosition;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+use termwiz::surface::CursorShape;
+
+// ── Performance cap ────────────────────────────────────────────────────────────
+const MAX_PARTICLES: usize = 256;
+
+// ── Fast PRNG ─────────────────────────────────────────────────────────────────
+// xorshift64 with a global atomic counter as per-instance seed.
+
+#[inline(always)]
+fn ease_out_factor(rate: f32, dt: f32) -> f32 {
+    let x = rate * dt;
+    if x < 1.0 {
+        let x2 = x * x;
+        x - x2 * 0.5 + x2 * x * (1.0 / 6.0)
+    } else {
+        1.0 - (-x).exp()
+    }
+}
+
+struct Rng(u64);
+
+impl Rng {
+    fn new() -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0x517cc1b727220a95);
+        // Fibonacci hashing increment keeps successive seeds well-distributed.
+        let seed = COUNTER.fetch_add(0x9e3779b97f4a7c15, Ordering::Relaxed);
+        Self(if seed == 0 { 1 } else { seed })
+    }
+
+    #[inline(always)]
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    /// Returns a value in [0, 1).
+    #[inline(always)]
+    fn next_f32(&mut self) -> f32 {
+        // Use top 23 mantissa bits for uniform f32 in [0, 1)
+        (self.next_u64() >> 41) as f32 * (1.0 / (1u64 << 23) as f32)
+    }
+}
+
+// ── Neovide-style smear corners ───────────────────────────────────────────────
+// Four independent corner animations (TL, TR, BR, BL).  Leading corners (most
+// aligned with movement) get a faster speed so they race ahead; trailing corners
+// use the full animation duration and lag behind.  The cursor body is then drawn
+// as the free-form quad connecting the four animated positions — identical in
+// principle to Neovide's PathBuilder(corners[0..3]) approach.
+
+/// Fractional corner offsets from the cell top-left, in cell units.
+/// Order: 0=TL, 1=TR, 2=BR, 3=BL — matching Neovide's STANDARD_CORNERS draw order.
+pub const CORNER_OFFSETS: [(f32, f32); 4] = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)];
+
+/// Normalised direction from cell centre to each corner (used for alignment ranking).
+/// centre is at (0.5, 0.5) in cell-relative coords; INV_SQRT2 ≈ 1/√2.
+const CORNER_DIR: [(f32, f32); 4] = {
+    const F: f32 = std::f32::consts::FRAC_1_SQRT_2;
+    [(-F, -F), (F, -F), (F, F), (-F, F)]
+};
+
+/// Returns shape-adjusted corner offsets in cell units.
+///
+/// Matches Neovide's `set_cursor_shape` which adjusts `relative_position` per shape:
+/// - **Block**: full cell corners `(0,0)→(1,1)`
+/// - **Bar**: compressed horizontally to `cell_percentage` width, like Neovide's
+///   `Vertical => ((x + 0.5) * cell_percentage - 0.5, y)`
+/// - **Underline**: compressed vertically to the bottom `cell_percentage` of the cell,
+///   like Neovide's `Horizontal => (x, -((-y + 0.5) * cell_percentage - 0.5))`
+pub fn shape_corner_offsets(
+    shape: CursorShape,
+    cell_width: f32,
+    cell_height: f32,
+) -> [(f32, f32); 4] {
+    const CELL_PERCENTAGE: f32 = 1.0 / 8.0;
+    match shape {
+        CursorShape::BlinkingBar | CursorShape::SteadyBar => {
+            let bar_frac = (CELL_PERCENTAGE).max(2.0 / cell_width);
+            [(0.0, 0.0), (bar_frac, 0.0), (bar_frac, 1.0), (0.0, 1.0)]
+        }
+        CursorShape::BlinkingUnderline | CursorShape::SteadyUnderline => {
+            let ul_h = (cell_height * 0.1).max(2.0);
+            let ul_frac = (ul_h / cell_height).min(1.0);
+            let top_frac = 1.0 - ul_frac;
+            [(0.0, top_frac), (1.0, top_frac), (1.0, 1.0), (0.0, 1.0)]
+        }
+        _ => CORNER_OFFSETS,
+    }
+}
+
+/// One independently animated cursor corner for the Neovide-style deforming smear.
+pub struct SmearCorner {
+    /// Current rendered position in stable pane-relative pixel space:
+    ///   x = column * cell_width,  y = row * cell_height
+    pub visual_x: f32,
+    pub visual_y: f32,
+    initialized: bool,
+    /// Exponential-ease speed for this corner; updated each time the cursor jumps.
+    speed: f32,
+}
+
+impl SmearCorner {
+    fn new() -> Self {
+        SmearCorner {
+            visual_x: 0.0,
+            visual_y: 0.0,
+            initialized: false,
+            speed: 0.0,
+        }
+    }
+
+    /// True while this corner hasn't yet reached its target position.
+    pub fn is_animating(&self, target_x: f32, target_y: f32) -> bool {
+        self.initialized
+            && ((self.visual_x - target_x).abs() > 0.5 || (self.visual_y - target_y).abs() > 0.5)
+    }
+
+    fn snap_to(&mut self, x: f32, y: f32) {
+        self.visual_x = x;
+        self.visual_y = y;
+        self.initialized = true;
+    }
+
+    fn tick(&mut self, target_x: f32, target_y: f32, dt: f32) {
+        if !self.initialized || self.speed <= 0.0 {
+            self.snap_to(target_x, target_y);
+            return;
+        }
+        let factor = ease_out_factor(self.speed * 10.0, dt);
+        self.visual_x += (target_x - self.visual_x) * factor;
+        self.visual_y += (target_y - self.visual_y) * factor;
+        if (self.visual_x - target_x).abs() < 0.5 {
+            self.visual_x = target_x;
+        }
+        if (self.visual_y - target_y).abs() < 0.5 {
+            self.visual_y = target_y;
+        }
+    }
+}
+
+// ── Particle ──────────────────────────────────────────────────────────────────
+
+pub struct Particle {
+    /// Position in stable pixel space:
+    ///   x = column_in_pane * cell_width  (+half cell for centering)
+    ///   y = stable_row     * cell_height (+half cell for centering)
+    pub x: f32,
+    pub y: f32,
+    pub vx: f32,
+    pub vy: f32,
+    /// Angular velocity of the velocity vector (rad/sec).  Non-zero for Railgun.
+    pub rotation_speed: f32,
+    pub lifetime: f32,
+    pub max_lifetime: f32,
+}
+
+// ── Highlight (single-point expanding effects) ────────────────────────────────
+
+/// Which kind of expanding highlight to draw.
+pub enum HighlightKind {
+    /// Expanding filled square.
+    SonicBoom { cx: f32, cy: f32 },
+    /// Expanding hollow ring (four thin rectangles).
+    Ripple { cx: f32, cy: f32 },
+    /// Expanding hollow rectangle (cell aspect ratio).
+    Wireframe {
+        cx: f32,
+        cy: f32,
+        cell_w: f32,
+        cell_h: f32,
+    },
+}
+
+/// A single-point, time-driven highlight animation.
+pub struct PointHighlight {
+    /// Normalised progress: 0.0 (just born) → 1.0 (expired).
+    pub t: f32,
+    pub kind: HighlightKind,
+}
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+pub struct CursorTrailState {
+    pub particles: Vec<Particle>,
+    pub highlight: Option<PointHighlight>,
+    /// Four independently animated corners for Neovide-style deforming smear.
+    /// Order: TL=0, TR=1, BR=2, BL=3.
+    pub smear_corners: [SmearCorner; 4],
+    /// Shape-adjusted corner offsets computed once per frame in update().
+    /// Used by has_smear_animation() and paint_animated_cursor().
+    cached_corner_offsets: [(f32, f32); 4],
+    prev_pos: StableCursorPosition,
+    last_tick: Instant,
+    /// Fractional carry so density is respected across frames.
+    count_remainder: f32,
+    rng: Rng,
+    /// False until the first update(); skips spawning on the first frame
+    /// to avoid a bogus trail from (0,0) to the real cursor position.
+    prev_initialized: bool,
+}
+
+impl CursorTrailState {
+    pub fn new() -> Self {
+        CursorTrailState {
+            particles: Vec::new(),
+            highlight: None,
+            smear_corners: std::array::from_fn(|_| SmearCorner::new()),
+            cached_corner_offsets: CORNER_OFFSETS,
+            prev_pos: StableCursorPosition::default(),
+            last_tick: Instant::now(),
+            count_remainder: 0.0,
+            rng: Rng::new(),
+            prev_initialized: false,
+        }
+    }
+
+    /// Returns true if there is anything to render this frame (particles / highlights).
+    #[inline]
+    pub fn has_active_animation(&self) -> bool {
+        !self.particles.is_empty() || self.highlight.is_some()
+    }
+
+    /// Returns the shape-adjusted corner offsets cached during the last `update()`.
+    #[inline]
+    pub fn corner_offsets(&self) -> &[(f32, f32); 4] {
+        &self.cached_corner_offsets
+    }
+
+    /// Returns true if any of the four smear corners haven't reached the target yet.
+    /// Uses `cached_corner_offsets` computed during the last `update()`.
+    pub fn has_smear_animation(
+        &self,
+        target_x: f32,
+        target_y: f32,
+        cell_width: f32,
+        cell_height: f32,
+    ) -> bool {
+        let offsets = self.cached_corner_offsets;
+        for (i, corner) in self.smear_corners.iter().enumerate() {
+            let (ox, oy) = offsets[i];
+            if corner.is_animating(target_x + ox * cell_width, target_y + oy * cell_height) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Called once per frame from `paint_pane`.
+    ///
+    /// - Ticks existing particles / highlight forward by `dt`.
+    /// - Spawns new particles / resets highlight if the cursor moved far enough.
+    /// - Removes expired particles inline (O(n) swap-remove, no allocation).
+    pub fn update(
+        &mut self,
+        current: &StableCursorPosition,
+        cell_width: f32,
+        cell_height: f32,
+        min_distance: usize,
+        style: Option<CursorTrailStyle>,
+        density: f32,
+        lifetime: f32,
+        speed: f32,
+        cursor_smear: bool,
+        anim_length: f32,
+        trail_size: f32,
+        cursor_shape: CursorShape,
+        now: Instant,
+    ) {
+        let dt = now.duration_since(self.last_tick).as_secs_f32().min(0.1);
+        self.last_tick = now;
+
+        self.cached_corner_offsets = shape_corner_offsets(cursor_shape, cell_width, cell_height);
+
+        let target_x = current.x as f32 * cell_width;
+        let target_y = current.y as f32 * cell_height;
+        let dx = (current.x as isize - self.prev_pos.x as isize).unsigned_abs();
+        let dy = (current.y as isize - self.prev_pos.y as isize).unsigned_abs();
+
+        if !self.prev_initialized {
+            self.prev_pos = *current;
+            self.prev_initialized = true;
+            return;
+        }
+
+        // ── Tick particles ────────────────────────────────────────────────────
+        for p in &mut self.particles {
+            p.lifetime -= dt;
+            p.x += p.vx * dt;
+            p.y += p.vy * dt;
+
+            if p.rotation_speed != 0.0 {
+                let (sin_a, cos_a) = (p.rotation_speed * dt).sin_cos();
+                let vx = p.vx * cos_a - p.vy * sin_a;
+                let vy = p.vx * sin_a + p.vy * cos_a;
+                p.vx = vx;
+                p.vy = vy;
+            }
+        }
+
+        // O(1) swap-remove: dead particles replaced by the last element.
+        let mut i = 0;
+        while i < self.particles.len() {
+            if self.particles[i].lifetime <= 0.0 {
+                self.particles.swap_remove(i);
+            } else {
+                i += 1;
+            }
+        }
+        if self.particles.is_empty() && self.particles.capacity() > MAX_PARTICLES * 2 {
+            self.particles.shrink_to(MAX_PARTICLES);
+        }
+
+        // ── Tick highlight ────────────────────────────────────────────────────
+        if let Some(ref mut h) = self.highlight {
+            if lifetime > 0.0 {
+                h.t += dt / lifetime;
+            } else {
+                h.t = 1.0;
+            }
+            if h.t >= 1.0 {
+                self.highlight = None;
+            }
+        }
+
+        // ── Spawn on movement ─────────────────────────────────────────────────
+        let half_w = cell_width * 0.5;
+        let half_h = cell_height * 0.5;
+
+        match style {
+            // No particle style configured: smear (if enabled) is the sole effect.
+            None => {}
+
+            // Particle styles: trigger when cursor moves at least min_distance cells.
+            Some(
+                CursorTrailStyle::Railgun | CursorTrailStyle::Torpedo | CursorTrailStyle::PixieDust,
+            ) => {
+                if dx + dy >= min_distance {
+                    let from_px = self.prev_pos.x as f32 * cell_width + half_w;
+                    let from_py = self.prev_pos.y as f32 * cell_height + half_h;
+                    let to_px = target_x + half_w;
+                    let to_py = target_y + half_h;
+                    let dist_x = to_px - from_px;
+                    let dist_y = to_py - from_py;
+                    let distance = dist_x.hypot(dist_y);
+                    self.spawn_trail_particles(
+                        from_px,
+                        from_py,
+                        dist_x,
+                        dist_y,
+                        distance,
+                        cell_height,
+                        density,
+                        lifetime,
+                        speed,
+                        style.unwrap(),
+                    );
+                }
+            }
+
+            // Highlight styles: trigger once per discrete cell move.
+            Some(inner_style) => {
+                if dx + dy >= min_distance {
+                    let to_px = target_x + half_w;
+                    let to_py = target_y + half_h;
+                    match inner_style {
+                        CursorTrailStyle::SonicBoom => {
+                            self.highlight = Some(PointHighlight {
+                                t: 0.0,
+                                kind: HighlightKind::SonicBoom {
+                                    cx: to_px,
+                                    cy: to_py,
+                                },
+                            });
+                        }
+                        CursorTrailStyle::Ripple => {
+                            self.highlight = Some(PointHighlight {
+                                t: 0.0,
+                                kind: HighlightKind::Ripple {
+                                    cx: to_px,
+                                    cy: to_py,
+                                },
+                            });
+                        }
+                        CursorTrailStyle::Wireframe => {
+                            self.highlight = Some(PointHighlight {
+                                t: 0.0,
+                                kind: HighlightKind::Wireframe {
+                                    cx: to_px,
+                                    cy: to_py,
+                                    cell_w: cell_width,
+                                    cell_h: cell_height,
+                                },
+                            });
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // ── Smear corners (Neovide-style 4-corner deforming smear) ───────────
+        if cursor_smear {
+            let offsets = self.cached_corner_offsets;
+
+            // On a cursor jump: assign per-corner speeds based on direction alignment.
+            // Leading corners (most aligned with movement) use a shorter duration so
+            // they race ahead, matching Neovide's `leading = animation_length * (1-trail_size)`.
+            //
+            // Only activate for multi-cell jumps (dx+dy > 1) to avoid distracting
+            // smear when typing or using single-cell hjkl navigation.
+            if dx + dy > 1 {
+                let prev_cx = self.prev_pos.x as f32 * cell_width + cell_width * 0.5;
+                let prev_cy = self.prev_pos.y as f32 * cell_height + cell_height * 0.5;
+                let cur_cx = target_x + cell_width * 0.5;
+                let cur_cy = target_y + cell_height * 0.5;
+                let move_dx = cur_cx - prev_cx;
+                let move_dy = cur_cy - prev_cy;
+                let move_dist = move_dx.hypot(move_dy);
+
+                if move_dist > 0.0 {
+                    let travel_x = move_dx / move_dist;
+                    let travel_y = move_dy / move_dist;
+
+                    // alignment[i] = dot(corner_dir[i], travel_dir): +1 = fully leading.
+                    let alignments: [f32; 4] = std::array::from_fn(|i| {
+                        CORNER_DIR[i].0 * travel_x + CORNER_DIR[i].1 * travel_y
+                    });
+
+                    // Sort by descending alignment to assign ranks 0 (trailing) – 3 (leading).
+                    let mut order = [0usize, 1, 2, 3];
+                    order.sort_by(|&a, &b| {
+                        alignments[b]
+                            .partial_cmp(&alignments[a])
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    });
+                    let mut ranks = [0usize; 4];
+                    for (rank_from_back, &idx) in order.iter().rev().enumerate() {
+                        ranks[idx] = rank_from_back;
+                    }
+
+                    // Duration per rank (matching Neovide's jump() logic).
+                    let leading_dur = (anim_length * (1.0 - trail_size).max(0.05)).max(0.005);
+                    let trailing_dur = anim_length.max(0.005);
+                    for (i, corner) in self.smear_corners.iter_mut().enumerate() {
+                        let dur = match ranks[i] {
+                            3 | 2 => leading_dur,
+                            1 => (leading_dur + trailing_dur) * 0.5,
+                            _ => trailing_dur,
+                        };
+                        corner.speed = 0.3 / dur;
+                    }
+                }
+            }
+
+            // Snap corners for single-cell moves (typing, hjkl) so no smear appears.
+            // Only let corners animate when we actually kicked off a multi-cell jump above.
+            if dx + dy > 0 && dx + dy <= 1 {
+                for (i, corner) in self.smear_corners.iter_mut().enumerate() {
+                    let (ox, oy) = offsets[i];
+                    corner.snap_to(target_x + ox * cell_width, target_y + oy * cell_height);
+                }
+            } else {
+                // Tick every corner toward its target (the 4 corners of the target cell).
+                for (i, corner) in self.smear_corners.iter_mut().enumerate() {
+                    let (ox, oy) = offsets[i];
+                    corner.tick(target_x + ox * cell_width, target_y + oy * cell_height, dt);
+                }
+            }
+        } else {
+            // Smear disabled: mark corners uninitialized so re-enabling snaps them
+            // to the correct target on the first tick, with no coordinate math here.
+            for corner in self.smear_corners.iter_mut() {
+                corner.initialized = false;
+            }
+        }
+
+        self.prev_pos = *current;
+    }
+
+    // ── Particle spawning ─────────────────────────────────────────────────────
+
+    fn spawn_trail_particles(
+        &mut self,
+        from_px: f32,
+        from_py: f32,
+        dist_x: f32,
+        dist_y: f32,
+        distance: f32,
+        cell_height: f32,
+        density: f32,
+        lifetime: f32,
+        speed: f32,
+        style: CursorTrailStyle,
+    ) {
+        if distance < 0.1 {
+            return;
+        }
+
+        // How many particles to spawn this movement.
+        let raw = (distance / cell_height) * density + self.count_remainder;
+        let count = raw.floor() as usize;
+        self.count_remainder = raw - count as f32;
+
+        // Never exceed the global cap.
+        let spare = MAX_PARTICLES.saturating_sub(self.particles.len());
+        let count = count.min(spare);
+        if count == 0 {
+            return;
+        }
+
+        let dir_x = dist_x / distance;
+        let dir_y = dist_y / distance;
+        // Perpendicular (90° counter-clockwise).
+        let base_speed = cell_height * speed; // pixels / sec
+
+        match style {
+            CursorTrailStyle::Railgun => {
+                use std::f32::consts::PI;
+                // Neovide-matching Railgun:
+                // - Particles placed on the straight travel path (no sinusoidal offset)
+                // - Velocity fans out in screen-space via (sin, cos) of a phase that
+                //   grows with position along the trail and travel distance
+                // - Lifetime = t * max so near-origin particles are born dim and die
+                //   fast, reproducing Neovide's characteristic fading-tail look
+                // - Rotation: PI rad/sec (Neovide default vfx_particle_curl = 1.0)
+                const PHASE_FACTOR: f32 = 1.5; // Neovide vfx_particle_phase default
+                const CURL: f32 = 1.0; // Neovide vfx_particle_curl default
+                for i in 0..count {
+                    // t: 1/count → 1.0, matching Neovide's (i+1)/count indexing
+                    let t = (i + 1) as f32 / count as f32;
+                    // Spawn on the straight travel line
+                    let px = from_px + dist_x * t;
+                    let py = from_py + dist_y * t;
+                    // Phase matches Neovide: t / PI * phase_factor * (distance / height)
+                    let phase = t / PI * PHASE_FACTOR * (distance / cell_height);
+                    // Velocity: rotate the travel-direction vector by -phase.
+                    // This fans particles around the movement axis, so the effect
+                    // looks consistent for both horizontal and vertical movement.
+                    // For vertical-down (dir=(0,1)) this reduces to (sin,cos)*speed,
+                    // exactly matching Neovide's screen-space formula.
+                    let vx = (dir_x * phase.cos() + dir_y * phase.sin()) * base_speed * 2.0;
+                    let vy = (-dir_x * phase.sin() + dir_y * phase.cos()) * base_speed * 2.0;
+                    // lifetime = t * max so life_frac = t * remaining_fraction.
+                    // Near-origin particles (small t) are born dim and die quickly.
+                    self.particles.push(Particle {
+                        x: px,
+                        y: py,
+                        vx,
+                        vy,
+                        rotation_speed: PI * CURL,
+                        lifetime: t * lifetime,
+                        max_lifetime: lifetime,
+                    });
+                }
+            }
+            CursorTrailStyle::Torpedo => {
+                for i in 0..count {
+                    let t = (i + 1) as f32 / count as f32;
+                    let rand_t = self.rng.next_f32();
+                    let px = from_px + dist_x * rand_t;
+                    let py = from_py + dist_y * rand_t;
+                    let rx = self.rng.next_f32() * 2.0 - 1.0;
+                    let ry = self.rng.next_f32() * 2.0 - 1.0;
+                    let rl = rx.hypot(ry).max(1e-6);
+                    let rnx = rx / rl;
+                    let rny = ry / rl;
+                    let pdx = rnx - dir_x * 1.5;
+                    let pdy = rny - dir_y * 1.5;
+                    let pdl = pdx.hypot(pdy).max(1e-6);
+                    let vx = pdx / pdl * base_speed;
+                    let vy = pdy / pdl * base_speed;
+                    let curl = (self.rng.next_f32() - 0.5) * std::f32::consts::FRAC_PI_2;
+                    self.particles.push(Particle {
+                        x: px,
+                        y: py,
+                        vx,
+                        vy,
+                        rotation_speed: curl,
+                        lifetime: t * lifetime,
+                        max_lifetime: lifetime,
+                    });
+                }
+            }
+            CursorTrailStyle::PixieDust => {
+                for i in 0..count {
+                    let t = (i + 1) as f32 / count as f32;
+                    let rand_t = self.rng.next_f32();
+                    let px = from_px + dist_x * rand_t;
+                    let py = from_py + dist_y * rand_t;
+                    let rx = self.rng.next_f32() * 2.0 - 1.0;
+                    let ry = self.rng.next_f32() * 2.0 - 1.0;
+                    let rl = rx.hypot(ry).max(1e-6);
+                    let rnx = rx / rl;
+                    let rny = ry / rl;
+                    let vx = rnx * 0.5 * 3.0 * base_speed;
+                    let vy = (0.4 + rny.abs()) * 3.0 * base_speed;
+                    let curl = (self.rng.next_f32() - 0.5) * std::f32::consts::FRAC_PI_2;
+                    self.particles.push(Particle {
+                        x: px,
+                        y: py,
+                        vx,
+                        vy,
+                        rotation_speed: curl,
+                        lifetime: t * lifetime,
+                        max_lifetime: lifetime,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -227,7 +227,7 @@ pub struct CursorTrailState {
 }
 
 #[derive(Copy, Clone)]
-pub struct PendingJump {
+struct PendingJump {
     from: StableCursorPosition,
     started_at: Instant,
 }
@@ -459,10 +459,14 @@ impl CursorTrailState {
         //
         //   • cursor returned to the anchor → the bounce was an artefact,
         //     cancel without ever drawing motion;
-        //   • cursor stabilised somewhere new → arm the smear belatedly,
-        //     1 frame of wall-clock latency;
-        //   • cursor still wandering → keep holding (handles multi-frame
-        //     bursts where tmux splits one btop redraw across several pushes);
+        //   • cursor stopped or shrank to a single-cell move (`dx + dy <= 1`)
+        //     → arm the smear belatedly. Single-cell continuations are
+        //     user-driven (typing, hjkl) and never part of a btop burst, so
+        //     we treat them as confirming intent. Total latency in this path
+        //     is one wezterm frame;
+        //   • cursor still wandering multi-cell → keep holding (handles
+        //     multi-frame bursts where tmux splits one btop redraw across
+        //     several pushes);
         //   • we've held longer than `cursor_animation_length` already →
         //     give up and arm. Holding longer than the smear's own duration
         //     makes no sense because the smear would already have completed.
@@ -491,10 +495,27 @@ impl CursorTrailState {
                     Phase::Hold
                 }
             } else if dx + dy > 1 {
+                // Transitioning into Hold for the first time: snap the corners
+                // to the pre-jump cell. Without this, two edge cases would
+                // make the cursor disappear or look distorted while held:
+                //   • corners still uninitialized (e.g. just after enabling
+                //     cursor_smear) → has_smear_animation() returns false, no
+                //     quad drawn, and is_smear_deferred() suppresses the cap
+                //     too — the cursor is invisible for the entire hold;
+                //   • corners mid-animation from a previous smear → freezing
+                //     them in flight leaves a distorted quad instead of a
+                //     stable cursor block at the anchor.
+                let from = self.prev_pos;
                 self.pending_jump = Some(PendingJump {
-                    from: self.prev_pos,
+                    from,
                     started_at: now,
                 });
+                let from_x = from.x as f32 * cell_width;
+                let from_y = from.y as f32 * cell_height;
+                for (i, corner) in self.smear_corners.iter_mut().enumerate() {
+                    let (ox, oy) = offsets[i];
+                    corner.snap_to(from_x + ox * cell_width, from_y + oy * cell_height);
+                }
                 Phase::Hold
             } else if dx + dy > 0 {
                 Phase::Snap

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -356,13 +356,23 @@ impl CursorTrailState {
         }
 
         // ── Tick particles ────────────────────────────────────────────────────
+        // A tiny (rotation_speed, sin, cos) cache avoids recomputing sin_cos for
+        // every particle.  Railgun particles all share rotation_speed = π, so
+        // the cache turns ~256 sin_cos calls per frame into just one.
+        let mut sincos_cache: (f32, f32, f32) = (f32::NAN, 0.0, 1.0);
         for p in &mut self.particles {
             p.lifetime -= dt;
             p.x += p.vx * dt;
             p.y += p.vy * dt;
 
             if p.rotation_speed != 0.0 {
-                let (sin_a, cos_a) = (p.rotation_speed * dt).sin_cos();
+                let (sin_a, cos_a) = if p.rotation_speed == sincos_cache.0 {
+                    (sincos_cache.1, sincos_cache.2)
+                } else {
+                    let (s, c) = (p.rotation_speed * dt).sin_cos();
+                    sincos_cache = (p.rotation_speed, s, c);
+                    (s, c)
+                };
                 let vx = p.vx * cos_a - p.vy * sin_a;
                 let vy = p.vx * sin_a + p.vy * cos_a;
                 p.vx = vx;
@@ -405,7 +415,9 @@ impl CursorTrailState {
 
             // Particle styles: trigger when cursor moves at least min_distance cells.
             Some(
-                CursorTrailStyle::Railgun | CursorTrailStyle::Torpedo | CursorTrailStyle::PixieDust,
+                inner @ (CursorTrailStyle::Railgun
+                | CursorTrailStyle::Torpedo
+                | CursorTrailStyle::PixieDust),
             ) => {
                 if dx + dy >= min_distance {
                     let from_px = self.prev_pos.x as f32 * cell_width + half_w;
@@ -425,7 +437,7 @@ impl CursorTrailState {
                         density,
                         lifetime,
                         speed,
-                        style.unwrap(),
+                        inner,
                     );
                 }
             }

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -197,6 +197,9 @@ pub struct CursorTrailState {
     /// Shape-adjusted corner offsets computed once per frame in update().
     /// Used by has_smear_animation() and paint_animated_cursor().
     cached_corner_offsets: [(f32, f32); 4],
+    /// (cursor_shape, cell_width bits, cell_height bits) that produced
+    /// `cached_corner_offsets`.  Re-computed only when this key changes.
+    cached_corner_key: (CursorShape, u32, u32),
     prev_pos: StableCursorPosition,
     last_tick: Instant,
     /// Fractional carry so density is respected across frames.
@@ -239,6 +242,7 @@ impl CursorTrailState {
             highlight: None,
             smear_corners: std::array::from_fn(|_| SmearCorner::new()),
             cached_corner_offsets: CORNER_OFFSETS,
+            cached_corner_key: (CursorShape::Default, 0, 0),
             prev_pos: StableCursorPosition::default(),
             last_tick: Instant::now(),
             count_remainder: 0.0,
@@ -334,7 +338,11 @@ impl CursorTrailState {
         let dt = now.duration_since(self.last_tick).as_secs_f32().min(0.1);
         self.last_tick = now;
 
-        self.cached_corner_offsets = shape_corner_offsets(cursor_shape, cell_width, cell_height);
+        let corner_key = (cursor_shape, cell_width.to_bits(), cell_height.to_bits());
+        if corner_key != self.cached_corner_key {
+            self.cached_corner_offsets = shape_corner_offsets(cursor_shape, cell_width, cell_height);
+            self.cached_corner_key = corner_key;
+        }
 
         let target_x = current.x as f32 * cell_width;
         let target_y = current.y as f32 * cell_height;

--- a/wezterm-gui/src/termwindow/cursortrail.rs
+++ b/wezterm-gui/src/termwindow/cursortrail.rs
@@ -223,7 +223,7 @@ pub struct CursorTrailState {
     ///     configured smear duration, we arm the smear belatedly;
     ///   - otherwise (cursor still moving multi-cell) we keep holding.
     ///
-    /// The hold timeout is `cursor_animation_length` itself: holding longer
+    /// The hold timeout is `cursor_animation_duration` itself: holding longer
     /// than the smear's own duration is pointless because the smear we'd
     /// eventually play would already have completed.
     pending_jump: Option<PendingJump>,
@@ -508,7 +508,7 @@ impl CursorTrailState {
         //   • cursor still wandering multi-cell → keep holding (handles
         //     multi-frame bursts where tmux splits one btop redraw across
         //     several pushes);
-        //   • we've held longer than `cursor_animation_length` already →
+        //   • we've held longer than `cursor_animation_duration` already →
         //     give up and arm. Holding longer than the smear's own duration
         //     makes no sense because the smear would already have completed.
         if cursor_smear {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -18,6 +18,7 @@ use crate::tabbar::{TabBarItem, TabBarState};
 use crate::termwindow::background::{
     load_background_image, reload_background_image, LoadedBackgroundLayer,
 };
+use crate::termwindow::cursortrail::CursorTrailState;
 use crate::termwindow::keyevent::{KeyTableArgs, KeyTableState};
 use crate::termwindow::modal::Modal;
 use crate::termwindow::render::paint::AllowImage;
@@ -72,6 +73,7 @@ pub mod background;
 pub mod box_model;
 pub mod charselect;
 pub mod clipboard;
+mod cursortrail;
 pub mod keyevent;
 pub mod modal;
 mod mouseevent;
@@ -401,6 +403,7 @@ pub struct TermWindow {
     window_drag_position: Option<MouseEvent>,
     current_mouse_event: Option<MouseEvent>,
     prev_cursor: PrevCursorPos,
+    cursor_trail_states: RefCell<HashMap<PaneId, CursorTrailState>>,
     last_scroll_info: RenderableDimensions,
 
     tab_state: RefCell<HashMap<TabId, TabState>>,
@@ -719,6 +722,7 @@ impl TermWindow {
             current_mouse_event: None,
             current_modifier_and_leds: Default::default(),
             prev_cursor: PrevCursorPos::new(),
+            cursor_trail_states: RefCell::new(HashMap::new()),
             last_scroll_info: RenderableDimensions::default(),
             tab_state: RefCell::new(HashMap::new()),
             pane_state: RefCell::new(HashMap::new()),
@@ -1308,9 +1312,11 @@ impl TermWindow {
                 MuxNotification::TabTitleChanged { .. } => {
                     self.update_title_post_status();
                 }
+                MuxNotification::PaneRemoved(pane_id) => {
+                    self.cursor_trail_states.borrow_mut().remove(&pane_id);
+                }
                 MuxNotification::PaneAdded(_)
                 | MuxNotification::WorkspaceRenamed { .. }
-                | MuxNotification::PaneRemoved(_)
                 | MuxNotification::WindowWorkspaceChanged(_)
                 | MuxNotification::ActiveWorkspaceChanged(_)
                 | MuxNotification::Empty
@@ -1777,6 +1783,7 @@ impl TermWindow {
         );
 
         self.show_scroll_bar = config.enable_scroll_bar;
+        self.cursor_trail_states.borrow_mut().clear();
         self.shape_generation += 1;
         {
             let mut shape_cache = self.shape_cache.borrow_mut();

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -286,6 +286,68 @@ impl crate::TermWindow {
         Ok(quad)
     }
 
+    /// Draw a free-form quadrilateral cursor smear with four fully independent
+    /// corner positions (Neovide-style deforming cursor body).
+    ///
+    /// Corners are in SCREEN pixel coordinates; order matches Neovide's draw path:
+    ///   tl = top-left, tr = top-right, br = bottom-right, bl = bottom-left.
+    /// `corner_alphas`: per-corner alpha multipliers in TL/TR/BR/BL order.
+    /// When `None` all four corners use the base `color` alpha unchanged.
+    /// Pass `Some([a0,a1,a2,a3])` to implement a gradient (e.g. trailing
+    /// corners fade to 0.0 for the `cursor_smear_gradient` effect).
+    pub fn draw_cursor_deformed_quad(
+        &self,
+        layers: &mut TripleLayerQuadAllocator,
+        layer_num: usize,
+        tl: (f32, f32),
+        tr: (f32, f32),
+        br: (f32, f32),
+        bl: (f32, f32),
+        color: LinearRgba,
+        corner_alphas: Option<[f32; 4]>,
+    ) {
+        use crate::quad::{Vertex, V_BOT_LEFT, V_BOT_RIGHT, V_TOP_LEFT, V_TOP_RIGHT};
+
+        let left_offset = self.dimensions.pixel_width as f32 / 2.0;
+        let top_offset = self.dimensions.pixel_height as f32 / 2.0;
+
+        let gl_state = match self.render_state.as_ref() {
+            Some(s) => s,
+            None => return,
+        };
+        let tex = gl_state.util_sprites.filled_box.texture_coords();
+        let (tx1, tx2, ty1, ty2) = (tex.min_x(), tex.max_x(), tex.min_y(), tex.max_y());
+
+        const IS_SOLID_COLOR: f32 = 3.0;
+        let (r, g, b, a) = color.tuple();
+
+        let col_for = |idx: usize| -> [f32; 4] {
+            let alpha = match corner_alphas {
+                Some(ref alphas) => alphas[idx],
+                None => a,
+            };
+            [r, g, b, alpha]
+        };
+
+        let mk = |px: f32, py: f32, u: f32, v: f32, col: [f32; 4]| Vertex {
+            position: [px - left_offset, py - top_offset],
+            tex: [u, v],
+            fg_color: col,
+            alt_color: col,
+            hsv: [1.0, 1.0, 1.0],
+            has_color: IS_SOLID_COLOR,
+            mix_value: 0.0,
+        };
+
+        let mut verts = [Vertex::default(); 4];
+        verts[V_TOP_LEFT] = mk(tl.0, tl.1, tx1, ty1, col_for(0));
+        verts[V_TOP_RIGHT] = mk(tr.0, tr.1, tx2, ty1, col_for(1));
+        verts[V_BOT_LEFT] = mk(bl.0, bl.1, tx1, ty2, col_for(3));
+        verts[V_BOT_RIGHT] = mk(br.0, br.1, tx2, ty2, col_for(2));
+
+        layers.extend_with(layer_num, &verts);
+    }
+
     pub fn poly_quad<'a>(
         &self,
         layers: &'a mut TripleLayerQuadAllocator,

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -18,6 +18,7 @@ use ordered_float::NotNan;
 use std::time::Instant;
 use wezterm_dynamic::Value;
 use wezterm_term::color::{ColorAttribute, ColorPalette};
+use termwiz::surface::CursorVisibility;
 use wezterm_term::{Line, StableRowIndex};
 use window::color::LinearRgba;
 
@@ -607,37 +608,61 @@ impl crate::TermWindow {
                 || config.cursor_animation_length > 0.0)
         {
             let now = Instant::now();
+            let cursor_visible = cursor.visibility == CursorVisibility::Visible;
 
             {
                 let cell_width = self.render_metrics.cell_size.width as f32;
                 let cell_height = self.render_metrics.cell_size.height as f32;
                 let mut trails = self.cursor_trail_states.borrow_mut();
                 let trail = trails.entry(pane_id).or_insert_with(CursorTrailState::new);
-                trail.update(
-                    &cursor,
-                    cell_width,
-                    cell_height,
-                    config.cursor_trail_min_distance,
-                    config.cursor_trail_style,
-                    config.cursor_vfx_particle_density,
-                    config.cursor_vfx_particle_lifetime,
-                    config.cursor_vfx_particle_speed,
-                    config.cursor_smear,
-                    config.cursor_animation_length,
-                    config.cursor_trail_size,
-                    config.default_cursor_style.effective_shape(cursor.shape),
-                    now,
-                );
+                if cursor_visible {
+                    trail.update(
+                        &cursor,
+                        cell_width,
+                        cell_height,
+                        config.cursor_trail_min_distance,
+                        config.cursor_trail_style,
+                        config.cursor_vfx_particle_density,
+                        config.cursor_vfx_particle_lifetime,
+                        config.cursor_vfx_particle_speed,
+                        config.cursor_smear,
+                        config.cursor_animation_length,
+                        config.cursor_trail_size,
+                        config.default_cursor_style.effective_shape(cursor.shape),
+                        now,
+                    );
+                } else {
+                    // Cursor hidden (e.g. paru, btop output phase): skip all
+                    // animation work so no trail or smear is painted. Position
+                    // is tracked silently so no jump-smear fires on reappear.
+                    trail.advance_hidden(&cursor);
+                }
             }
 
-            let trail_states = self.cursor_trail_states.borrow();
-            let trail_state = match trail_states.get(&pane_id) {
-                Some(s) => s,
-                None => return Ok(()),
-            };
+            if cursor_visible {
+                let trail_states = self.cursor_trail_states.borrow();
+                let trail_state = match trail_states.get(&pane_id) {
+                    Some(s) => s,
+                    None => return Ok(()),
+                };
 
-            if config.cursor_trail_style.is_some() {
-                self.paint_cursor_trail(
+                if config.cursor_trail_style.is_some() {
+                    self.paint_cursor_trail(
+                        layers,
+                        pos,
+                        &cursor,
+                        &dims,
+                        current_viewport,
+                        top_pixel_y,
+                        padding_left,
+                        border.clone(),
+                        &palette,
+                        trail_state,
+                        now,
+                    )?;
+                }
+
+                self.paint_animated_cursor(
                     layers,
                     pos,
                     &cursor,
@@ -645,26 +670,12 @@ impl crate::TermWindow {
                     current_viewport,
                     top_pixel_y,
                     padding_left,
-                    border.clone(),
+                    border,
                     &palette,
                     trail_state,
                     now,
                 )?;
             }
-
-            self.paint_animated_cursor(
-                layers,
-                pos,
-                &cursor,
-                &dims,
-                current_viewport,
-                top_pixel_y,
-                padding_left,
-                border,
-                &palette,
-                trail_state,
-                now,
-            )?;
         }
 
         /*

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -1,6 +1,7 @@
 use crate::quad::{HeapQuadAllocator, QuadTrait, TripleLayerQuadAllocator};
 use crate::selection::SelectionRange;
 use crate::termwindow::box_model::*;
+use crate::termwindow::cursortrail::{CursorTrailState, HighlightKind};
 use crate::termwindow::render::{
     same_hyperlink, CursorProperties, LineQuadCacheKey, LineQuadCacheValue, LineToEleShapeCacheKey,
     RenderScreenLineParams,
@@ -78,11 +79,10 @@ impl crate::TermWindow {
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;
 
         let cursor = pos.pane.get_cursor_position();
+        let pane_id = pos.pane.pane_id();
         if pos.is_active {
             self.prev_cursor.update(&cursor);
         }
-
-        let pane_id = pos.pane.pane_id();
         let current_viewport = self.get_viewport(pane_id);
         let dims = pos.pane.get_dimensions();
 
@@ -335,6 +335,9 @@ impl crate::TermWindow {
                 window_is_transparent: bool,
                 layers: &'a mut TripleLayerQuadAllocator<'b>,
                 error: Option<anyhow::Error>,
+                /// When true the cursor is omitted from line rendering and drawn
+                /// separately as an animated overlay in `paint_animated_cursor`.
+                suppress_cursor: bool,
             }
 
             let left_pixel_x = padding_left
@@ -365,6 +368,14 @@ impl crate::TermWindow {
                 window_is_transparent,
                 layers,
                 error: None,
+                // For the active pane only: suppress the static cursor from line
+                // rendering so it is drawn separately by paint_animated_cursor.
+                // Inactive panes must keep their cursor in line rendering because
+                // paint_animated_cursor is not called for them.
+                suppress_cursor: pos.is_active
+                    && (config.cursor_smear
+                        || config.cursor_trail_style.is_some()
+                        || config.cursor_animation_length > 0.0),
             };
 
             impl<'a, 'b> LineRender<'a, 'b> {
@@ -423,6 +434,12 @@ impl crate::TermWindow {
 
                     let shape_hash = self.term_window.shape_hash_for_line(line);
 
+                    // When cursor animation is active, keep the cursor in the
+                    // cache key so the line caches and reuses its quads across
+                    // frames while the cursor sits still.  The animated overlay
+                    // drawn by paint_animated_cursor covers the static cursor rect.
+                    let cache_cursor = cursor;
+
                     let quad_key = LineQuadCacheKey {
                         pane_id: self.pane_id,
                         password_input,
@@ -432,7 +449,7 @@ impl crate::TermWindow {
                         quad_generation: self.term_window.quad_generation,
                         composing: composing.clone(),
                         selection: selrange.clone(),
-                        cursor,
+                        cursor: cache_cursor,
                         shape_hash,
                         top_pixel_y: NotNan::new(self.top_pixel_y).unwrap()
                             + (line_idx + self.pos.top) as f32
@@ -486,6 +503,19 @@ impl crate::TermWindow {
                         },
                     };
 
+                    // Sentinel cursor that won't match any visible row,
+                    // used to suppress static cursor drawing when animating.
+                    let suppress_sentinel;
+                    let render_cursor: &StableCursorPosition = if self.suppress_cursor {
+                        suppress_sentinel = StableCursorPosition {
+                            y: StableRowIndex::MIN,
+                            ..*self.cursor
+                        };
+                        &suppress_sentinel
+                    } else {
+                        self.cursor
+                    };
+
                     let render_result = self
                         .term_window
                         .render_screen_line(
@@ -497,7 +527,7 @@ impl crate::TermWindow {
                                 stable_line_idx: Some(stable_row),
                                 line: &line,
                                 selection: selrange.clone(),
-                                cursor: &self.cursor,
+                                cursor: render_cursor,
                                 palette: &self.palette,
                                 dims: &self.dims,
                                 config: &self.term_window.config,
@@ -569,6 +599,72 @@ impl crate::TermWindow {
             if let Some(error) = render.error.take() {
                 return Err(error).context("error while calling with_lines_mut");
             }
+        }
+
+        if pos.is_active
+            && (config.cursor_smear
+                || config.cursor_trail_style.is_some()
+                || config.cursor_animation_length > 0.0)
+        {
+            let now = Instant::now();
+
+            {
+                let cell_width = self.render_metrics.cell_size.width as f32;
+                let cell_height = self.render_metrics.cell_size.height as f32;
+                let mut trails = self.cursor_trail_states.borrow_mut();
+                let trail = trails.entry(pane_id).or_insert_with(CursorTrailState::new);
+                trail.update(
+                    &cursor,
+                    cell_width,
+                    cell_height,
+                    config.cursor_trail_min_distance,
+                    config.cursor_trail_style,
+                    config.cursor_vfx_particle_density,
+                    config.cursor_vfx_particle_lifetime,
+                    config.cursor_vfx_particle_speed,
+                    config.cursor_smear,
+                    config.cursor_animation_length,
+                    config.cursor_trail_size,
+                    config.default_cursor_style.effective_shape(cursor.shape),
+                    now,
+                );
+            }
+
+            let trail_states = self.cursor_trail_states.borrow();
+            let trail_state = match trail_states.get(&pane_id) {
+                Some(s) => s,
+                None => return Ok(()),
+            };
+
+            if config.cursor_trail_style.is_some() {
+                self.paint_cursor_trail(
+                    layers,
+                    pos,
+                    &cursor,
+                    &dims,
+                    current_viewport,
+                    top_pixel_y,
+                    padding_left,
+                    border.clone(),
+                    &palette,
+                    trail_state,
+                    now,
+                )?;
+            }
+
+            self.paint_animated_cursor(
+                layers,
+                pos,
+                &cursor,
+                &dims,
+                current_viewport,
+                top_pixel_y,
+                padding_left,
+                border,
+                &palette,
+                trail_state,
+                now,
+            )?;
         }
 
         /*
@@ -685,5 +781,416 @@ impl crate::TermWindow {
             baseline: 1.0,
             content: ComputedElementContent::Children(vec![]),
         })
+    }
+
+    fn paint_cursor_trail(
+        &self,
+        layers: &mut TripleLayerQuadAllocator,
+        pos: &PositionedPane,
+        cursor: &StableCursorPosition,
+        dims: &RenderableDimensions,
+        current_viewport: Option<StableRowIndex>,
+        top_pixel_y: f32,
+        padding_left: f32,
+        border: window::parameters::Border,
+        palette: &ColorPalette,
+        trail_state: &CursorTrailState,
+        now: Instant,
+    ) -> anyhow::Result<()> {
+        let config = &self.config;
+
+        if !trail_state.has_active_animation() {
+            return Ok(());
+        }
+
+        let cell_width = self.render_metrics.cell_size.width as f32;
+        let cell_height = self.render_metrics.cell_size.height as f32;
+
+        let viewport_top: StableRowIndex = current_viewport.unwrap_or(dims.physical_top);
+        let viewport_top_px = viewport_top as f32 * cell_height;
+        let viewport_h_px = dims.viewport_rows as f32 * cell_height;
+
+        let pane_left = pos.left as f32 * cell_width;
+        let pane_top = pos.top as f32 * cell_height;
+        let left_offset = padding_left + border.left.get() as f32;
+
+        let cursor_shape = config.default_cursor_style.effective_shape(cursor.shape);
+        let trail_color = if config.force_reverse_video_cursor {
+            palette.foreground.to_linear()
+        } else {
+            palette.cursor_bg.to_linear()
+        };
+        let (r, g, b, _) = trail_color.tuple();
+        let start_opacity = config.cursor_vfx_opacity;
+
+        let layer_num = match cursor_shape {
+            termwiz::surface::CursorShape::BlinkingBar
+            | termwiz::surface::CursorShape::SteadyBar => 2,
+            _ => 0,
+        };
+
+        // ── Particles (Railgun / Torpedo / PixieDust) ─────────────────────────
+        // Batch all visible particle quads into a single vertex buffer submission
+        // to avoid per-particle allocate() overhead (up to 256 draw calls → 1).
+        {
+            use crate::quad::{TripleLayerQuadAllocatorTrait, Vertex, VERTICES_PER_CELL};
+
+            let half_win_w = self.dimensions.pixel_width as f32 / 2.0;
+            let half_win_h = self.dimensions.pixel_height as f32 / 2.0;
+            let particle_size = config.cursor_vfx_particle_size;
+
+            let (has_color, mix_val, is_ring) = match config.cursor_trail_style {
+                Some(config::CursorTrailStyle::Railgun)
+                | Some(config::CursorTrailStyle::Torpedo) => (5.0f32, 0.5f32, true),
+                _ => (3.0f32, 0.0f32, false),
+            };
+
+            let gl_state = self.render_state.as_ref();
+            let (tx1, tx2, ty1, ty2) = if is_ring {
+                (0.0f32, 1.0f32, 0.0f32, 1.0f32)
+            } else if let Some(gs) = gl_state {
+                let tex = gs.util_sprites.filled_box.texture_coords();
+                (tex.min_x(), tex.max_x(), tex.min_y(), tex.max_y())
+            } else {
+                (0.0, 1.0, 0.0, 1.0)
+            };
+
+            let mut batch: Vec<Vertex> =
+                Vec::with_capacity(trail_state.particles.len() * VERTICES_PER_CELL);
+
+            for p in &trail_state.particles {
+                let life_frac = p.lifetime / p.max_lifetime;
+                let alpha = start_opacity * life_frac;
+                if alpha <= 0.005 {
+                    continue;
+                }
+
+                let screen_x = left_offset + pane_left + p.x;
+                let screen_y = top_pixel_y + pane_top + (p.y - viewport_top_px);
+
+                if screen_y < top_pixel_y + pane_top - cell_height
+                    || screen_y > top_pixel_y + pane_top + viewport_h_px
+                {
+                    continue;
+                }
+
+                let col = [r, g, b, alpha];
+                let hsv = [1.0f32, 1.0, 1.0];
+
+                let size = match config.cursor_trail_style {
+                    Some(config::CursorTrailStyle::PixieDust) => cell_width * particle_size * 0.4,
+                    _ => cell_width * particle_size * life_frac,
+                };
+                let half = size * 0.5;
+
+                let mk = |px: f32, py: f32, u: f32, v: f32| Vertex {
+                    position: [px, py],
+                    tex: [u, v],
+                    fg_color: col,
+                    alt_color: col,
+                    hsv,
+                    has_color,
+                    mix_value: mix_val,
+                };
+
+                batch.push(mk(
+                    screen_x - half - half_win_w,
+                    screen_y - half - half_win_h,
+                    tx1,
+                    ty1,
+                ));
+                batch.push(mk(
+                    screen_x + half - half_win_w,
+                    screen_y - half - half_win_h,
+                    tx2,
+                    ty1,
+                ));
+                batch.push(mk(
+                    screen_x - half - half_win_w,
+                    screen_y + half - half_win_h,
+                    tx1,
+                    ty2,
+                ));
+                batch.push(mk(
+                    screen_x + half - half_win_w,
+                    screen_y + half - half_win_h,
+                    tx2,
+                    ty2,
+                ));
+            }
+
+            if !batch.is_empty() {
+                layers.extend_with(layer_num, &batch);
+            }
+        }
+
+        // ── Highlight (SonicBoom / Ripple / Wireframe) ───────────────────────
+        if let Some(ref h) = trail_state.highlight {
+            match &h.kind {
+                // ── SonicBoom: expanding filled square ────────────────────────
+                HighlightKind::SonicBoom { cx, cy } => {
+                    let t = h.t;
+                    let opacity = start_opacity * (1.0 - t).powi(2);
+                    if opacity > 0.005 {
+                        let radius = t * cell_height * 1.5;
+                        let d = radius * 2.0;
+                        let screen_cx = left_offset + pane_left + cx;
+                        let screen_cy = top_pixel_y + pane_top + (cy - viewport_top_px);
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(screen_cx - radius, screen_cy - radius, d, d),
+                            LinearRgba::with_components(r, g, b, opacity),
+                        )?;
+                    }
+                }
+
+                // ── Ripple: expanding hollow ring (4 thin rectangles) ─────────
+                HighlightKind::Ripple { cx, cy } => {
+                    let t = h.t;
+                    let opacity = start_opacity * (1.0 - t);
+                    if opacity > 0.005 {
+                        let radius = t * cell_height * 2.5;
+                        let bw = 2.5_f32;
+                        let d = radius * 2.0;
+                        let screen_cx = left_offset + pane_left + cx;
+                        let screen_cy = top_pixel_y + pane_top + (cy - viewport_top_px);
+                        let x0 = screen_cx - radius;
+                        let y0 = screen_cy - radius;
+                        let color = LinearRgba::with_components(r, g, b, opacity);
+                        // top bar
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0, y0, d, bw),
+                            color,
+                        )?;
+                        // bottom bar
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0, y0 + d - bw, d, bw),
+                            color,
+                        )?;
+                        // left side
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0, y0 + bw, bw, d - 2.0 * bw),
+                            color,
+                        )?;
+                        // right side
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0 + d - bw, y0 + bw, bw, d - 2.0 * bw),
+                            color,
+                        )?;
+                    }
+                }
+
+                // ── Wireframe: expanding hollow rectangle (cell aspect ratio) ─
+                HighlightKind::Wireframe {
+                    cx,
+                    cy,
+                    cell_w,
+                    cell_h,
+                } => {
+                    let t = h.t;
+                    let opacity = start_opacity * (1.0 - t);
+                    if opacity > 0.005 {
+                        let scale = t * 2.5;
+                        let rx = cell_w * scale;
+                        let ry = cell_h * scale;
+                        let bw = 2.5_f32;
+                        let w = rx * 2.0;
+                        let h = ry * 2.0;
+                        let screen_cx = left_offset + pane_left + cx;
+                        let screen_cy = top_pixel_y + pane_top + (cy - viewport_top_px);
+                        let x0 = screen_cx - rx;
+                        let y0 = screen_cy - ry;
+                        let color = LinearRgba::with_components(r, g, b, opacity);
+                        // top bar
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0, y0, w, bw),
+                            color,
+                        )?;
+                        // bottom bar
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0, y0 + h - bw, w, bw),
+                            color,
+                        )?;
+                        // left side
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0, y0 + bw, bw, h - 2.0 * bw),
+                            color,
+                        )?;
+                        // right side
+                        self.filled_rectangle(
+                            layers,
+                            layer_num,
+                            euclid::rect(x0 + w - bw, y0 + bw, bw, h - 2.0 * bw),
+                            color,
+                        )?;
+                    }
+                }
+            }
+        }
+
+        // Schedule the next repaint immediately; the presentation engine
+        // (PresentMode::Fifo) will vsync to the actual display refresh rate.
+        if trail_state.has_active_animation() {
+            self.update_next_frame_time(Some(now));
+        }
+
+        Ok(())
+    }
+
+    /// Draws the cursor at its target position, rendering the Neovide-style
+    /// deforming smear body when `cursor_smear` is active.
+    fn paint_animated_cursor(
+        &self,
+        layers: &mut TripleLayerQuadAllocator,
+        pos: &PositionedPane,
+        cursor: &StableCursorPosition,
+        dims: &RenderableDimensions,
+        current_viewport: Option<StableRowIndex>,
+        top_pixel_y: f32,
+        padding_left: f32,
+        border: window::parameters::Border,
+        palette: &ColorPalette,
+        trail_state: &CursorTrailState,
+        now: Instant,
+    ) -> anyhow::Result<()> {
+        let config = &self.config;
+
+        let cell_width = self.render_metrics.cell_size.width as f32;
+        let cell_height = self.render_metrics.cell_size.height as f32;
+
+        let viewport_top_px = current_viewport.unwrap_or(dims.physical_top) as f32 * cell_height;
+        let pane_left = pos.left as f32 * cell_width;
+        let pane_top = pos.top as f32 * cell_height;
+        let left_offset = padding_left + border.left.get() as f32;
+
+        let cursor_color = if config.force_reverse_video_cursor {
+            palette.foreground.to_linear()
+        } else {
+            palette.cursor_bg.to_linear()
+        };
+
+        let shape = config.default_cursor_style.effective_shape(cursor.shape);
+
+        // Apply cursor blink if the shape is a blinking variant.
+        let is_blinking = matches!(
+            shape,
+            termwiz::surface::CursorShape::BlinkingBlock
+                | termwiz::surface::CursorShape::BlinkingBar
+                | termwiz::surface::CursorShape::BlinkingUnderline
+        ) && config.cursor_blink_rate != 0
+            && self.focused.is_some()
+            && pos.is_active;
+
+        let cursor_color = if is_blinking {
+            let mut color_ease = self.cursor_blink_state.borrow_mut();
+            color_ease.update_start(self.prev_cursor.last_cursor_movement());
+            let (intensity, next) = color_ease.intensity_continuous();
+            self.update_next_frame_time(Some(next));
+            // intensity=0 → fully visible, intensity=1 → fully invisible.
+            // Skip drawing entirely when invisible so the cursor truly disappears
+            // (drawing a zero-alpha rect on a solid background shows nothing, but
+            // smear / trail draws underneath it would still be visible otherwise).
+            if intensity >= 1.0 {
+                return Ok(());
+            }
+            let (r, g, b, _a) = cursor_color.tuple();
+            LinearRgba::with_components(r, g, b, 1.0 - intensity)
+        } else {
+            cursor_color
+        };
+
+        // Logical (target) cursor position in stable pixel space.
+        let target_x = cursor.x as f32 * cell_width;
+        let target_y = cursor.y as f32 * cell_height;
+
+        // Screen offset shared by both visual and target positions.
+        let screen_off_x = left_offset + pane_left;
+        let screen_off_y = top_pixel_y + pane_top - viewport_top_px;
+
+        // Per-shape: cursor rect size, cell-relative TL offset, render layer.
+        let (rect_w, rect_h, off_x, off_y, layer) = match shape {
+            termwiz::surface::CursorShape::Default
+            | termwiz::surface::CursorShape::BlinkingBlock
+            | termwiz::surface::CursorShape::SteadyBlock => {
+                (cell_width, cell_height, 0.0f32, 0.0f32, 0usize)
+            }
+            termwiz::surface::CursorShape::BlinkingUnderline
+            | termwiz::surface::CursorShape::SteadyUnderline => {
+                let h = (cell_height * 0.1).max(2.0);
+                (cell_width, h, 0.0, cell_height - h, 0)
+            }
+            termwiz::surface::CursorShape::BlinkingBar
+            | termwiz::surface::CursorShape::SteadyBar => {
+                let w = (cell_width * 0.15).max(2.0);
+                (w, cell_height, 0.0, 0.0, 2)
+            }
+        };
+
+        // ── Neovide-style deforming smear (all shapes) ───────────────────────
+        // Four corners animate at different speeds — leading edge races ahead,
+        // trailing edge lags — producing the characteristic stretched-body look.
+        // Corner targets are shape-adjusted (bar compressed, underline at bottom)
+        // in the trail state so the animated positions are already correct.
+        let smear_active = config.cursor_smear
+            && trail_state.has_smear_animation(target_x, target_y, cell_width, cell_height);
+
+        if smear_active {
+            let c = &trail_state.smear_corners;
+            let tl = (screen_off_x + c[0].visual_x, screen_off_y + c[0].visual_y);
+            let tr = (screen_off_x + c[1].visual_x, screen_off_y + c[1].visual_y);
+            let br = (screen_off_x + c[2].visual_x, screen_off_y + c[2].visual_y);
+            let bl = (screen_off_x + c[3].visual_x, screen_off_y + c[3].visual_y);
+
+            let corner_alphas = if config.cursor_smear_gradient {
+                let (_, _, _, base_a) = cursor_color.tuple();
+                let offsets = trail_state.corner_offsets();
+                let max_dist = cell_width.hypot(cell_height);
+                Some(std::array::from_fn::<f32, 4, _>(|i| {
+                    let (ox, oy) = offsets[i];
+                    let tx = target_x + ox * cell_width;
+                    let ty = target_y + oy * cell_height;
+                    let dist = (c[i].visual_x - tx).hypot(c[i].visual_y - ty);
+                    let lag = (dist / max_dist).min(1.0);
+                    base_a * (1.0 - lag)
+                }))
+            } else {
+                None
+            };
+
+            self.draw_cursor_deformed_quad(layers, 0, tl, tr, br, bl, cursor_color, corner_alphas);
+            self.update_next_frame_time(Some(now));
+        }
+
+        // Always draw the cursor rect at the target position with the actual
+        // cursor shape.  When animating this caps the smear's deformed front
+        // face, making the cursor head appear straight and undistorted.
+        // When at rest (no smear) this is the sole cursor draw.
+        {
+            let screen_x = screen_off_x + target_x + off_x;
+            let screen_y = screen_off_y + target_y + off_y;
+            self.filled_rectangle(
+                layers,
+                layer,
+                euclid::rect(screen_x, screen_y, rect_w, rect_h),
+                cursor_color,
+            )?;
+        }
+
+        Ok(())
     }
 }

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -1176,11 +1176,17 @@ impl crate::TermWindow {
             self.update_next_frame_time(Some(now));
         }
 
-        // Always draw the cursor rect at the target position with the actual
-        // cursor shape.  When animating this caps the smear's deformed front
-        // face, making the cursor head appear straight and undistorted.
-        // When at rest (no smear) this is the sole cursor draw.
-        {
+        // Draw the cursor rect at the target position with the actual cursor
+        // shape. When animating this caps the smear's deformed front face,
+        // making the cursor head appear straight and undistorted. When at rest
+        // (no smear) this is the sole cursor draw.
+        //
+        // Suppressed while a multi-cell jump is being deferred for snap-back
+        // detection: drawing it would betray the deferred destination, since
+        // the smear quad is still frozen at the pre-jump cell. The smear quad
+        // alone is enough — at rest it forms a regular cursor block at the
+        // pre-jump cell, which is exactly what we want the user to see.
+        if !trail_state.is_smear_deferred() {
             let screen_x = screen_off_x + target_x + off_x;
             let screen_y = screen_off_y + target_y + off_y;
             self.filled_rectangle(

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -866,73 +866,100 @@ impl crate::TermWindow {
                 (0.0, 1.0, 0.0, 1.0)
             };
 
-            let mut batch: Vec<Vertex> =
-                Vec::with_capacity(trail_state.particles.len() * VERTICES_PER_CELL);
+            // ── Hoist frame-constant values out of the per-particle loop ──────
+            // screen_base_{x,y}: common screen-space offset, computed once.
+            let screen_base_x = left_offset + pane_left;
+            // viewport_top_px is already folded in so the loop only adds p.y.
+            let screen_base_y = top_pixel_y + pane_top - viewport_top_px;
+            // Viewport culling bounds (particle centre coordinates, not clip).
+            let y_cull_min = top_pixel_y + pane_top - cell_height;
+            let y_cull_max = top_pixel_y + pane_top + viewport_h_px;
+            // For PixieDust size is independent of life_frac; precompute both paths.
+            let is_pixie_dust =
+                matches!(config.cursor_trail_style, Some(config::CursorTrailStyle::PixieDust));
+            // particle_half_base = cell_width * particle_size * 0.5;
+            // For non-PixieDust: half = particle_half_base * life_frac
+            // For PixieDust:     half = pixie_half (constant per frame)
+            let particle_half_base = cell_width * particle_size * 0.5;
+            let pixie_half = particle_half_base * 0.4;
 
-            for p in &trail_state.particles {
-                let life_frac = p.lifetime / p.max_lifetime;
-                let alpha = start_opacity * life_frac;
-                if alpha <= 0.005 {
-                    continue;
-                }
-
-                let screen_x = left_offset + pane_left + p.x;
-                let screen_y = top_pixel_y + pane_top + (p.y - viewport_top_px);
-
-                if screen_y < top_pixel_y + pane_top - cell_height
-                    || screen_y > top_pixel_y + pane_top + viewport_h_px
-                {
-                    continue;
-                }
-
-                let col = [r, g, b, alpha];
-                let hsv = [1.0f32, 1.0, 1.0];
-
-                let size = match config.cursor_trail_style {
-                    Some(config::CursorTrailStyle::PixieDust) => cell_width * particle_size * 0.4,
-                    _ => cell_width * particle_size * life_frac,
-                };
-                let half = size * 0.5;
-
-                let mk = |px: f32, py: f32, u: f32, v: f32| Vertex {
-                    position: [px, py],
-                    tex: [u, v],
-                    fg_color: col,
-                    alt_color: col,
-                    hsv,
-                    has_color,
-                    mix_value: mix_val,
-                };
-
-                batch.push(mk(
-                    screen_x - half - half_win_w,
-                    screen_y - half - half_win_h,
-                    tx1,
-                    ty1,
-                ));
-                batch.push(mk(
-                    screen_x + half - half_win_w,
-                    screen_y - half - half_win_h,
-                    tx2,
-                    ty1,
-                ));
-                batch.push(mk(
-                    screen_x - half - half_win_w,
-                    screen_y + half - half_win_h,
-                    tx1,
-                    ty2,
-                ));
-                batch.push(mk(
-                    screen_x + half - half_win_w,
-                    screen_y + half - half_win_h,
-                    tx2,
-                    ty2,
-                ));
+            // ── Thread-local scratch buffer: zero heap allocation per frame ───
+            // The Vec grows to the high-water mark and is reused across frames,
+            // eliminating the malloc/free pair that previously occurred every
+            // animation frame (60 Hz × ~27 KB for a full 256-particle batch).
+            thread_local! {
+                static PARTICLE_VERTS: std::cell::RefCell<Vec<Vertex>> =
+                    std::cell::RefCell::new(Vec::new());
             }
 
-            if !batch.is_empty() {
-                layers.extend_with(layer_num, &batch);
-            }
+            PARTICLE_VERTS.with(|scratch| {
+                let mut batch = scratch.borrow_mut();
+                batch.clear();
+                batch.reserve(trail_state.particles.len() * VERTICES_PER_CELL);
+
+                for p in &trail_state.particles {
+                    let life_frac = p.lifetime / p.max_lifetime;
+                    let alpha = start_opacity * life_frac;
+                    if alpha <= 0.005 {
+                        continue;
+                    }
+
+                    let screen_x = screen_base_x + p.x;
+                    let screen_y = screen_base_y + p.y;
+
+                    if screen_y < y_cull_min || screen_y > y_cull_max {
+                        continue;
+                    }
+
+                    let col = [r, g, b, alpha];
+                    let hsv = [1.0f32, 1.0, 1.0];
+
+                    let half = if is_pixie_dust {
+                        pixie_half
+                    } else {
+                        particle_half_base * life_frac
+                    };
+
+                    let mk = |px: f32, py: f32, u: f32, v: f32| Vertex {
+                        position: [px, py],
+                        tex: [u, v],
+                        fg_color: col,
+                        alt_color: col,
+                        hsv,
+                        has_color,
+                        mix_value: mix_val,
+                    };
+
+                    batch.push(mk(
+                        screen_x - half - half_win_w,
+                        screen_y - half - half_win_h,
+                        tx1,
+                        ty1,
+                    ));
+                    batch.push(mk(
+                        screen_x + half - half_win_w,
+                        screen_y - half - half_win_h,
+                        tx2,
+                        ty1,
+                    ));
+                    batch.push(mk(
+                        screen_x - half - half_win_w,
+                        screen_y + half - half_win_h,
+                        tx1,
+                        ty2,
+                    ));
+                    batch.push(mk(
+                        screen_x + half - half_win_w,
+                        screen_y + half - half_win_h,
+                        tx2,
+                        ty2,
+                    ));
+                }
+
+                if !batch.is_empty() {
+                    layers.extend_with(layer_num, &batch);
+                }
+            });
         }
 
         // ── Highlight (SonicBoom / Ripple / Wireframe) ───────────────────────
@@ -1056,9 +1083,10 @@ impl crate::TermWindow {
 
         // Schedule the next repaint immediately; the presentation engine
         // (PresentMode::Fifo) will vsync to the actual display refresh rate.
-        if trail_state.has_active_animation() {
-            self.update_next_frame_time(Some(now));
-        }
+        // has_active_animation() was confirmed true at the top of this function
+        // (early-return path). Nothing mutates trail_state during paint, so it
+        // remains true here — call unconditionally to avoid a redundant check.
+        self.update_next_frame_time(Some(now));
 
         Ok(())
     }

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -303,6 +303,54 @@ impl crate::TermWindow {
         let cursor_is_default_color =
             palette.cursor_fg == global_cursor_fg && palette.cursor_bg == global_cursor_bg;
 
+        // Tick the cursor trail / smear state BEFORE line rendering so the
+        // line-render path knows whether to suppress the static cursor.
+        //
+        // We only suppress while a multi-cell jump is being *deferred* for
+        // snap-back detection — during that window the cursor has actually
+        // moved but we want the user to still see it parked at the pre-jump
+        // cell (drawn by the frozen smear quad), so showing the static
+        // cursor at its new position would betray the deferred destination.
+        //
+        // During an ordinary smear animation we deliberately do NOT
+        // suppress: the static cursor draws at its target with full
+        // cursor_fg / cursor_bg / inversion styling, while the smear quad
+        // streaks behind it on layer 0. Both the smear and the cursor cell
+        // bg use cursor_bg, so the layered draw is visually seamless and
+        // cursor_fg becomes visible the moment the cursor reaches its new
+        // cell instead of after the smear has finished.
+        let cursor_anim_enabled = pos.is_active
+            && (config.cursor_smear
+                || config.cursor_trail_style.is_some()
+                || config.cursor_animation_length > 0.0);
+        let now = Instant::now();
+        let cursor_visible = cursor.visibility == CursorVisibility::Visible;
+        let mut suppress_static_cursor = false;
+        if cursor_anim_enabled {
+            let mut trails = self.cursor_trail_states.borrow_mut();
+            let trail = trails.entry(pane_id).or_insert_with(CursorTrailState::new);
+            if cursor_visible {
+                trail.update(
+                    &cursor,
+                    cell_width,
+                    cell_height,
+                    config.cursor_trail_min_distance,
+                    config.cursor_trail_style,
+                    config.cursor_vfx_particle_density,
+                    config.cursor_vfx_particle_lifetime,
+                    config.cursor_vfx_particle_speed,
+                    config.cursor_smear,
+                    config.cursor_animation_length,
+                    config.cursor_trail_size,
+                    config.default_cursor_style.effective_shape(cursor.shape),
+                    now,
+                );
+                suppress_static_cursor = trail.is_smear_deferred();
+            } else {
+                trail.advance_hidden(&cursor);
+            }
+        }
+
         {
             let stable_range = match current_viewport {
                 Some(top) => top..top + dims.viewport_rows as StableRowIndex,
@@ -369,14 +417,12 @@ impl crate::TermWindow {
                 window_is_transparent,
                 layers,
                 error: None,
-                // For the active pane only: suppress the static cursor from line
-                // rendering so it is drawn separately by paint_animated_cursor.
-                // Inactive panes must keep their cursor in line rendering because
-                // paint_animated_cursor is not called for them.
-                suppress_cursor: pos.is_active
-                    && (config.cursor_smear
-                        || config.cursor_trail_style.is_some()
-                        || config.cursor_animation_length > 0.0),
+                // Suppress the static cursor only while the smear is actively
+                // animating or deferred — at rest, the line render path is the
+                // only place that applies cursor_fg / cursor_bg / inversion to
+                // the glyph beneath the cursor, so unconditional suppression
+                // would silently break those palette colours.
+                suppress_cursor: suppress_static_cursor,
             };
 
             impl<'a, 'b> LineRender<'a, 'b> {
@@ -393,7 +439,9 @@ impl crate::TermWindow {
                     // Constrain to the pane width!
                     let selrange = selrange.start..selrange.end.min(self.dims.cols);
 
-                    let (cursor, composing, password_input) = if self.cursor.y == stable_row {
+                    let (cursor, composing, password_input) = if self.cursor.y == stable_row
+                        && !self.suppress_cursor
+                    {
                         (
                             Some(CursorProperties {
                                 position: StableCursorPosition {
@@ -602,43 +650,10 @@ impl crate::TermWindow {
             }
         }
 
-        if pos.is_active
-            && (config.cursor_smear
-                || config.cursor_trail_style.is_some()
-                || config.cursor_animation_length > 0.0)
-        {
-            let now = Instant::now();
-            let cursor_visible = cursor.visibility == CursorVisibility::Visible;
-
-            {
-                let cell_width = self.render_metrics.cell_size.width as f32;
-                let cell_height = self.render_metrics.cell_size.height as f32;
-                let mut trails = self.cursor_trail_states.borrow_mut();
-                let trail = trails.entry(pane_id).or_insert_with(CursorTrailState::new);
-                if cursor_visible {
-                    trail.update(
-                        &cursor,
-                        cell_width,
-                        cell_height,
-                        config.cursor_trail_min_distance,
-                        config.cursor_trail_style,
-                        config.cursor_vfx_particle_density,
-                        config.cursor_vfx_particle_lifetime,
-                        config.cursor_vfx_particle_speed,
-                        config.cursor_smear,
-                        config.cursor_animation_length,
-                        config.cursor_trail_size,
-                        config.default_cursor_style.effective_shape(cursor.shape),
-                        now,
-                    );
-                } else {
-                    // Cursor hidden (e.g. paru, btop output phase): skip all
-                    // animation work so no trail or smear is painted. Position
-                    // is tracked silently so no jump-smear fires on reappear.
-                    trail.advance_hidden(&cursor);
-                }
-            }
-
+        if cursor_anim_enabled {
+            // Trail state was already ticked above (before line rendering)
+            // so we could decide on suppress_static_cursor for the cache key.
+            // Here we only paint based on that already-up-to-date state.
             if cursor_visible {
                 let trail_states = self.cursor_trail_states.borrow();
                 let trail_state = match trail_states.get(&pane_id) {
@@ -879,9 +894,10 @@ impl crate::TermWindow {
                 matches!(config.cursor_trail_style, Some(config::CursorTrailStyle::PixieDust));
             // particle_half_base = cell_width * particle_size * 0.5;
             // For non-PixieDust: half = particle_half_base * life_frac
-            // For PixieDust:     half = pixie_half (constant per frame)
+            // For PixieDust:     half = pixie_half (constant per frame, min 2px so
+            //                    particles remain visible at small cell sizes)
             let particle_half_base = cell_width * particle_size * 0.5;
-            let pixie_half = particle_half_base * 0.4;
+            let pixie_half = particle_half_base.max(2.0);
 
             // ── Thread-local scratch buffer: zero heap allocation per frame ───
             // The Vec grows to the high-water mark and is reused across frames,
@@ -896,6 +912,9 @@ impl crate::TermWindow {
                 let mut batch = scratch.borrow_mut();
                 batch.clear();
                 batch.reserve(trail_state.particles.len() * VERTICES_PER_CELL);
+
+                // hsv is identical for every particle; hoist it out of the loop.
+                const HSV: [f32; 3] = [1.0, 1.0, 1.0];
 
                 for p in &trail_state.particles {
                     let life_frac = p.lifetime / p.max_lifetime;
@@ -912,7 +931,6 @@ impl crate::TermWindow {
                     }
 
                     let col = [r, g, b, alpha];
-                    let hsv = [1.0f32, 1.0, 1.0];
 
                     let half = if is_pixie_dust {
                         pixie_half
@@ -925,7 +943,7 @@ impl crate::TermWindow {
                         tex: [u, v],
                         fg_color: col,
                         alt_color: col,
-                        hsv,
+                        hsv: HSV,
                         has_color,
                         mix_value: mix_val,
                     };
@@ -1161,25 +1179,6 @@ impl crate::TermWindow {
         let screen_off_x = left_offset + pane_left;
         let screen_off_y = top_pixel_y + pane_top - viewport_top_px;
 
-        // Per-shape: cursor rect size, cell-relative TL offset, render layer.
-        let (rect_w, rect_h, off_x, off_y, layer) = match shape {
-            termwiz::surface::CursorShape::Default
-            | termwiz::surface::CursorShape::BlinkingBlock
-            | termwiz::surface::CursorShape::SteadyBlock => {
-                (cell_width, cell_height, 0.0f32, 0.0f32, 0usize)
-            }
-            termwiz::surface::CursorShape::BlinkingUnderline
-            | termwiz::surface::CursorShape::SteadyUnderline => {
-                let h = (cell_height * 0.1).max(2.0);
-                (cell_width, h, 0.0, cell_height - h, 0)
-            }
-            termwiz::surface::CursorShape::BlinkingBar
-            | termwiz::surface::CursorShape::SteadyBar => {
-                let w = (cell_width * 0.15).max(2.0);
-                (w, cell_height, 0.0, 0.0, 2)
-            }
-        };
-
         // ── Neovide-style deforming smear (all shapes) ───────────────────────
         // Four corners animate at different speeds — leading edge races ahead,
         // trailing edge lags — producing the characteristic stretched-body look.
@@ -1215,26 +1214,18 @@ impl crate::TermWindow {
             self.update_next_frame_time(Some(now));
         }
 
-        // Draw the cursor rect at the target position with the actual cursor
-        // shape. When animating this caps the smear's deformed front face,
-        // making the cursor head appear straight and undistorted. When at rest
-        // (no smear) this is the sole cursor draw.
+        // No cap rect: the static cursor drawn by the line render path is
+        // the canonical cursor draw at the target cell and already applies
+        // cursor_fg / cursor_bg / inversion to the underlying glyph. The
+        // smear quad streaks behind it on layer 0 using the same cursor_bg
+        // colour, so the head reads as a clean cursor cell with a trailing
+        // smear and cursor_fg is visible immediately on arrival rather than
+        // after the smear finishes.
         //
-        // Suppressed while a multi-cell jump is being deferred for snap-back
-        // detection: drawing it would betray the deferred destination, since
-        // the smear quad is still frozen at the pre-jump cell. The smear quad
-        // alone is enough — at rest it forms a regular cursor block at the
-        // pre-jump cell, which is exactly what we want the user to see.
-        if !trail_state.is_smear_deferred() {
-            let screen_x = screen_off_x + target_x + off_x;
-            let screen_y = screen_off_y + target_y + off_y;
-            self.filled_rectangle(
-                layers,
-                layer,
-                euclid::rect(screen_x, screen_y, rect_w, rect_h),
-                cursor_color,
-            )?;
-        }
+        // While a multi-cell jump is deferred, the static cursor is
+        // suppressed in line rendering (see suppress_static_cursor in
+        // paint_pane) so the frozen smear quad alone forms the visible
+        // cursor block at the pre-jump cell.
 
         Ok(())
     }

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -322,7 +322,7 @@ impl crate::TermWindow {
         let cursor_anim_enabled = pos.is_active
             && (config.cursor_smear
                 || config.cursor_trail_style.is_some()
-                || config.cursor_animation_length > 0.0);
+                || config.cursor_animation_duration > 0.0);
         let now = Instant::now();
         let cursor_visible = cursor.visibility == CursorVisibility::Visible;
         let mut suppress_static_cursor = false;
@@ -340,7 +340,7 @@ impl crate::TermWindow {
                     config.cursor_vfx_particle_lifetime,
                     config.cursor_vfx_particle_speed,
                     config.cursor_smear,
-                    config.cursor_animation_length,
+                    config.cursor_animation_duration,
                     config.cursor_trail_size,
                     config.default_cursor_style.effective_shape(cursor.shape),
                     now,


### PR DESCRIPTION
## Summary

Adds Neovide-style cursor animation effects: a deforming smear that stretches between the previous and current cursor position, and optional particle VFX trails. All effects are opt-in and disabled by default.

---

### Smear effect (`cursor_smear`)

Animates the cursor body as a deforming quadrilateral whose four corners move at independent speeds — leading corners race ahead while trailing corners lag, producing a characteristic stretched-body look. All cursor shapes (block, bar, underline) are supported.

[Screencast_20260412_220839.webm](https://github.com/user-attachments/assets/c2b8df00-16a5-455c-a747-431c458e30d4)


### Particle effects (`cursor_trail_style`)

Six styles are available:

| Value | Description |
|---|---|
| `Torpedo` | Particles scatter opposing the direction of travel |
| `PixieDust` | Small squares that fall under gravity |
| `Railgun` | Sinusoidal particle stream fanning along the movement vector |
| `SonicBoom` | Expanding filled square at the cursor destination |
| `Ripple` | Expanding hollow ring at the cursor destination |
| `Wireframe` | Expanding hollow rectangle at the cursor destination |

[Screencast_20260412_221405.webm](https://github.com/user-attachments/assets/2a5bd40a-abb7-4483-a1a2-ed7c228a59d0)

Smear and particles are independent — both can be active simultaneously.

---

### New configuration options

```lua
-- Neovide-style deforming smear (default: disabled)
config.cursor_smear = true

-- Comet gradient: tail fades to transparent (default: false = uniform opacity)
config.cursor_smear_gradient = false

-- Smear animation duration in seconds (default: 0.15)
config.cursor_animation_length = 0.150

-- Trail size: 1.0 = maximum stretch, 0.0 = no visible trail (default: 1.0)
config.cursor_trail_size = 1.0

-- Particle / highlight style; leave unset for no particles (default: nil)
config.cursor_trail_style = "Torpedo"  -- or PixieDust, Railgun, SonicBoom, Ripple, Wireframe

-- Minimum cursor movement in cells before effects trigger (default: 4)
config.cursor_trail_min_distance = 4

-- Particle opacity, 1.0 = fully opaque (default: 0.6)
config.cursor_vfx_opacity = 0.6

-- How long particles persist in seconds (default: 0.35)
config.cursor_vfx_particle_lifetime = 0.35

-- Particles spawned per cell of movement (default: 0.7)
config.cursor_vfx_particle_density = 0.7

-- Initial particle speed in cells/sec (default: 8.0)
config.cursor_vfx_particle_speed = 8.0

-- Particle diameter as a fraction of cell width (default: 0.5)
config.cursor_vfx_particle_size = 0.5
```
---
Implementation notes

- Zero cost when disabled: the cursor trail system is not entered at all unless at least one of cursor_smear, cursor_trail_style, or cursor_animation_length > 0 is set.
- Frame-rate independent: all animations use exponential ease-out driven by real elapsed time (dt), not frame count.
- Particle cap: hard cap of 256 live particles per pane. O(1) swap-remove keeps the particle list compact with no per-frame allocation.
- Batched GPU submission: all particle quads for a frame are written into a single vertex buffer in one extend_with call, avoiding per-particle allocate() overhead.
- PRNG: xorshift64 seeded via Fibonacci-hashing of a global atomic counter — cheap and well-distributed across panes.
- Per-pane state: each pane has its own CursorTrailState, keyed by PaneId. State is cleaned up automatically when a pane is closed.
- Vsync-aware scheduling: update_next_frame_time is called only when an animation is actually in progress, so idle panes do not drive unnecessary repaints.

---
Credits

The smear and particle animation design is inspired by and closely modelled after the cursor VFX system in Neovide, the GPU-accelerated Neovim frontend. Specifically:

- The four-corner deforming smear approach mirrors Neovide's PathBuilder(corners[0..3]) with per-corner speed assignment based on direction alignment (leading = animation_length * (1 - trail_size)).
- Corner shape adjustments for bar and underline cursors follow Neovide's set_cursor_shape relative-position formulas.
- Configuration parameter names (cursor_animation_length, cursor_trail_size, cursor_vfx_*) are intentionally aligned with Neovide's to ease migration.

Torpedo and PixieDust received the most attention and are the most faithfully implemented styles. Railgun is a reasonable approximation of Neovide's phase-based particle fan. SonicBoom, Ripple, and Wireframe are basic implementations of the expanding-shape concept and do not attempt to match Neovide's exact look.

---
Closes #7387
Closes #7420 (replaced)