### PR TITLE
flatpak: bump runtime to 24.08

### DIFF
--- a/assets/flatpak/org.wezfurlong.wezterm.json
+++ b/assets/flatpak/org.wezfurlong.wezterm.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.wezfurlong.wezterm",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/assets/flatpak/org.wezfurlong.wezterm.template.json
+++ b/assets/flatpak/org.wezfurlong.wezterm.template.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.wezfurlong.wezterm",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "23.08",
+    "runtime-version": "24.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/ci/flatpak.sh
+++ b/ci/flatpak.sh
@@ -2,7 +2,7 @@
 set -xe
 
 flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-flatpak install --noninteractive --user flathub org.freedesktop.Platform//23.08 org.freedesktop.Sdk//23.08 org.freedesktop.Sdk.Extension.rust-stable//23.08
+flatpak install --noninteractive --user flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 org.freedesktop.Sdk.Extension.rust-stable//24.08
 
 flatpak install --noninteractive --user org.freedesktop.appstream-glib
 


### PR DESCRIPTION
bumps `org.freedesktop.Platform`, `Sdk`, and `Sdk.Extension.rust-stable` from 23.08 to 24.08 in the manifest pair and the ci install script.

closes #6965