### PR TITLE
fix copy mode selection flicker in terminal multiplexers

### DIFF
--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -423,9 +423,13 @@ impl CopyRenderable {
         let pane_id = self.delegate.pane_id();
         self.window
             .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
+                let mux = mux::Mux::get();
                 let mut selection = term_window.selection(pane_id);
                 selection.origin.take();
                 selection.range.take();
+                if let Some(pane) = mux.get_pane(pane_id) {
+                    selection.seqno = pane.get_current_seqno();
+                }
             })));
     }
 
@@ -514,10 +518,14 @@ impl CopyRenderable {
         let mode = self.selection_mode;
         self.window
             .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
+                let mux = mux::Mux::get();
                 let mut selection = term_window.selection(pane_id);
                 selection.origin = Some(start);
                 selection.range = Some(range);
                 selection.rectangular = mode == SelectionMode::Block;
+                if let Some(pane) = mux.get_pane(pane_id) {
+                    selection.seqno = pane.get_current_seqno();
+                }
                 window.invalidate();
             })));
         self.adjust_viewport_for_cursor_position();


### PR DESCRIPTION
Closes #7740

## Changes

- Update `selection.seqno = pane.get_current_seqno()` inside `CopyRenderable::adjust_selection()` and `CopyRenderable::clear_selection()` so the selection state stays in sync with the pane's current sequence number.
- Without this update, the seqno remained at its default (0). In a multiplexer (zellij/tmux), the underlying pane keeps producing output (status bar refresh, cursor repositioning, etc.), so `check_for_dirty_lines_and_invalidate_selection()` reports every visible line as dirty on every render cycle and the highlight flashes and disappears on each cursor move.
- Mirrors the pattern already used by `extend_selection_at_mouse_cursor` (`termwindow/selection.rs:120`) and `QuickSelectOverlay::select_and_copy_match_number` (`overlay/quickselect.rs:955`).

## Repro / Verification

1. Open WezTerm, start `zellij` (or `tmux`).
2. Trigger `ActivateCopyMode`, press `v`, then move with `h/j/k/l`.
3. Before the fix: highlight flashes and vanishes.
4. After the fix: highlight persists and extends correctly.

Verified locally on macOS (Darwin 25.3.0) with a release build of this branch.