### PR TITLE
docs: fix Linuxbrew installation path

### DIFF
--- a/docs/install/linux.md
+++ b/docs/install/linux.md
@@ -281,13 +281,13 @@ hide:
 
     ```console
     $ brew tap wezterm/wezterm-linuxbrew
-    $ brew install wezterm
+    $ brew install wezterm/wezterm-linuxbrew/wezterm
     ```
 
     If you'd like to use a nightly build you can perform a head install:
 
     ```console
-    $ brew install --HEAD wezterm
+    $ brew install --HEAD wezterm/wezterm-linuxbrew/wezterm
     ```
 
     to upgrade to a newer nightly, it is simplest to remove then
@@ -295,7 +295,7 @@ hide:
 
     ```console
     $ brew rm wezterm
-    $ brew install --HEAD wezterm
+    $ brew install --HEAD wezterm/wezterm-linuxbrew/wezterm
     ```
 === "Nix/NixOS"
 


### PR DESCRIPTION
On Linux, the generic 'wezterm' formula name in Homebrew/Linuxbrew attempts to install the macOS cask, leading to a failure. This PR updates the documentation to use the fully qualified tap name 'wezterm/wezterm-linuxbrew/wezterm' for Linux installation commands.