### PR TITLE
fix(wezterm-gui): duplicated "the" in uniforms/commands/pane comments

### DIFF
--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -27,7 +27,7 @@ pub enum ArgType {
 
 /// A helper function used to synthesize key binding permutations.
 /// If the input is a character on a US ANSI keyboard layout, returns
-/// the the typical character that is produced when holding down
+/// the typical character that is produced when holding down
 /// the shift key and pressing the original key.
 /// This doesn't produce an exhaustive list because there are only
 /// a handful of default assignments in the command DEFS below.

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -194,7 +194,7 @@ impl crate::TermWindow {
                     LinearRgba::with_components(r, g, b, intensity)
                 } else {
                     // otherwise We'll interpolate between the background color
-                    // and the the target color
+                    // and the target color
                     let (r1, g1, b1, a) = palette
                         .background
                         .to_linear()

--- a/wezterm-gui/src/uniforms.rs
+++ b/wezterm-gui/src/uniforms.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 /// The builder works a bit more dynamically by accumulating references to
 /// the names and values.
 /// When binding structs to the shader, the name strings are dynamically
-/// allocated because glsl expects to bind the the `bar` field of struct `foo`
+/// allocated because glsl expects to bind the `bar` field of struct `foo`
 /// using a name like "foo.bar".
 /// A companion trait `UniformStruct` is used to aid in defining structs
 /// that can be passed as uniforms.


### PR DESCRIPTION
Three one-line typo fixes for duplicated "the" in doc-comments inside `wezterm-gui/src/`:
- `uniforms.rs` — "/// allocated because glsl expects to bind the the `bar` field of struct `foo`" → "...bind the `bar` field of struct `foo`"
- `commands.rs` — "/// the the typical character that is produced when holding down" → "/// the typical character that is produced when holding down"
- `termwindow/render/pane.rs` — "// and the the target color" → "// and the target color"

No code/behavior change.