### PR TITLE
Fix mux client-server deadlock when connecting with many panes

### DIFF
--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use codec::*;
 use config::{configuration, SshDomain, TlsDomainClient, UnixDomain, UnixTarget};
 use filedescriptor::FileDescriptor;
-use futures::FutureExt;
+use futures::AsyncReadExt as _;
 use mux::client::ClientId;
 use mux::connui::ConnectionUI;
 use mux::domain::DomainId;
@@ -48,7 +48,6 @@ enum ReaderMessage {
         pdu: Pdu,
         promise: Sender<anyhow::Result<Pdu>>,
     },
-    Readable,
 }
 
 #[derive(Clone)]
@@ -350,87 +349,117 @@ async fn client_thread_async(
     local_domain_id: Option<DomainId>,
     rx: &mut Receiver<ReaderMessage>,
 ) -> anyhow::Result<()> {
-    let mut next_serial = 1u64;
+    let stream = reconnectable.take_stream().unwrap();
+    let (reader, writer) = futures::AsyncReadExt::split(stream);
 
-    struct Promises {
-        map: HashMap<u64, Sender<anyhow::Result<Pdu>>>,
-    }
+    // Channel for writer to register promises with the reader task.
+    // Writer sends (serial, promise_sender) before writing the PDU to the socket,
+    // so the reader always has the promise registered before the response can arrive.
+    let (promise_tx, promise_rx) = smol::channel::unbounded::<(u64, Sender<anyhow::Result<Pdu>>)>();
 
-    impl Promises {
-        fn fail_all(&mut self, reason: &str) {
-            log::trace!("failing all promises: {}", reason);
-            for (_, promise) in self.map.drain() {
-                let _ = promise.try_send(Err(anyhow!("{}", reason)));
-            }
-        }
-    }
+    let writer_fut = async {
+        let mut writer = writer;
+        let mut next_serial = 1u64;
 
-    impl Drop for Promises {
-        fn drop(&mut self) {
-            self.fail_all("Client was destroyed");
-        }
-    }
-    let mut promises = Promises {
-        map: HashMap::new(),
-    };
+        loop {
+            match rx.recv().await {
+                Ok(ReaderMessage::SendPdu { pdu, promise }) => {
+                    let serial = next_serial;
+                    next_serial += 1;
 
-    let mut stream = reconnectable.take_stream().unwrap();
+                    // Register promise with reader before writing to socket
+                    promise_tx
+                        .send((serial, promise))
+                        .await
+                        .map_err(|_| anyhow!("reader task gone"))?;
 
-    loop {
-        let rx_msg = rx.recv();
-        let wait_for_read = stream
-            .wait_for_readable()
-            .map(|_| Ok(ReaderMessage::Readable));
-
-        match smol::future::or(rx_msg, wait_for_read).await {
-            Ok(ReaderMessage::SendPdu { pdu, promise }) => {
-                let serial = next_serial;
-                next_serial += 1;
-                promises.map.insert(serial, promise);
-
-                pdu.encode_async(&mut stream, serial)
-                    .await
-                    .context("encoding a PDU to send to the server")?;
-                stream.flush().await.context("flushing PDU to server")?;
-            }
-            Ok(ReaderMessage::Readable) => {
-                match Pdu::decode_async(&mut stream, Some(next_serial)).await {
-                    Ok(decoded) => {
-                        log::debug!(
-                            "decoded serial {} {}",
-                            decoded.serial,
-                            decoded.pdu.pdu_name()
-                        );
-                        if decoded.serial == 0 {
-                            process_unilateral(local_domain_id, decoded)
-                                .context("processing unilateral PDU from server")
-                                .map_err(|e| {
-                                    log::error!("process_unilateral: {:?}", e);
-                                    e
-                                })?;
-                        } else if let Some(promise) = promises.map.remove(&decoded.serial) {
-                            if promise.try_send(Ok(decoded.pdu)).is_err() {
-                                return Err(NotReconnectableError::ClientWasDestroyed.into());
-                            }
-                        } else {
-                            let reason =
-                                format!("got serial {:?} without a corresponding promise", decoded);
-                            promises.fail_all(&reason);
-                            anyhow::bail!("{}", reason);
-                        }
-                    }
-                    Err(err) => {
-                        let reason = format!("Error while decoding response pdu: {:#}", err);
-                        log::error!("{}", reason);
-                        promises.fail_all(&reason);
-                        return Err(err).context("Error while decoding response pdu");
-                    }
+                    pdu.encode_async(&mut writer, serial)
+                        .await
+                        .context("encoding a PDU to send to the server")?;
+                    writer.flush().await.context("flushing PDU to server")?;
+                }
+                Err(_) => {
+                    return Err(NotReconnectableError::ClientWasDestroyed.into());
                 }
             }
-            Err(_) => {
-                return Err(NotReconnectableError::ClientWasDestroyed.into());
+        }
+    };
+
+    let reader_fut = async {
+        let mut reader = reader;
+        let mut promises = PromiseMap::new();
+
+        loop {
+            // Pass None for max_serial: with split read/write, the reader cannot
+            // track the writer's next_serial without a race condition, since new
+            // serials may be assigned while decode_async is awaiting.
+            match Pdu::decode_async(&mut reader, None).await {
+                Ok(decoded) => {
+                    log::debug!(
+                        "decoded serial {} {}",
+                        decoded.serial,
+                        decoded.pdu.pdu_name()
+                    );
+
+                    // Drain any newly registered promises from the writer
+                    while let Ok((serial, promise)) = promise_rx.try_recv() {
+                        promises.map.insert(serial, promise);
+                    }
+
+                    if decoded.serial == 0 {
+                        process_unilateral(local_domain_id, decoded)
+                            .context("processing unilateral PDU from server")
+                            .map_err(|e| {
+                                log::error!("process_unilateral: {:?}", e);
+                                e
+                            })?;
+                    } else if let Some(promise) = promises.map.remove(&decoded.serial) {
+                        if promise.try_send(Ok(decoded.pdu)).is_err() {
+                            return Err(NotReconnectableError::ClientWasDestroyed.into());
+                        }
+                    } else {
+                        let reason =
+                            format!("got serial {:?} without a corresponding promise", decoded);
+                        promises.fail_all(&reason);
+                        anyhow::bail!("{}", reason);
+                    }
+                }
+                Err(err) => {
+                    let reason = format!("Error while decoding response pdu: {:#}", err);
+                    log::error!("{}", reason);
+                    promises.fail_all(&reason);
+                    return Err(err).context("Error while decoding response pdu");
+                }
             }
         }
+    };
+
+    // Run both tasks concurrently; first error terminates both
+    smol::future::race(writer_fut, reader_fut).await
+}
+
+struct PromiseMap {
+    map: HashMap<u64, Sender<anyhow::Result<Pdu>>>,
+}
+
+impl PromiseMap {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    fn fail_all(&mut self, reason: &str) {
+        log::trace!("failing all promises: {}", reason);
+        for (_, promise) in self.map.drain() {
+            let _ = promise.try_send(Err(anyhow!("{}", reason)));
+        }
+    }
+}
+
+impl Drop for PromiseMap {
+    fn drop(&mut self) {
+        self.fail_all("Client was destroyed");
     }
 }
 

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -2,7 +2,6 @@ use crate::sessionhandler::{PduSender, SessionHandler};
 use anyhow::Context;
 use async_ossl::AsyncSslStream;
 use codec::{DecodedPdu, Pdu};
-use futures::FutureExt;
 use mux::{Mux, MuxNotification};
 use smol::prelude::*;
 use smol::Async;
@@ -15,13 +14,6 @@ pub trait AsRawDesc: std::os::windows::io::AsRawSocket + std::os::windows::io::A
 
 impl AsRawDesc for UnixStream {}
 impl AsRawDesc for AsyncSslStream {}
-
-#[derive(Debug)]
-enum Item {
-    Notif(MuxNotification),
-    WritePdu(DecodedPdu),
-    Readable,
-}
 
 pub async fn process<T>(stream: T) -> anyhow::Result<()>
 where
@@ -36,7 +28,7 @@ where
     process_async(stream).await
 }
 
-pub async fn process_async<T>(mut stream: Async<T>) -> anyhow::Result<()>
+pub async fn process_async<T>(stream: Async<T>) -> anyhow::Result<()>
 where
     T: 'static,
     T: std::io::Read,
@@ -46,13 +38,20 @@ where
 {
     log::trace!("process_async called");
 
-    let (item_tx, item_rx) = smol::channel::unbounded::<Item>();
+    let (reader, writer) = futures::AsyncReadExt::split(stream);
+
+    // Channel for PDUs to be written to the client.
+    // Fed by: SessionHandler responses, scheduled pane pushes, and notifications.
+    let (write_tx, write_rx) = smol::channel::unbounded::<DecodedPdu>();
+
+    // Channel for mux notifications to be processed by the reader task.
+    let (notif_tx, notif_rx) = smol::channel::unbounded::<MuxNotification>();
 
     let pdu_sender = PduSender::new({
-        let item_tx = item_tx.clone();
+        let write_tx = write_tx.clone();
         move |pdu| {
-            item_tx
-                .try_send(Item::WritePdu(pdu))
+            write_tx
+                .try_send(pdu)
                 .map_err(|e| anyhow::anyhow!("{:?}", e))
         }
     });
@@ -60,65 +59,93 @@ where
 
     {
         let mux = Mux::get();
-        let tx = item_tx.clone();
-        mux.subscribe(move |n| tx.try_send(Item::Notif(n)).is_ok());
+        mux.subscribe(move |n| notif_tx.try_send(n).is_ok());
     }
 
-    loop {
-        let rx_msg = item_rx.recv();
-        let wait_for_read = stream.readable().map(|_| Ok(Item::Readable));
+    // Writer task: drain write channel, encode + flush to stream.
+    // Independent of reading — never blocks the reader.
+    let writer_fut = async {
+        let mut writer = writer;
 
-        match smol::future::or(rx_msg, wait_for_read).await {
-            Ok(Item::Readable) => {
-                let decoded = match Pdu::decode_async(&mut stream, None).await {
-                    Ok(data) => data,
-                    Err(err) => {
-                        if let Some(err) = err.root_cause().downcast_ref::<std::io::Error>() {
-                            if err.kind() == std::io::ErrorKind::UnexpectedEof {
-                                // Client disconnected: no need to make a noise
-                                return Ok(());
-                            }
-                        }
-                        return Err(err).context("reading Pdu from client");
-                    }
-                };
-                handler.process_one(decoded);
-            }
-            Ok(Item::WritePdu(decoded)) => {
-                match decoded.pdu.encode_async(&mut stream, decoded.serial).await {
-                    Ok(()) => {}
-                    Err(err) => {
-                        if let Some(err) = err.root_cause().downcast_ref::<std::io::Error>() {
-                            if err.kind() == std::io::ErrorKind::BrokenPipe {
-                                // Client disconnected: no need to make a noise
-                                return Ok(());
-                            }
-                        }
-                        return Err(err).context("encoding PDU to client");
-                    }
-                };
-                match stream.flush().await {
-                    Ok(()) => {}
-                    Err(err) => {
+        while let Ok(decoded) = write_rx.recv().await {
+            match decoded.pdu.encode_async(&mut writer, decoded.serial).await {
+                Ok(()) => {}
+                Err(err) => {
+                    if let Some(err) = err.root_cause().downcast_ref::<std::io::Error>() {
                         if err.kind() == std::io::ErrorKind::BrokenPipe {
-                            // Client disconnected: no need to make a noise
                             return Ok(());
                         }
-                        return Err(err).context("flushing PDU to client");
                     }
+                    return Err(err).context("encoding PDU to client");
+                }
+            };
+            match writer.flush().await {
+                Ok(()) => {}
+                Err(err) => {
+                    if err.kind() == std::io::ErrorKind::BrokenPipe {
+                        return Ok(());
+                    }
+                    return Err(err).context("flushing PDU to client");
                 }
             }
-            Ok(Item::Notif(MuxNotification::PaneOutput(pane_id))) => {
+        }
+
+        Ok(())
+    };
+
+    // Reader task: handle client requests and mux notifications.
+    // Never writes to stream — all PDUs go through write_tx.
+    //
+    // IMPORTANT: decode_async is NOT cancellation-safe. It reads bytes
+    // incrementally (leb128 byte-by-byte), so dropping it mid-read loses
+    // consumed bytes and corrupts the stream. Therefore we must NOT race
+    // decode_async against notifications. Instead, drain notifications
+    // non-blockingly between PDU decodes.
+    let reader_fut = async {
+        let mut reader = reader;
+
+        loop {
+            // Drain all pending notifications before blocking on the next PDU.
+            // Notifications that arrive during decode_async will be processed
+            // on the next loop iteration. This is acceptable because:
+            // - The client polls for render changes periodically, so decodes
+            //   complete regularly even when the user is idle.
+            // - schedule_pane_push and send_pdu are non-blocking (they enqueue
+            //   work for the writer task or spawn_into_main_thread).
+            drain_notifications(&mut handler, &write_tx, &notif_rx);
+
+            match Pdu::decode_async(&mut reader, None).await {
+                Ok(decoded) => {
+                    handler.process_one(decoded);
+                }
+                Err(err) => {
+                    if let Some(err) = err.root_cause().downcast_ref::<std::io::Error>() {
+                        if err.kind() == std::io::ErrorKind::UnexpectedEof {
+                            return Ok(());
+                        }
+                    }
+                    return Err(err).context("reading Pdu from client");
+                }
+            }
+        }
+    };
+
+    // Run both tasks concurrently; first to finish terminates both
+    smol::future::race(writer_fut, reader_fut).await
+}
+
+/// Drain all pending notifications from the channel without blocking.
+fn drain_notifications(
+    handler: &mut SessionHandler,
+    write_tx: &smol::channel::Sender<DecodedPdu>,
+    notif_rx: &smol::channel::Receiver<MuxNotification>,
+) {
+    while let Ok(notif) = notif_rx.try_recv() {
+        match notif {
+            MuxNotification::PaneOutput(pane_id) => {
                 handler.schedule_pane_push(pane_id);
             }
-            Ok(Item::Notif(MuxNotification::PaneAdded(_pane_id))) => {}
-            Ok(Item::Notif(MuxNotification::PaneRemoved(pane_id))) => {
-                Pdu::PaneRemoved(codec::PaneRemoved { pane_id })
-                    .encode_async(&mut stream, 0)
-                    .await?;
-                stream.flush().await.context("flushing PDU to client")?;
-            }
-            Ok(Item::Notif(MuxNotification::Alert { pane_id, alert })) => {
+            MuxNotification::Alert { pane_id, alert } => {
                 {
                     let per_pane = handler.per_pane(pane_id);
                     let mut per_pane = per_pane.lock().unwrap();
@@ -126,88 +153,87 @@ where
                 }
                 handler.schedule_pane_push(pane_id);
             }
-            Ok(Item::Notif(MuxNotification::SaveToDownloads { .. })) => {}
-            Ok(Item::Notif(MuxNotification::AssignClipboard {
+            MuxNotification::PaneRemoved(pane_id) => {
+                send_pdu(write_tx, Pdu::PaneRemoved(codec::PaneRemoved { pane_id }));
+            }
+            MuxNotification::AssignClipboard {
                 pane_id,
                 selection,
                 clipboard,
-            })) => {
-                Pdu::SetClipboard(codec::SetClipboard {
-                    pane_id,
-                    clipboard,
-                    selection,
-                })
-                .encode_async(&mut stream, 0)
-                .await?;
-                stream.flush().await.context("flushing PDU to client")?;
+            } => {
+                send_pdu(
+                    write_tx,
+                    Pdu::SetClipboard(codec::SetClipboard {
+                        pane_id,
+                        clipboard,
+                        selection,
+                    }),
+                );
             }
-            Ok(Item::Notif(MuxNotification::TabAddedToWindow { tab_id, window_id })) => {
-                Pdu::TabAddedToWindow(codec::TabAddedToWindow { tab_id, window_id })
-                    .encode_async(&mut stream, 0)
-                    .await?;
-                stream.flush().await.context("flushing PDU to client")?;
+            MuxNotification::TabAddedToWindow { tab_id, window_id } => {
+                send_pdu(
+                    write_tx,
+                    Pdu::TabAddedToWindow(codec::TabAddedToWindow { tab_id, window_id }),
+                );
             }
-            Ok(Item::Notif(MuxNotification::WindowRemoved(_window_id))) => {}
-            Ok(Item::Notif(MuxNotification::WindowCreated(_window_id))) => {}
-            Ok(Item::Notif(MuxNotification::WindowInvalidated(_window_id))) => {}
-            Ok(Item::Notif(MuxNotification::WindowWorkspaceChanged(window_id))) => {
+            MuxNotification::WindowWorkspaceChanged(window_id) => {
                 let workspace = {
                     let mux = Mux::get();
                     mux.get_window(window_id)
                         .map(|w| w.get_workspace().to_string())
                 };
                 if let Some(workspace) = workspace {
-                    Pdu::WindowWorkspaceChanged(codec::WindowWorkspaceChanged {
-                        window_id,
-                        workspace,
-                    })
-                    .encode_async(&mut stream, 0)
-                    .await?;
-                    stream.flush().await.context("flushing PDU to client")?;
+                    send_pdu(
+                        write_tx,
+                        Pdu::WindowWorkspaceChanged(codec::WindowWorkspaceChanged {
+                            window_id,
+                            workspace,
+                        }),
+                    );
                 }
             }
-            Ok(Item::Notif(MuxNotification::PaneFocused(pane_id))) => {
-                Pdu::PaneFocused(codec::PaneFocused { pane_id })
-                    .encode_async(&mut stream, 0)
-                    .await?;
-                stream.flush().await.context("flushing PDU to client")?;
+            MuxNotification::PaneFocused(pane_id) => {
+                send_pdu(write_tx, Pdu::PaneFocused(codec::PaneFocused { pane_id }));
             }
-            Ok(Item::Notif(MuxNotification::TabResized(tab_id))) => {
-                Pdu::TabResized(codec::TabResized { tab_id })
-                    .encode_async(&mut stream, 0)
-                    .await?;
-                stream.flush().await.context("flushing PDU to client")?;
+            MuxNotification::TabResized(tab_id) => {
+                send_pdu(write_tx, Pdu::TabResized(codec::TabResized { tab_id }));
             }
-            Ok(Item::Notif(MuxNotification::TabTitleChanged { tab_id, title })) => {
-                Pdu::TabTitleChanged(codec::TabTitleChanged { tab_id, title })
-                    .encode_async(&mut stream, 0)
-                    .await?;
-                stream.flush().await.context("flushing PDU to client")?;
+            MuxNotification::TabTitleChanged { tab_id, title } => {
+                send_pdu(
+                    write_tx,
+                    Pdu::TabTitleChanged(codec::TabTitleChanged { tab_id, title }),
+                );
             }
-            Ok(Item::Notif(MuxNotification::WindowTitleChanged { window_id, title })) => {
-                Pdu::WindowTitleChanged(codec::WindowTitleChanged { window_id, title })
-                    .encode_async(&mut stream, 0)
-                    .await?;
-                stream.flush().await.context("flushing PDU to client")?;
+            MuxNotification::WindowTitleChanged { window_id, title } => {
+                send_pdu(
+                    write_tx,
+                    Pdu::WindowTitleChanged(codec::WindowTitleChanged { window_id, title }),
+                );
             }
-            Ok(Item::Notif(MuxNotification::WorkspaceRenamed {
+            MuxNotification::WorkspaceRenamed {
                 old_workspace,
                 new_workspace,
-            })) => {
-                Pdu::RenameWorkspace(codec::RenameWorkspace {
-                    old_workspace,
-                    new_workspace,
-                })
-                .encode_async(&mut stream, 0)
-                .await?;
-                stream.flush().await.context("flushing PDU to client")?;
+            } => {
+                send_pdu(
+                    write_tx,
+                    Pdu::RenameWorkspace(codec::RenameWorkspace {
+                        old_workspace,
+                        new_workspace,
+                    }),
+                );
             }
-            Ok(Item::Notif(MuxNotification::ActiveWorkspaceChanged(_))) => {}
-            Ok(Item::Notif(MuxNotification::Empty)) => {}
-            Err(err) => {
-                log::error!("process_async Err {}", err);
-                return Ok(());
-            }
+            MuxNotification::PaneAdded(_) => {}
+            MuxNotification::SaveToDownloads { .. } => {}
+            MuxNotification::WindowRemoved(_) => {}
+            MuxNotification::WindowCreated(_) => {}
+            MuxNotification::WindowInvalidated(_) => {}
+            MuxNotification::ActiveWorkspaceChanged(_) => {}
+            MuxNotification::Empty => {}
         }
     }
+}
+
+/// Helper to send a unilateral PDU (serial 0) to the write channel.
+fn send_pdu(write_tx: &smol::channel::Sender<DecodedPdu>, pdu: Pdu) {
+    let _ = write_tx.try_send(DecodedPdu { serial: 0, pdu });
 }

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -5,6 +5,7 @@ use codec::{DecodedPdu, Pdu};
 use mux::{Mux, MuxNotification};
 use smol::prelude::*;
 use smol::Async;
+use std::sync::{Arc, Mutex};
 use wezterm_uds::UnixStream;
 
 #[cfg(unix)]
@@ -44,7 +45,7 @@ where
     // Fed by: SessionHandler responses, scheduled pane pushes, and notifications.
     let (write_tx, write_rx) = smol::channel::unbounded::<DecodedPdu>();
 
-    // Channel for mux notifications to be processed by the reader task.
+    // Channel for mux notifications to be processed by the notification task.
     let (notif_tx, notif_rx) = smol::channel::unbounded::<MuxNotification>();
 
     let pdu_sender = PduSender::new({
@@ -55,7 +56,7 @@ where
                 .map_err(|e| anyhow::anyhow!("{:?}", e))
         }
     });
-    let mut handler = SessionHandler::new(pdu_sender);
+    let handler = Arc::new(Mutex::new(SessionHandler::new(pdu_sender)));
 
     {
         let mux = Mux::get();
@@ -93,143 +94,140 @@ where
         Ok(())
     };
 
-    // Reader task: handle client requests and mux notifications.
+    // Reader task: decode client requests and dispatch to handler.
     // Never writes to stream — all PDUs go through write_tx.
-    //
-    // IMPORTANT: decode_async is NOT cancellation-safe. It reads bytes
-    // incrementally (leb128 byte-by-byte), so dropping it mid-read loses
-    // consumed bytes and corrupts the stream. Therefore we must NOT race
-    // decode_async against notifications. Instead, drain notifications
-    // non-blockingly between PDU decodes.
-    let reader_fut = async {
-        let mut reader = reader;
+    let reader_fut = {
+        let handler = Arc::clone(&handler);
+        async move {
+            let mut reader = reader;
 
-        loop {
-            // Drain all pending notifications before blocking on the next PDU.
-            // Notifications that arrive during decode_async will be processed
-            // on the next loop iteration. This is acceptable because:
-            // - The client polls for render changes periodically, so decodes
-            //   complete regularly even when the user is idle.
-            // - schedule_pane_push and send_pdu are non-blocking (they enqueue
-            //   work for the writer task or spawn_into_main_thread).
-            drain_notifications(&mut handler, &write_tx, &notif_rx);
-
-            match Pdu::decode_async(&mut reader, None).await {
-                Ok(decoded) => {
-                    handler.process_one(decoded);
-                }
-                Err(err) => {
-                    if let Some(err) = err.root_cause().downcast_ref::<std::io::Error>() {
-                        if err.kind() == std::io::ErrorKind::UnexpectedEof {
-                            return Ok(());
-                        }
+            loop {
+                match Pdu::decode_async(&mut reader, None).await {
+                    Ok(decoded) => {
+                        handler.lock().unwrap().process_one(decoded);
                     }
-                    return Err(err).context("reading Pdu from client");
+                    Err(err) => {
+                        if let Some(err) = err.root_cause().downcast_ref::<std::io::Error>() {
+                            if err.kind() == std::io::ErrorKind::UnexpectedEof {
+                                return Ok(());
+                            }
+                        }
+                        return Err(err).context("reading Pdu from client");
+                    }
                 }
             }
         }
     };
 
-    // Run both tasks concurrently; first to finish terminates both
-    smol::future::race(writer_fut, reader_fut).await
+    // Notification task: receive mux notifications and dispatch to handler.
+    // Runs independently so notifications are processed promptly even when
+    // decode_async is blocked waiting for client data.
+    let notif_fut = async {
+        while let Ok(notif) = notif_rx.recv().await {
+            handle_notification(&handler, &write_tx, notif);
+        }
+        Ok(())
+    };
+
+    // Run all three tasks concurrently; first to finish terminates all
+    smol::future::race(writer_fut, smol::future::race(reader_fut, notif_fut)).await
 }
 
-/// Drain all pending notifications from the channel without blocking.
-fn drain_notifications(
-    handler: &mut SessionHandler,
+/// Handle a single mux notification.
+fn handle_notification(
+    handler: &Arc<Mutex<SessionHandler>>,
     write_tx: &smol::channel::Sender<DecodedPdu>,
-    notif_rx: &smol::channel::Receiver<MuxNotification>,
+    notif: MuxNotification,
 ) {
-    while let Ok(notif) = notif_rx.try_recv() {
-        match notif {
-            MuxNotification::PaneOutput(pane_id) => {
-                handler.schedule_pane_push(pane_id);
-            }
-            MuxNotification::Alert { pane_id, alert } => {
-                {
-                    let per_pane = handler.per_pane(pane_id);
-                    let mut per_pane = per_pane.lock().unwrap();
-                    per_pane.notifications.push(alert);
-                }
-                handler.schedule_pane_push(pane_id);
-            }
-            MuxNotification::PaneRemoved(pane_id) => {
-                send_pdu(write_tx, Pdu::PaneRemoved(codec::PaneRemoved { pane_id }));
-            }
-            MuxNotification::AssignClipboard {
-                pane_id,
-                selection,
-                clipboard,
-            } => {
-                send_pdu(
-                    write_tx,
-                    Pdu::SetClipboard(codec::SetClipboard {
-                        pane_id,
-                        clipboard,
-                        selection,
-                    }),
-                );
-            }
-            MuxNotification::TabAddedToWindow { tab_id, window_id } => {
-                send_pdu(
-                    write_tx,
-                    Pdu::TabAddedToWindow(codec::TabAddedToWindow { tab_id, window_id }),
-                );
-            }
-            MuxNotification::WindowWorkspaceChanged(window_id) => {
-                let workspace = {
-                    let mux = Mux::get();
-                    mux.get_window(window_id)
-                        .map(|w| w.get_workspace().to_string())
-                };
-                if let Some(workspace) = workspace {
-                    send_pdu(
-                        write_tx,
-                        Pdu::WindowWorkspaceChanged(codec::WindowWorkspaceChanged {
-                            window_id,
-                            workspace,
-                        }),
-                    );
-                }
-            }
-            MuxNotification::PaneFocused(pane_id) => {
-                send_pdu(write_tx, Pdu::PaneFocused(codec::PaneFocused { pane_id }));
-            }
-            MuxNotification::TabResized(tab_id) => {
-                send_pdu(write_tx, Pdu::TabResized(codec::TabResized { tab_id }));
-            }
-            MuxNotification::TabTitleChanged { tab_id, title } => {
-                send_pdu(
-                    write_tx,
-                    Pdu::TabTitleChanged(codec::TabTitleChanged { tab_id, title }),
-                );
-            }
-            MuxNotification::WindowTitleChanged { window_id, title } => {
-                send_pdu(
-                    write_tx,
-                    Pdu::WindowTitleChanged(codec::WindowTitleChanged { window_id, title }),
-                );
-            }
-            MuxNotification::WorkspaceRenamed {
-                old_workspace,
-                new_workspace,
-            } => {
-                send_pdu(
-                    write_tx,
-                    Pdu::RenameWorkspace(codec::RenameWorkspace {
-                        old_workspace,
-                        new_workspace,
-                    }),
-                );
-            }
-            MuxNotification::PaneAdded(_) => {}
-            MuxNotification::SaveToDownloads { .. } => {}
-            MuxNotification::WindowRemoved(_) => {}
-            MuxNotification::WindowCreated(_) => {}
-            MuxNotification::WindowInvalidated(_) => {}
-            MuxNotification::ActiveWorkspaceChanged(_) => {}
-            MuxNotification::Empty => {}
+    match notif {
+        MuxNotification::PaneOutput(pane_id) => {
+            handler.lock().unwrap().schedule_pane_push(pane_id);
         }
+        MuxNotification::Alert { pane_id, alert } => {
+            let mut handler = handler.lock().unwrap();
+            {
+                let per_pane = handler.per_pane(pane_id);
+                let mut per_pane = per_pane.lock().unwrap();
+                per_pane.notifications.push(alert);
+            }
+            handler.schedule_pane_push(pane_id);
+        }
+        MuxNotification::PaneRemoved(pane_id) => {
+            send_pdu(write_tx, Pdu::PaneRemoved(codec::PaneRemoved { pane_id }));
+        }
+        MuxNotification::AssignClipboard {
+            pane_id,
+            selection,
+            clipboard,
+        } => {
+            send_pdu(
+                write_tx,
+                Pdu::SetClipboard(codec::SetClipboard {
+                    pane_id,
+                    clipboard,
+                    selection,
+                }),
+            );
+        }
+        MuxNotification::TabAddedToWindow { tab_id, window_id } => {
+            send_pdu(
+                write_tx,
+                Pdu::TabAddedToWindow(codec::TabAddedToWindow { tab_id, window_id }),
+            );
+        }
+        MuxNotification::WindowWorkspaceChanged(window_id) => {
+            let workspace = {
+                let mux = Mux::get();
+                mux.get_window(window_id)
+                    .map(|w| w.get_workspace().to_string())
+            };
+            if let Some(workspace) = workspace {
+                send_pdu(
+                    write_tx,
+                    Pdu::WindowWorkspaceChanged(codec::WindowWorkspaceChanged {
+                        window_id,
+                        workspace,
+                    }),
+                );
+            }
+        }
+        MuxNotification::PaneFocused(pane_id) => {
+            send_pdu(write_tx, Pdu::PaneFocused(codec::PaneFocused { pane_id }));
+        }
+        MuxNotification::TabResized(tab_id) => {
+            send_pdu(write_tx, Pdu::TabResized(codec::TabResized { tab_id }));
+        }
+        MuxNotification::TabTitleChanged { tab_id, title } => {
+            send_pdu(
+                write_tx,
+                Pdu::TabTitleChanged(codec::TabTitleChanged { tab_id, title }),
+            );
+        }
+        MuxNotification::WindowTitleChanged { window_id, title } => {
+            send_pdu(
+                write_tx,
+                Pdu::WindowTitleChanged(codec::WindowTitleChanged { window_id, title }),
+            );
+        }
+        MuxNotification::WorkspaceRenamed {
+            old_workspace,
+            new_workspace,
+        } => {
+            send_pdu(
+                write_tx,
+                Pdu::RenameWorkspace(codec::RenameWorkspace {
+                    old_workspace,
+                    new_workspace,
+                }),
+            );
+        }
+        MuxNotification::PaneAdded(_) => {}
+        MuxNotification::SaveToDownloads { .. } => {}
+        MuxNotification::WindowRemoved(_) => {}
+        MuxNotification::WindowCreated(_) => {}
+        MuxNotification::WindowInvalidated(_) => {}
+        MuxNotification::ActiveWorkspaceChanged(_) => {}
+        MuxNotification::Empty => {}
     }
 }
 


### PR DESCRIPTION

### Problem

When a GUI client connects to a mux server hosting many panes (around 30 tabs in my setup, each with applications producing large output), the GUI freezes permanently on startup and the only recovery is restarting the mux server. Reconnecting the GUI alone does not help because the server-side socket handler is also stuck.

The cause is a bidirectional socket deadlock: both `process_async` (server) and `client_thread_async` (client) interleave reads and writes on a single task. During connection the client sends a burst of `GetPaneRenderChanges` (one per pane) while the server simultaneously writes responses and notifications. With enough concurrent bidirectional traffic, both sides can end up blocked on write with neither reading, and the OS socket buffers fill. SSH domains rarely hit this thanks to extra TCP/SSH/proxy buffering.

### Fix

Split each side into independent async tasks using `futures::AsyncReadExt::split()`:

- **Client (`wezterm-client/src/client.rs`)**: writer task encodes outgoing PDUs and registers promises via channel; reader task continuously decodes responses and dispatches.
- **Server (`wezterm-mux-server-impl/src/dispatch.rs`)**: writer task drains a channel of outbound PDUs; reader task decodes client requests; a separate **notification task** dispatches `MuxNotification` events.

The notification task is separated from the reader because `Pdu::decode_async` reads bytes incrementally (leb128) and is not cancellation-safe. Handling notifications inside the reader (e.g., via non-blocking poll between decodes) would delay them whenever the client is idle inside `decode_async`. Keeping notifications on their own task preserves the timely processing the original single-task design provided.

### Notable choices

- `max_serial` is now `None`. The original `Some(next_serial)` rejected decoded PDUs with implausibly large serials (defense-in-depth against stream corruption). With split read/write the reader cannot atomically read the writer's `next_serial`. Restoring a similar check via an `Arc<AtomicU64>` shared counter plus a safety margin is feasible but widens the diff; we can add it if preferred.
- `PromiseMap` has a `Drop` impl that fails any outstanding promises with an explicit error on exit, instead of silently dropping channels.
- Server `SessionHandler` is shared via `Arc<Mutex<_>>`. Contention is minimal: all three tasks run cooperatively on the same smol executor thread, and lock hold times are short (clone sender, touch per-pane map, spawn work).

### Testing

Running on a mux server with around 30 tabs across multiple windows for over a month (commit author dates reflect the original work in late March). GUI startup is instantaneous (previously deadlocked); ongoing usage and Chinese IME input behave normally.

`cargo fmt --all -- --check` passes. The fix is concurrency/architecture-level and difficult to cover with a deterministic unit test; we did not add one.

### Note on AI collaboration

This patch is a collaboration with Claude (Anthropic's AI assistant), as the Co-Authored-By trailers reflect. The design and code were iterated through dialogue, and every change was reviewed in detail by the human author.
