### PR TITLE
docs(install/linux): qualify Linuxbrew install command to dodge cask collision

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -281,13 +281,17 @@ hide:
 
     ```console
     $ brew tap wezterm/wezterm-linuxbrew
-    $ brew install wezterm
+    $ brew install wezterm/wezterm-linuxbrew/wezterm
     ```
+
+    The fully-qualified `wezterm/wezterm-linuxbrew/wezterm` form is required
+    on Linux: a plain `brew install wezterm` resolves to the macOS-only cask
+    and fails with `Error: macOS is required for this software`.
 
     If you'd like to use a nightly build you can perform a head install:
 
     ```console
-    $ brew install --HEAD wezterm
+    $ brew install --HEAD wezterm/wezterm-linuxbrew/wezterm
     ```
 
     to upgrade to a newer nightly, it is simplest to remove then


### PR DESCRIPTION
Fixes #7755.

Reported issue: `brew install wezterm` on Linux resolves to the macOS-only Homebrew cask instead of the Linuxbrew formula from `wezterm/wezterm-linuxbrew`, and aborts with `Error: macOS is required for this software`.

Fix: use the fully-qualified formula name in the install snippets — `brew install wezterm/wezterm-linuxbrew/wezterm` (and the same for `--HEAD`) — and add a one-line note explaining why the qualification is required on Linux.

```diff
- $ brew install wezterm
+ $ brew install wezterm/wezterm-linuxbrew/wezterm

- $ brew install --HEAD wezterm
+ $ brew install --HEAD wezterm/wezterm-linuxbrew/wezterm
```

Single file (`docs/install/linux.md`), docs-only, no code or test changes.