### PR TITLE
docs: example for adjusting window opacity incrementally

### DIFF
--- a/docs/config/lua/window/set_config_overrides.md
+++ b/docs/config/lua/window/set_config_overrides.md
@@ -73,3 +73,49 @@ return {
 }
 ```
 
+In this example, two key assignments (`CTRL-SHIFT-PageUp` and `CTRL-SHIFT-PageDown`)
+adjust the window opacity incrementally instead of toggling. Each press reads
+the current opacity (falling back to the configured value if no override is
+set yet), nudges it by 0.1, and clamps the result to a sensible range so the
+window stays visible:
+
+```lua
+local wezterm = require 'wezterm'
+
+local function adjust_opacity(window, delta)
+  local overrides = window:get_config_overrides() or {}
+  -- Pick up the current opacity from the override, then the static config,
+  -- defaulting to fully opaque if neither is set.
+  local current = overrides.window_background_opacity
+    or window:effective_config().window_background_opacity
+    or 1.0
+  -- Clamp to [0.1, 1.0] so the window doesn't disappear or exceed full opacity.
+  overrides.window_background_opacity =
+    math.max(0.1, math.min(1.0, current + delta))
+  window:set_config_overrides(overrides)
+end
+
+wezterm.on('increase-opacity', function(window, _)
+  adjust_opacity(window, 0.1)
+end)
+
+wezterm.on('decrease-opacity', function(window, _)
+  adjust_opacity(window, -0.1)
+end)
+
+return {
+  keys = {
+    {
+      key = 'PageUp',
+      mods = 'CTRL|SHIFT',
+      action = wezterm.action.EmitEvent 'increase-opacity',
+    },
+    {
+      key = 'PageDown',
+      mods = 'CTRL|SHIFT',
+      action = wezterm.action.EmitEvent 'decrease-opacity',
+    },
+  },
+}
+```
+

--- a/docs/config/lua/window/set_config_overrides.md
+++ b/docs/config/lua/window/set_config_overrides.md
@@ -95,25 +95,21 @@ local function adjust_opacity(window, delta)
   window:set_config_overrides(overrides)
 end
 
-wezterm.on('increase-opacity', function(window, _)
-  adjust_opacity(window, 0.1)
-end)
-
-wezterm.on('decrease-opacity', function(window, _)
-  adjust_opacity(window, -0.1)
-end)
-
 return {
   keys = {
     {
       key = 'PageUp',
       mods = 'CTRL|SHIFT',
-      action = wezterm.action.EmitEvent 'increase-opacity',
+      action = wezterm.action_callback(function(window, _)
+        adjust_opacity(window, 0.1)
+      end),
     },
     {
       key = 'PageDown',
       mods = 'CTRL|SHIFT',
-      action = wezterm.action.EmitEvent 'decrease-opacity',
+      action = wezterm.action_callback(function(window, _)
+        adjust_opacity(window, -0.1)
+      end),
     },
   },
 }


### PR DESCRIPTION
adds a third example to `set_config_overrides` showing how to adjust `window_background_opacity` by a delta with two key bindings, instead of just toggling.

closes #5792