### PR TITLE
Fix the titlebar on macos after exiting fullscreen

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1049,6 +1049,7 @@ impl WindowInner {
                     current_app.setPresentationOptions_(
                         NSApplicationPresentationOptions::NSApplicationPresentationDefault,
                     );
+                    self.update_titlebar_background();
                 },
                 None => unsafe {
                     // Go full screen


### PR DESCRIPTION
## Summary
Fixes an issue where the titlebar background color disappears after exiting fullscreen on macOS when `MACOS_USE_BACKGROUND_COLOR_AS_TITLEBAR_COLOR` is used.

## Problem
<img width="888" height="622" alt="Screenshot 2026-05-14 at 5 05 45 PM" src="https://github.com/user-attachments/assets/8c2bbd47-6ad6-4de8-9ed6-c92a3e727065" />

