### PR TITLE
Add NocturnalZone color scheme

### DIFF
--- a/sync-color-schemes/src/main.rs
+++ b/sync-color-schemes/src/main.rs
@@ -425,6 +425,9 @@ async fn main() -> anyhow::Result<()> {
     schemeses
         .sync_toml("https://github.com/eldritch-theme/wezterm", "master", "")
         .await?;
+    schemeses
+        .sync_toml("https://github.com/noxyzone/nocturnalzone-wezterm", "main", "")
+        .await?;
     schemeses.accumulate(iterm2::sync_iterm2().await.context("sync iterm2")?);
     schemeses.accumulate(base16::sync().await.context("sync base16")?);
     schemeses.accumulate(gogh::sync_gogh().await.context("sync gogh")?);


### PR DESCRIPTION
## Summary

- Adds [NocturnalZone](https://github.com/noxyzone/nocturnalzone-wezterm) to the color scheme sync list
- Dark theme based on the NocturnalZone brand palette
- Includes full tab bar colors

## Source

- Repository: https://github.com/noxyzone/nocturnalzone-wezterm
- Theme file: `NocturnalZone.toml`