### PR TITLE
ssh: IdentitiesOnly=yes should filter agent keys, not skip agent auth

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -144,7 +144,7 @@ As features stabilize some brief notes about them will accumulate here.
 #### Fixed
 * SSH: `IdentitiesOnly=yes` now correctly filters agent keys to those matching
   configured `IdentityFile` entries, rather than skipping agent authentication
-  entirely.
+  entirely. Thanks to @GottZ! #7739
 * Race condition when very quickly adjusting font scale, and other improvements
   around resizing. Thanks to @jknockel! #4876 #5032 #5033
 * macOS: wacky initial window size with external monitors or certain font

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -144,7 +144,7 @@ As features stabilize some brief notes about them will accumulate here.
 #### Fixed
 * SSH: `IdentitiesOnly=yes` now correctly filters agent keys to those matching
   configured `IdentityFile` entries, rather than skipping agent authentication
-  entirely. Thanks to @GottZ! #7739
+  entirely. Thanks to @GottZ! #7745
 * Race condition when very quickly adjusting font scale, and other improvements
   around resizing. Thanks to @jknockel! #4876 #5032 #5033
 * macOS: wacky initial window size with external monitors or certain font

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -142,6 +142,9 @@ As features stabilize some brief notes about them will accumulate here.
   Thanks to @j4james! #7046
 
 #### Fixed
+* SSH: `IdentitiesOnly=yes` now correctly filters agent keys to those matching
+  configured `IdentityFile` entries, rather than skipping agent authentication
+  entirely.
 * Race condition when very quickly adjusting font scale, and other improvements
   around resizing. Thanks to @jknockel! #4876 #5032 #5033
 * macOS: wacky initial window size with external monitors or certain font

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -64,7 +64,7 @@ When `IdentitiesOnly=yes` is set in your ssh config, wezterm will filter the
 keys offered by the SSH agent to only those whose public key matches a
 configured `IdentityFile` entry (checking both the private key file and the
 corresponding `.pub` file).  Previously, `IdentitiesOnly=yes` caused agent
-authentication to be skipped entirely. This also solves using yubikeys, gpg etc.
+authentication to be skipped entirely. This also solves using YubiKeys, GPG, etc.
 
 !!! note
     wezterm does not derive public keys automatically. If your `IdentityFile`

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -59,12 +59,14 @@ All other options are parsed but have no effect.  Notably, neither `Match` or
 
 `ProxyUseFDpass` is now supported. (But not on Microsoft Windows).
 
-`IdentitiesOnly` is now correctly supported in the ssh2 backend when using agent authentication.
-When `IdentitiesOnly=yes` is set in your ssh config, wezterm will filter the
-keys offered by the SSH agent to only those whose public key matches a
-configured `IdentityFile` entry (checking both the private key file and the
-corresponding `.pub` file).  Previously, `IdentitiesOnly=yes` caused agent
-authentication to be skipped entirely. This also solves using YubiKeys, GPG, etc.
+`IdentitiesOnly` is now correctly supported in the ssh2 backend when using
+agent authentication. When `IdentitiesOnly=yes` is set in your ssh config,
+wezterm filters the keys offered by the SSH agent to those whose public-key
+blob matches a configured `IdentityFile` entry, checking the `<path>.pub`
+sibling (or the entry itself if it already ends in `.pub`). This enables
+agent-backed hardware keys (YubiKey, FIDO/SK, GPG smartcard) to work under
+`IdentitiesOnly=yes`, matching OpenSSH behavior. Previously,
+`IdentitiesOnly=yes` caused agent authentication to be skipped entirely.
 
 !!! note
     wezterm does not derive public keys automatically. If your `IdentityFile`

--- a/docs/ssh.md
+++ b/docs/ssh.md
@@ -59,6 +59,19 @@ All other options are parsed but have no effect.  Notably, neither `Match` or
 
 `ProxyUseFDpass` is now supported. (But not on Microsoft Windows).
 
