### PR TITLE
Fix PaneFocused notification storm on pane destruction and mux reconciliation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ camino = "1.0"
 cassowary = "0.3"
 cc = {version="1.0", features = ["parallel"]}
 cgl = "0.3"
-chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde"]}
+chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde", "clock"]}
 clap = {version="4.0", features=["derive"]}
 clap_complete = "4.4"
 clap_complete_fig = "4.0"

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::client::{ClientId, ClientInfo};
 use crate::pane::{CachePolicy, Pane, PaneId};
 use crate::ssh_agent::AgentProxy;
-use crate::tab::{SplitRequest, Tab, TabId};
+use crate::tab::{NotifyMux, SplitRequest, Tab, TabId};
 use crate::window::{Window, WindowId};
 use anyhow::{anyhow, Context, Error};
 use config::keyassignment::SpawnTabDomain;
@@ -559,7 +559,7 @@ impl Mux {
             .get_tab(tab_id)
             .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
 
-        tab.set_active_pane(&pane);
+        tab.set_active_pane_with_notify(&pane, NotifyMux::No);
 
         Ok(())
     }

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -20,6 +20,12 @@ pub type Cursor = bintree::Cursor<Arc<dyn Pane>, SplitDirectionAndSize>;
 static TAB_ID: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(0);
 pub type TabId = usize;
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum NotifyMux {
+    Yes,
+    No,
+}
+
 #[derive(Default)]
 struct Recency {
     count: usize,
@@ -699,7 +705,11 @@ impl Tab {
     }
 
     pub fn set_active_pane(&self, pane: &Arc<dyn Pane>) {
-        self.inner.lock().set_active_pane(pane)
+        self.set_active_pane_with_notify(pane, NotifyMux::Yes)
+    }
+
+    pub fn set_active_pane_with_notify(&self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
+        self.inner.lock().set_active_pane(pane, notify)
     }
 
     pub fn set_active_idx(&self, pane_index: usize) {
@@ -1747,7 +1757,7 @@ impl TabInner {
         self.active
     }
 
-    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>) {
+    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
         let prior = self.get_active_pane();
 
         if is_pane(pane, &prior.as_ref()) {
@@ -1768,22 +1778,26 @@ impl TabInner {
         {
             self.active = item.index;
             self.recency.tag(item.index);
-            self.advise_focus_change(prior);
+            self.advise_focus_change(prior, notify);
         }
     }
 
-    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>) {
+    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>, notify: NotifyMux) {
         let mux = Mux::get();
         let current = self.get_active_pane();
         match (prior, current) {
             (Some(prior), Some(current)) if prior.pane_id() != current.pane_id() => {
                 prior.focus_changed(false);
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (None, Some(current)) => {
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (Some(prior), None) => {
                 prior.focus_changed(false);
@@ -1798,7 +1812,7 @@ impl TabInner {
         let prior = self.get_active_pane();
         self.active = pane_index;
         self.recency.tag(pane_index);
-        self.advise_focus_change(prior);
+        self.advise_focus_change(prior, NotifyMux::Yes);
     }
 
     fn assign_pane(&mut self, pane: &Arc<dyn Pane>) {
@@ -1861,7 +1875,7 @@ impl TabInner {
         if keep_focus {
             self.set_active_idx(pane_index);
         } else {
-            self.advise_focus_change(Some(pane));
+            self.advise_focus_change(Some(pane), NotifyMux::Yes);
         }
         None
     }
@@ -2279,7 +2293,7 @@ mod test {
         fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
             Ok(None)
         }
-        fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+        fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
             unimplemented!()
         }
         fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {
@@ -2515,6 +2529,53 @@ mod test {
         assert_eq!(24, panes[2].height);
         assert_eq!(400, panes[2].pixel_width);
         assert_eq!(600, panes[2].pixel_height);
+    }
+
+    #[test]
+    fn set_active_pane_can_suppress_mux_notification() {
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+
+        let mux = Arc::new(Mux::new(None));
+        Mux::set_mux(&mux);
+
+        let notifications = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&notifications);
+        mux.subscribe(move |notification| {
+            if let MuxNotification::PaneFocused(pane_id) = notification {
+                seen.lock().push(pane_id);
+            }
+            true
+        });
+
+        let tab = Tab::new(&size);
+        let pane_1 = FakePane::new(1, size);
+        tab.assign_pane(&pane_1);
+        let pane_2 = FakePane::new(2, size);
+        let split = tab
+            .compute_split_size(
+                0,
+                SplitRequest {
+                    direction: SplitDirection::Horizontal,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        tab.split_and_insert(0, SplitRequest::default(), Arc::clone(&pane_2))
+            .unwrap();
+
+        pane_1.resize(split.first).unwrap();
+        tab.set_active_pane_with_notify(&pane_1, NotifyMux::No);
+
+        assert_eq!(Vec::<PaneId>::new(), *notifications.lock());
+        assert_eq!(1, tab.get_active_pane().unwrap().pane_id());
+
+        Mux::shutdown();
     }
 
     fn is_send_and_sync<T: Send + Sync>() -> bool {

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -1,7 +1,7 @@
 use crate::domain::{DomainId, WriterWrapper};
 use crate::localpane::LocalPane;
 use crate::pane::{alloc_pane_id, PaneId};
-use crate::tab::{SplitDirection, SplitRequest, SplitSize, Tab, TabId};
+use crate::tab::{NotifyMux, SplitDirection, SplitRequest, SplitSize, Tab, TabId};
 use crate::tmux::{AttachState, TmuxDomain, TmuxDomainState, TmuxRemotePane, TmuxTab};
 use crate::tmux_pty::{TmuxChild, TmuxPty};
 use crate::{Mux, MuxNotification, Pane};
@@ -341,7 +341,7 @@ impl TmuxDomainState {
 
                     match mux.get_tab(local_tab.tab_id) {
                         Some(tab) => {
-                            tab.set_active_pane(&local_pane);
+                            tab.set_active_pane_with_notify(&local_pane, NotifyMux::No);
                             mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
                         }
                         None => {}

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -226,6 +226,17 @@ impl ClientPane {
                 // it here.
                 log::trace!("advised of remote pane focus: {pane_id}");
 
+                // Match the server's focus state before applying it locally.
+                // `focus_pane_and_containing_tab` calls through to
+                // `focus_changed(true)`, and for remote panes that normally
+                // advises the server of the new focus. Without this guard, a
+                // server-originated focus notification can be echoed back as a
+                // fresh `SetFocusedPane` request.
+                {
+                    let mut focused = self.client.focused_remote_pane_id.lock().unwrap();
+                    *focused = Some(pane_id);
+                }
+
                 let mux = Mux::get();
                 if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
                     log::error!("Error reconciling remote PaneFocused notification: {err:#}");

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -78,13 +78,20 @@ impl GuiFrontEnd {
                     .detach();
                 }
                 MuxNotification::PaneFocused(pane_id) => {
-                    promise::spawn::spawn_into_main_thread(async move {
-                        let mux = Mux::get();
-                        if let Err(err) = mux.focus_pane_and_containing_tab(pane_id) {
-                            log::error!("Error reconciling PaneFocused notification: {err:#}");
-                        }
-                    })
-                    .detach();
+                    // Skip notifications for panes the mux has already destroyed
+                    // (e.g. backlog draining after a domain detach). Prevents the
+                    // UI thread from being flooded with no-op reconciliation tasks
+                    // when many panes go away at once.
+                    // See https://github.com/wezterm/wezterm/issues/4390
+                    if Mux::get().get_pane(pane_id).is_some() {
+                        promise::spawn::spawn_into_main_thread(async move {
+                            let mux = Mux::get();
+                            if let Err(err) = mux.focus_pane_and_containing_tab(pane_id) {
+                                log::error!("Error reconciling PaneFocused notification: {err:#}");
+                            }
+                        })
+                        .detach();
+                    }
                 }
                 MuxNotification::TabTitleChanged { .. } => {}
                 MuxNotification::WindowTitleChanged { .. } => {}

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -6,7 +6,7 @@ use mux::client::ClientId;
 use mux::domain::SplitSource;
 use mux::pane::{CachePolicy, Pane, PaneId};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
-use mux::tab::TabId;
+use mux::tab::{NotifyMux, TabId};
 use mux::{Mux, MuxNotification};
 use promise::spawn::spawn_into_main_thread;
 use std::collections::HashMap;
@@ -358,7 +358,7 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(tab_id)
                                 .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
-                            tab.set_active_pane(&pane);
+                            tab.set_active_pane_with_notify(&pane, NotifyMux::No);
 
                             mux.record_focus_for_current_identity(pane_id);
                             mux.notify(mux::MuxNotification::PaneFocused(pane_id));


### PR DESCRIPTION
Fixes #4390

Picks up where #4737 left off. That PR was closed because
unconditionally suppressing the `PaneFocused` notification from
`advise_focus_change` broke `wezterm cli activate-{tab,pane}` over SSH
and prevented focus updates from reaching other attached clients.

## Problem

Three things conspire to create a runaway focus-notification loop:

1. **Destroyed-pane storm** — when a unix-domain detach tears down many
   panes at once, the subscriber drains a burst of `PaneFocused`
   notifications whose pane ids are already gone. The handler in
   `frontend.rs` spawns a reconciliation task on the main thread for
   *every* one of them. Thousands of these pile up faster than the UI
   thread can service them, resulting in unresponsive mouse input,
   erratic focus changes, and a flood of
   `"Error reconciling PaneFocused notification: pane X not found"`
   in the log.

2. **Redundant re-notification** — several call sites
   (`Mux::add_pane_to_window`, `sessionhandler`, `tmux_commands`)
   call `set_active_pane` and then immediately fire their own
   `MuxNotification::PaneFocused`. Because `advise_focus_change` also
   fires the same notification, every focus change emits the event
   twice. With two rapid user-initiated switches (pane 0 → 1 → 0),
   the doubled events interleave and the queue never drains —
   exactly the scenario described in #4390 and #4517.

3. **Client echo-back** — when a remote `PaneFocused` arrives at a
   client pane, `focus_pane_and_containing_tab` calls
   `focus_changed(true)`, which for a `ClientPane` advises the server
   of the "new" focus. This echoes the server's own notification
   right back as a fresh `SetFocusedPane` PDU, adding fuel to the
   loop.

## Fix

Each layer gets a targeted guard rather than a blanket suppression:

- **`frontend.rs`** — cheap synchronous `get_pane()` check before
  spawning the reconciliation task. Defunct notifications are dropped
  without touching the UI thread. A pane that disappears between the
  guard and the spawned task falls through to the existing error log.

- **`tab.rs`** — new `NotifyMux` enum and `set_active_pane_with_notify`
  entry point. Call sites that fire their own notification pass
  `NotifyMux::No` to avoid the duplicate; everyone else (including the
  GUI and `set_active_idx`) still gets the notification via the
  default `set_active_pane` → `NotifyMux::Yes` path.
  This is the same `NotifyMux` idea from #4737, but applied only to the
  three call sites that already send the notification themselves, so
  SSH-attached clients and `wezterm cli activate-*` keep working.

- **`clientpane.rs`** — pre-set `focused_remote_pane_id` before calling
  `focus_pane_and_containing_tab`, so the subsequent
  `focus_changed(true)` sees the pane as already focused on the server
  side and does not echo back a `SetFocusedPane` PDU.

## Testing

Added `set_active_pane_can_suppress_mux_notification` unit test that
verifies `NotifyMux::No` actually suppresses the notification.

Manually verified:
- local pane focus switching (including rapid Alt+arrow spam)
- `wezterm cli activate-pane` / `activate-tab` over unix domain
- detaching a domain with many panes no longer floods the log