### PR TITLE
filedescriptor: Add `into_stdio` conversion

### DIFF
--- a/filedescriptor/src/lib.rs
+++ b/filedescriptor/src/lib.rs
@@ -304,6 +304,12 @@ impl FileDescriptor {
         self.as_stdio_impl()
     }
 
+    /// A convenience method for creating a `std::process::Stdio` object,
+    /// transferring ownership of the underlying handle to the returned `Stdio`.
+    pub fn into_stdio(self) -> std::process::Stdio {
+        self.into_stdio_impl()
+    }
+
     /// A convenience method for creating a `std::fs::File` object.
     /// The `File` is created using a duplicated handle so
     /// that the source handle remains alive.
@@ -328,6 +334,12 @@ impl FileDescriptor {
     /// Supports stdin, stdout, and stderr redirections.
     pub fn redirect_stdio<F: AsRawFileDescriptor>(f: &F, stdio: StdioDescriptor) -> Result<Self> {
         Self::redirect_stdio_impl(f, stdio)
+    }
+}
+
+impl From<FileDescriptor> for std::process::Stdio {
+    fn from(value: FileDescriptor) -> Self {
+        value.into_stdio()
     }
 }
 

--- a/filedescriptor/src/unix.rs
+++ b/filedescriptor/src/unix.rs
@@ -266,6 +266,12 @@ impl FileDescriptor {
     }
 
     #[inline]
+    pub(crate) fn into_stdio_impl(self) -> std::process::Stdio {
+        let fd = self.into_raw_fd();
+        unsafe { std::process::Stdio::from_raw_fd(fd) }
+    }
+
+    #[inline]
     pub(crate) fn as_file_impl(&self) -> Result<std::fs::File> {
         let duped = OwnedHandle::dup(self)?;
         let fd = duped.into_raw_fd();

--- a/filedescriptor/src/windows.rs
+++ b/filedescriptor/src/windows.rs
@@ -234,6 +234,12 @@ impl FileDescriptor {
     }
 
     #[inline]
+    pub(crate) fn into_stdio_impl(self) -> std::process::Stdio {
+        let handle = self.into_raw_handle();
+        unsafe { std::process::Stdio::from_raw_handle(handle) }
+    }
+
+    #[inline]
     pub(crate) fn as_file_impl(&self) -> Result<std::fs::File> {
         let duped = self.handle.try_clone()?;
         let handle = duped.into_raw_handle();


### PR DESCRIPTION
- Add `FileDescriptor::into_stdio` to create a `std::process::Stdio` by transferring ownership of the underlying handle without duplicating it.
- Add `From<FileDescriptor>` for `std::process::Stdio` for convenience.