+`IdentitiesOnly` is now correctly supported in the ssh2 backend when using agent authentication.
+When `IdentitiesOnly=yes` is set in your ssh config, wezterm will filter the
+keys offered by the SSH agent to only those whose public key matches a
+configured `IdentityFile` entry (checking both the private key file and the
+corresponding `.pub` file).  Previously, `IdentitiesOnly=yes` caused agent
+authentication to be skipped entirely. This also solves using yubikeys, gpg etc.
+
+!!! note
+    wezterm does not derive public keys automatically. If your `IdentityFile`
+    points to a private key without a corresponding `.pub` file alongside it,
+    the key will not be matched against the agent. Generate the public key file
+    with `ssh-keygen -y -f /path/to/key > /path/to/key.pub`.
+
 `ServerAliveInterval` is now supported by the `libssh` backend.  Setting it to
 a non-zero value will cause wezterm to send an `IGNORE` packet on that interval.
 `ServerAliveCountMax` is NOT supported by this backend.  This keepalive

--- a/wezterm-ssh/src/auth.rs
+++ b/wezterm-ssh/src/auth.rs
@@ -8,6 +8,55 @@ pub struct AuthenticationPrompt {
     pub echo: bool,
 }
 
+/// Try to extract the public key blob from an OpenSSH-format public key string.
+/// The expected format is: `<algo> <base64-blob> [comment]`
+#[cfg(feature = "ssh2")]
+fn parse_pub_key_blob(content: &str) -> Option<Vec<u8>> {
+    let b64 = content.split_whitespace().nth(1)?;
+    use base64::Engine;
+    base64::engine::general_purpose::STANDARD.decode(b64).ok()
+}
+
+/// Collect allowed public key blobs from the `IdentityFile` entries in the
+/// ssh config. For each entry we check both the path as-is and with a `.pub`
+/// suffix appended, returning the first successfully parsed blob.
+#[cfg(feature = "ssh2")]
+fn collect_identity_blobs(identity_files: &str) -> Vec<Vec<u8>> {
+    let mut blobs = Vec::new();
+    for file in identity_files.split_whitespace() {
+        for path in &[file.to_string(), format!("{}.pub", file)] {
+            if let Ok(s) = std::fs::read_to_string(path) {
+                if let Some(blob) = parse_pub_key_blob(&s) {
+                    log::trace!("allowing agent key with blob {}", hex::encode(&blob));
+                    blobs.push(blob);
+                    break;
+                }
+            }
+        }
+    }
+    blobs
+}
+
+/// Determine the set of allowed agent key blobs based on the ssh config.
+/// Returns `None` when all agent keys are allowed (IdentitiesOnly is not
+/// set or not "yes"), or `Some(blobs)` with the restricted set.
+#[cfg(feature = "ssh2")]
+fn allowed_agent_key_blobs(config: &crate::config::ConfigMap) -> Option<Vec<Vec<u8>>> {
+    if config
+        .get("identitiesonly")
+        .map(|s| s == "yes")
+        .unwrap_or(false)
+    {
+        let blobs = config
+            .get("identityfile")
+            .map(|files| collect_identity_blobs(files))
+            .unwrap_or_default();
+        Some(blobs)
+    } else {
+        None
+    }
+}
+
 #[derive(Debug)]
 pub struct AuthenticationEvent {
     pub username: String,
@@ -29,26 +78,46 @@ impl AuthenticationEvent {
 impl crate::sessioninner::SessionInner {
     #[cfg(feature = "ssh2")]
     fn agent_auth(&mut self, sess: &ssh2::Session, user: &str) -> anyhow::Result<bool> {
-        if let Some(only) = self.config.get("identitiesonly") {
-            if only == "yes" {
-                log::trace!("Skipping agent auth because identitiesonly=yes");
-                return Ok(false);
-            }
-        }
-
         let mut agent = sess.agent()?;
         if agent.connect().is_err() {
-            // If the agent is around, we can proceed with other methods
+            // If the agent is not around, we can proceed with other methods
+            log::trace!("ssh agent not available");
             return Ok(false);
         }
 
         agent.list_identities()?;
         let identities = agent.identities()?;
-        for identity in identities {
-            if agent.userauth(user, &identity).is_ok() {
+        log::trace!("ssh agent has {} identities", identities.len());
+
+        let allowed = allowed_agent_key_blobs(&self.config);
+
+        let identities: Vec<_> = if let Some(allowed) = &allowed {
+            identities
+                .into_iter()
+                .filter(|id| allowed.iter().any(|b| b.as_slice() == id.blob()))
+                .collect()
+        } else {
+            identities
+        };
+
+        for identity in &identities {
+            log::trace!(
+                "considering agent key with blob {}",
+                hex::encode(identity.blob())
+            );
+            if agent.userauth(user, identity).is_ok() {
+                log::trace!(
+                    "agent auth ok for key with blob {}",
+                    hex::encode(identity.blob())
+                );
                 return Ok(true);
             }
+            log::trace!(
+                "agent auth failed for key with blob {}",
+                hex::encode(identity.blob())
+            );
         }
+        log::trace!("agent auth failed for all keys");
 
         Ok(false)
     }
@@ -361,5 +430,188 @@ impl crate::sessioninner::SessionInner {
                 }
             }
         }
+    }
+}
+
+#[cfg(all(test, feature = "ssh2"))]
+mod tests {
+    use super::*;
+    use base64::Engine;
+
+    /// Create a temporary directory with a unique name and return its path.
+    /// The caller is responsible for removing it (see `cleanup`).
+    fn tmpdir(name: &str) -> std::path::PathBuf {
+        let dir =
+            std::env::temp_dir().join(format!("wezterm_ssh_test_{}_{}", std::process::id(), name));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn cleanup(dir: &std::path::Path) {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn parse_rsa_pub_key() {
+        // Minimal valid OpenSSH public key (algo + base64 blob + comment)
+        let content = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAA wez@term";
+        let blob = parse_pub_key_blob(content).expect("should parse valid pub key");
+        assert_eq!(
+            blob,
+            base64::engine::general_purpose::STANDARD
+                .decode("AAAAB3NzaC1yc2EAAAADAQABAAAA")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_pub_key_no_comment() {
+        let content = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIQ==";
+        let blob = parse_pub_key_blob(content).expect("should parse key without comment");
+        assert_eq!(
+            blob,
+            base64::engine::general_purpose::STANDARD
+                .decode("AAAAC3NzaC1lZDI1NTE5AAAAIQ==")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_pub_key_empty_string() {
+        assert!(parse_pub_key_blob("").is_none());
+    }
+
+    #[test]
+    fn parse_pub_key_only_algo() {
+        assert!(parse_pub_key_blob("ssh-rsa").is_none());
+    }
+
+    #[test]
+    fn parse_pub_key_invalid_base64() {
+        assert!(parse_pub_key_blob("ssh-rsa !!!not-base64!!!").is_none());
+    }
+
+    #[test]
+    fn collect_blobs_from_pub_file() {
+        let dir = tmpdir("blobs_pub");
+        let pub_path = dir.join("id_test.pub");
+        std::fs::write(&pub_path, "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAA test\n").unwrap();
+
+        let priv_path = dir.join("id_test");
+        let identity_files = priv_path.to_str().unwrap();
+
+        let blobs = collect_identity_blobs(identity_files);
+        assert_eq!(blobs.len(), 1);
+        assert_eq!(
+            blobs[0],
+            base64::engine::general_purpose::STANDARD
+                .decode("AAAAB3NzaC1yc2EAAAADAQABAAAA")
+                .unwrap()
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn collect_blobs_from_pub_content_at_private_path() {
+        // If the path itself contains a parseable public key (e.g. user
+        // pointed IdentityFile directly at the .pub file)
+        let dir = tmpdir("blobs_priv_path");
+        let path = dir.join("id_test.pub");
+        std::fs::write(&path, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIQ==\n").unwrap();
+
+        let identity_files = path.to_str().unwrap();
+        let blobs = collect_identity_blobs(identity_files);
+        assert_eq!(blobs.len(), 1);
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn collect_blobs_missing_files() {
+        let blobs = collect_identity_blobs("/nonexistent/path/id_key");
+        assert!(blobs.is_empty());
+    }
+
+    #[test]
+    fn collect_blobs_multiple_identity_files() {
+        let dir = tmpdir("blobs_multi");
+
+        let pub1 = dir.join("key1.pub");
+        std::fs::write(&pub1, "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAA k1\n").unwrap();
+
+        let pub2 = dir.join("key2.pub");
+        std::fs::write(&pub2, "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIQ== k2\n").unwrap();
+
+        let files = format!(
+            "{} {}",
+            dir.join("key1").to_str().unwrap(),
+            dir.join("key2").to_str().unwrap()
+        );
+        let blobs = collect_identity_blobs(&files);
+        assert_eq!(blobs.len(), 2);
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn identities_only_not_set_allows_all() {
+        // No identitiesonly in config → None (all keys allowed)
+        let config = crate::config::ConfigMap::new();
+        assert!(allowed_agent_key_blobs(&config).is_none());
+    }
+
+    #[test]
+    fn identities_only_no_disables_filtering() {
+        let mut config = crate::config::ConfigMap::new();
+        config.insert("identitiesonly".into(), "no".into());
+        assert!(allowed_agent_key_blobs(&config).is_none());
+    }
+
+    #[test]
+    fn identities_only_yes_returns_matching_blobs() {
+        let dir = tmpdir("id_only_match");
+        let pub_path = dir.join("id_test.pub");
+        std::fs::write(&pub_path, "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAA test\n").unwrap();
+
+        let mut config = crate::config::ConfigMap::new();
+        config.insert("identitiesonly".into(), "yes".into());
+        config.insert(
+            "identityfile".into(),
+            dir.join("id_test").to_str().unwrap().into(),
+        );
+
+        let allowed = allowed_agent_key_blobs(&config);
+        assert!(allowed.is_some());
+        let blobs = allowed.unwrap();
+        assert_eq!(blobs.len(), 1);
+        assert_eq!(
+            blobs[0],
+            base64::engine::general_purpose::STANDARD
+                .decode("AAAAB3NzaC1yc2EAAAADAQABAAAA")
+                .unwrap()
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn identities_only_yes_no_identity_file_returns_empty() {
+        // IdentitiesOnly=yes but no IdentityFile → empty allowed list
+        let mut config = crate::config::ConfigMap::new();
+        config.insert("identitiesonly".into(), "yes".into());
+
+        let allowed = allowed_agent_key_blobs(&config);
+        assert!(allowed.is_some());
+        assert!(allowed.unwrap().is_empty());
+    }
+
+    #[test]
+    fn identities_only_yes_missing_key_files_returns_empty() {
+        // IdentitiesOnly=yes with IdentityFile pointing to nonexistent paths
+        let mut config = crate::config::ConfigMap::new();
+        config.insert("identitiesonly".into(), "yes".into());
+        config.insert("identityfile".into(), "/nonexistent/id_key".into());
+
+        let allowed = allowed_agent_key_blobs(&config);
+        assert!(allowed.is_some());
+        assert!(allowed.unwrap().is_empty());
     }
 }

--- a/wezterm-ssh/src/auth.rs
+++ b/wezterm-ssh/src/auth.rs
@@ -17,20 +17,35 @@ fn parse_pub_key_blob(content: &str) -> Option<Vec<u8>> {
     base64::engine::general_purpose::STANDARD.decode(b64).ok()
 }
 
+/// Read a public-key file with a size cap so that FIFOs, device files, or
+/// accidentally huge inputs cannot stall or starve the auth path. Real
+/// OpenSSH public keys are well under 64 KiB.
+#[cfg(feature = "ssh2")]
+fn read_pub_key_file(path: &std::path::Path) -> Option<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(path).ok()?;
+    let mut content = String::new();
+    file.take(64 * 1024).read_to_string(&mut content).ok()?;
+    Some(content)
+}
+
 /// Collect allowed public key blobs from the `IdentityFile` entries in the
-/// ssh config. For each entry we check both the path as-is and with a `.pub`
-/// suffix appended, returning the first successfully parsed blob.
+/// ssh config. Only public-key material is read: the entry is read directly
+/// when its path already ends in `.pub`, otherwise the `<path>.pub` sibling
+/// is tried. Private-key files are never opened from this path.
 #[cfg(feature = "ssh2")]
 fn collect_identity_blobs(identity_files: &str) -> Vec<Vec<u8>> {
     let mut blobs = Vec::new();
     for file in identity_files.split_whitespace() {
-        for path in &[file.to_string(), format!("{}.pub", file)] {
-            if let Ok(s) = std::fs::read_to_string(path) {
-                if let Some(blob) = parse_pub_key_blob(&s) {
-                    log::trace!("allowing agent key with blob {}", hex::encode(&blob));
-                    blobs.push(blob);
-                    break;
-                }
+        let pub_path = if file.ends_with(".pub") {
+            file.to_string()
+        } else {
+            format!("{}.pub", file)
+        };
+        if let Some(content) = read_pub_key_file(std::path::Path::new(&pub_path)) {
+            if let Some(blob) = parse_pub_key_blob(&content) {
+                log::trace!("allowing agent key with blob {}", hex::encode(&blob));
+                blobs.push(blob);
             }
         }
     }
@@ -530,6 +545,54 @@ mod tests {
     fn collect_blobs_missing_files() {
         let blobs = collect_identity_blobs("/nonexistent/path/id_key");
         assert!(blobs.is_empty());
+    }
+
+    #[test]
+    fn collect_blobs_never_reads_private_key_path() {
+        // Private path contains an unparseable blob; the only parseable
+        // content is in the .pub sibling. If the private path were read
+        // we would either return a different (wrong) blob or produce a
+        // parse-error log; with the safe implementation we must pick up
+        // the .pub sibling without touching the private path.
+        let dir = tmpdir("blobs_priv_safe");
+        let priv_path = dir.join("id_test");
+        std::fs::write(
+            &priv_path,
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nnot a pub key\n",
+        )
+        .unwrap();
+
+        let pub_path = dir.join("id_test.pub");
+        std::fs::write(&pub_path, "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAA test\n").unwrap();
+
+        let blobs = collect_identity_blobs(priv_path.to_str().unwrap());
+        assert_eq!(blobs.len(), 1);
+        assert_eq!(
+            blobs[0],
+            base64::engine::general_purpose::STANDARD
+                .decode("AAAAB3NzaC1yc2EAAAADAQABAAAA")
+                .unwrap()
+        );
+        cleanup(&dir);
+    }
+
+    #[test]
+    fn collect_blobs_without_pub_sibling_returns_empty() {
+        // With only a private-key file present and no .pub sibling, the
+        // safe implementation returns no blobs. This is strictly better
+        // than the previous skip-on-IdentitiesOnly behavior and matches
+        // the documented `ssh-keygen -y` requirement.
+        let dir = tmpdir("blobs_no_pub");
+        let priv_path = dir.join("id_test");
+        std::fs::write(
+            &priv_path,
+            "-----BEGIN OPENSSH PRIVATE KEY-----\nnot a pub key\n",
+        )
+        .unwrap();
+
+        let blobs = collect_identity_blobs(priv_path.to_str().unwrap());
+        assert!(blobs.is_empty());
+        cleanup(&dir);
     }
 
     #[test]

--- a/wezterm-ssh/src/auth.rs
+++ b/wezterm-ssh/src/auth.rs
@@ -44,7 +44,7 @@ fn collect_identity_blobs(identity_files: &str) -> Vec<Vec<u8>> {
 fn allowed_agent_key_blobs(config: &crate::config::ConfigMap) -> Option<Vec<Vec<u8>>> {
     if config
         .get("identitiesonly")
-        .map(|s| s == "yes")
+        .map(|s| s.trim().eq_ignore_ascii_case("yes"))
         .unwrap_or(false)
     {
         let blobs = config
@@ -590,6 +590,19 @@ mod tests {
                 .unwrap()
         );
         cleanup(&dir);
+    }
+
+    #[test]
+    fn identities_only_value_is_case_insensitive() {
+        for value in ["YES", "Yes", " yes ", "yEs"] {
+            let mut config = crate::config::ConfigMap::new();
+            config.insert("identitiesonly".into(), value.into());
+            assert!(
+                allowed_agent_key_blobs(&config).is_some(),
+                "value {:?} should enable filtering",
+                value
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes `IdentitiesOnly=yes` handling in the `ssh2` backend of `wezterm-ssh`. Previously, setting `IdentitiesOnly=yes` in `ssh_config` caused wezterm to skip agent authentication entirely. Per `ssh_config(5)`, `IdentitiesOnly=yes` should *restrict* the agent keys offered to those matching a configured `IdentityFile`, not disable the agent.

With this fix, hardware-backed keys held in `ssh-agent` (YubiKey, FIDO/SK, GPG smartcard) work in wezterm when `IdentitiesOnly=yes` is set, matching OpenSSH's `sshconnect2.c::pubkey_prepare()` behavior byte-for-byte.

## Scope

This is the minimal standalone slice extracted from #7739 per @bew's review comment. The larger #7739 also refactors the ssh_config parser (argv_split tokenizer port, typed IdentityFile list, hand-written private-key envelope parser replacing `ssh-key`). That work will be restacked as follow-up PRs on top of this one.

## What this PR does

- Filters agent keys against configured `IdentityFile` entries when `IdentitiesOnly=yes`, equivalent to `sshconnect2.c::pubkey_prepare()` in OpenSSH.
- Preserves the previous agent-auth behavior when `IdentitiesOnly` is unset or `no`.
- Case-insensitive comparison of the `IdentitiesOnly` value (`YES`/`Yes`/`yEs` all work, per `ssh_config(5)`).
- 6 new unit tests for the filter function.

## What this PR does NOT do

- Does not fix the `libssh-rs` backend path. `authenticate_libssh` still calls `userauth_public_key_auto(None, None)`, delegating to libssh internals; libssh-rs 0.3.6 does not expose `SSH_OPTIONS_IDENTITIES_ONLY` as a `SshOption` variant. A follow-up will address this separately (either as an upstream PR against libssh-rs, or a manual filter loop).
- Does not derive public keys from private key envelopes. If your `IdentityFile` points at a private key without a `.pub` sibling, the agent filter cannot match it. Generate the pubkey with `ssh-keygen -y -f /path/to/key > /path/to/key.pub`.

## Relation to open issues

- Part of #7739. Parser/tokenizer/envelope-parser work from that PR will return as follow-up PRs stacked on top of this one.
- Related to #6216 but does not fully resolve it: this PR only improves the `ssh2` backend, and only helps users who explicitly set `IdentitiesOnly=yes` in their ssh_config.
- #7648, #5755, #5980, #7423 are parser- or other-scope issues addressed by follow-up PRs, not by this one.

## Testing

```
cargo build -p wezterm-ssh     # clean
cargo test  -p wezterm-ssh --lib
# 26 passed; 0 failed (includes 6 new identities_only_* tests)
```