### PR TITLE
docs: fix Linuxbrew install command

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -281,7 +281,7 @@ hide:
 
     ```console
     $ brew tap wezterm/wezterm-linuxbrew
-    $ brew install wezterm
+    $ brew install wezterm/wezterm-linuxbrew/wezterm
     ```
 
     If you'd like to use a nightly build you can perform a head install:


### PR DESCRIPTION
Fixes #7755

Update the Linuxbrew install command in the Linux install docs to use the tapped formula path.