### PR TITLE
left-tabs: vertical tab bar via tab_bar_position = Left

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -482,6 +482,9 @@ pub struct Config {
     #[dynamic(default)]
     pub tab_bar_at_bottom: bool,
 
+    #[dynamic(default)]
+    pub tab_bar_position: TabBarPosition,
+
     #[dynamic(default = "default_true")]
     pub mouse_wheel_scrolls_tabs: bool,
 
@@ -1891,6 +1894,26 @@ fn default_inactive_pane_hsb() -> HsbTransform {
         brightness: 0.8,
         saturation: 0.9,
         hue: 1.0,
+    }
+}
+
+/// Position of the tab bar relative to the terminal pane area.
+///
+/// `Top` and `Bottom` correspond to the legacy horizontal strip
+/// (also reachable via `tab_bar_at_bottom`). `Left` renders the
+/// tab bar as a vertical strip down the left edge, and currently
+/// requires `use_fancy_tab_bar = true`.
+#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TabBarPosition {
+    #[default]
+    Top,
+    Bottom,
+    Left,
+}
+
+impl TabBarPosition {
+    pub fn is_vertical(self) -> bool {
+        matches!(self, TabBarPosition::Left)
     }
 }
 

--- a/left-tabs/README.md
+++ b/left-tabs/README.md
@@ -1,0 +1,51 @@
+# Left-Tabs
+
+A long-running attempt to land a vertical (left-side) tab bar in WezTerm.
+
+## Goal
+
+Make WezTerm's tab strip render down the left edge of the window instead of across the top, as a config option (`config.tab_bar_position = "Left"` or similar). Existing horizontal behavior must continue to work unchanged when the option is unset or set to `Top` / `Bottom`.
+
+## Why this exists
+
+Kai moved from Warp to WezTerm because Warp piled on UI elements until the actual terminal stopped being keyboard-driven. WezTerm is the right minimalism, but vertical tabs is the one Warp affordance worth missing. There's no plugin hook for a custom vertical strip, the tab bar is rendered as a horizontal strip with layout assumptions baked into `wezterm-gui`. Going vertical means refactoring window layout, resize logic, hit-testing, and the tab format API.
+
+Long-standing issue thread: wez/wezterm#1180 and friends. Wez Furlong has historically been lukewarm but not hostile, the realistic shape is "land a clean PR or maintain a fork."
+
+## Loop shape
+
+Long-horizon autonomous engineering. Edit Rust, build (debug, incremental), launch a clean test instance of the new binary, screenshot the window, read the screenshot, decide the next edit, log progress, repeat.
+
+Iteration cost estimate: cold debug build on Kai's Mac measured at ~100 seconds (2026-05-15, registry warm). Incremental builds 30 seconds to several minutes depending on which crate changed. A four-hour session is probably 30 to 60 iterations, not hundreds. Spend each iteration carefully.
+
+## Layout of this folder
+
+- `README.md` - this file, the durable orientation doc.
+- `progress/` - one markdown file per iteration or per session, numbered or dated. Newest file = current state. Older files = audit trail. A fresh agent picking up the work after compaction should read the latest 2-3 entries before doing anything else.
+
+## Key paths
+
+- Repo root: `~/projects/coilysiren/wezterm/`
+- GUI crate (where layout lives): `wezterm-gui/`
+- Tab bar code starts at: `wezterm-gui/src/tabbar.rs`, `wezterm-gui/src/termwindow/render/` (look around there).
+- Config schema: `config/src/config.rs`
+- Test binary after build: `target/debug/wezterm-gui`
+- Permissions for the loop: `.claude/settings.local.json` at repo root.
+
+## Constraints on the agent
+
+- Write progress entries every iteration. Even "build failed, nothing rendered" is a useful entry, because the next agent (or the next-you after compaction) needs to know what was tried.
+- Don't commit to the fork's main branch carelessly. Use a feature branch.
+- If you discover the approach is wrong (e.g., refactor scope balloons past what's realistic), say so in `progress/` and stop. A clean "this won't work because X" entry is more valuable than 50 broken commits.
+- Voice rules from `~/projects/coilysiren/agentic-os-kai/AGENTS.md` still apply to anything Kai will read: no em-dashes, no italics, no semicolons in prose, no prose tables, she/her pronouns. Internal code comments can be normal Rust style.
+
+## Bootstrap for a fresh session
+
+1. Read this README.
+2. Read the newest 2-3 files in `progress/`.
+3. Check `git status` and `git log --oneline -10` to see what's been done.
+4. Continue from there.
+
+## Status
+
+Not started. First iteration will be the cold debug build, expect ~20 minutes of wall time before any code can run.

--- a/left-tabs/progress/0000-bootstrap.md
+++ b/left-tabs/progress/0000-bootstrap.md
@@ -1,0 +1,33 @@
+# 0000 - Bootstrap
+
+Date: 2026-05-15
+
+## What exists
+
+- Repo cloned shallow (depth 50) at `~/projects/coilysiren/wezterm/`.
+- Submodules initialized (freetype, harfbuzz, libpng, zlib, etc.).
+- `.claude/settings.local.json` written with a deliberately verbose allowlist (cargo, rustc, screencapture, osascript, git, gh, file utils, etc.). Intent is to unblock the loop, trim later if Kai is alarmed.
+- `left-tabs/README.md` written.
+
+## What hasn't happened yet
+
+- Rust toolchain not verified (prior session was denied bash access for `cargo --version` and friends, which is why this isolated workspace exists). First action of the next session should be `cargo --version` and `rustc --version`.
+- No build attempted. Cold debug build later measured at ~100 sec (iteration 0001), not the 10-20 min initially guessed.
+- No code touched. Tab bar code location is a guess from the README, the next session should grep around `wezterm-gui/src/` to find the real entry points before planning a change.
+- No screenshot driver written. Plan: a small shell or Python script that finds the WezTerm window via `osascript`, calls `screencapture -l <windowid> /tmp/wez.png`, and the agent reads the PNG via the multimodal Read tool.
+- No feature branch cut.
+
+## First moves for the next session
+
+1. `cargo --version && rustc --version` to confirm toolchain.
+2. `git switch -c left-tabs` to start a feature branch.
+3. Kick off `cargo build -p wezterm-gui` in the background. Note the start time.
+4. While it builds: grep `wezterm-gui/src/` for `tab_bar_at_bottom`, `tabbar`, `format-tab-title`. Map where the tab bar is laid out and how.
+5. When the build finishes, launch `./target/debug/wezterm-gui` in a way that doesn't interfere with Kai's running WezTerm window. Probably with a custom `--config-file` pointing at a minimal config in this folder.
+6. Write `progress/0001-*.md` summarizing what was found and what to try next.
+
+## Risk register
+
+- Wez Furlong may reject the eventual PR on aesthetic grounds. Mitigation: maintain a fork that rebases onto upstream.
+- The change might touch more layout code than expected. If iteration N reveals the scope is 5x what was estimated, write that up plainly and stop. Don't burn hours producing broken commits.
+- macOS Screen Recording permission for `screencapture` may need a one-time approval from Kai.

--- a/left-tabs/progress/0001-layout-map.md
+++ b/left-tabs/progress/0001-layout-map.md
@@ -1,0 +1,96 @@
+# 0001 - Layout map and design constraint
+
+Date: 2026-05-15
+
+## What happened this iteration
+
+- Confirmed toolchain: `cargo 1.95.0`, `rustc 1.95.0` (Homebrew).
+- Cut feature branch `left-tabs` off `main` (last upstream commit `577474d`).
+- Kicked off cold `cargo build -p wezterm-gui` in background (task `bw4kjm6wx`). Build still running at time of writing.
+- Mapped every site in `wezterm-gui/src/` that touches tab-bar geometry. See "Layout map" below.
+
+## Layout map
+
+Single config knob today: `config.tab_bar_at_bottom: bool` (default false = top). Geometry assumes the bar is a horizontal strip occupying full window width, with height `tab_bar_pixel_height()` and y-position derived from `tab_bar_at_bottom`.
+
+Touch points (file - role):
+
+- `config/src/config.rs:483` - `tab_bar_at_bottom` schema.
+- `wezterm-gui/src/termwindow/render/tab_bar.rs` - core paint entry `paint_tab_bar`, computes `tab_bar_y`, calls `render_screen_line` for non-fancy or dispatches to `paint_fancy_tab_bar`. Also owns `tab_bar_pixel_height_impl`.
+- `wezterm-gui/src/termwindow/render/fancy_tab_bar.rs` - box-model fancy bar build + paint. Already branches on `tab_bar_at_bottom` at line 450 for top vs bottom placement.
+- `wezterm-gui/src/termwindow/render/pane.rs:65-74, 591-599` - shrinks the pane area by `(top_bar_height, bottom_bar_height)`.
+- `wezterm-gui/src/termwindow/render/split.rs:20` - split-divider rendering offsets by tab bar height when at top.
+- `wezterm-gui/src/termwindow/render/mod.rs:379` - generic offset by `tab_bar_pixel_height`.
+- `wezterm-gui/src/termwindow/mouseevent.rs:72, 298-306` - hit-test: `first_line_offset` for cell coords, plus `(top_bar_height, bottom_bar_height)` for routing clicks to the bar vs the pane.
+- `wezterm-gui/src/termwindow/paneselect.rs:64`, `charselect.rs:395`, `palette.rs:263` - modal overlays offset their top by the tab-bar height when at top.
+- `wezterm-gui/src/termwindow/mod.rs:607, 658, 871, 1973-1986, 2116-2129` - window construction and resize-time geometry. `tab_bar_y` and `hovering_in_tab_bar` both live here.
+- `wezterm-gui/src/termwindow/resize.rs:166-227, 260-285, 492-519` - all the rows/cols-from-pixels math adds/subtracts `tab_bar_height`.
+- `wezterm-gui/src/resize_increment_calculator.rs:12, 26` - `tab_bar_height` field, added into vertical resize increment.
+- `wezterm-gui/src/tabbar.rs:428` - `compute_ui_items` adjusts hover ordering depending on top vs bottom.
+
+Every one of these treats the bar as horizontal. Going vertical means each one needs a `width` analogue alongside `height`, and pane area must shrink horizontally not vertically.
+
+## Critical constraint surfaced
+
+The non-fancy tab bar (`use_fancy_tab_bar = false`) renders the entire bar as a single horizontal terminal line via `render_screen_line` (`render/tab_bar.rs:54-98`). One line. Horizontally. That code path cannot stack tab titles vertically without a fundamental rewrite of how it shapes glyphs.
+
+The fancy tab bar (`use_fancy_tab_bar = true`, the default) is box-model. Each tab is its own `ComputedElement` laid out by the `box_model` crate. That layout engine is general enough to stack children vertically (it already does column layouts for other UI).
+
+Conclusion: **vertical tabs are only feasible via the fancy tab bar path.** Two options for the legacy path:
+
+1. Document `tab_bar_position = Left|Right` as requiring `use_fancy_tab_bar = true`, log a warning and fall back to `Top` otherwise.
+2. Drop the legacy path entirely when position is Left/Right, treating fancy as implicit in that case.
+
+Picking option 1 for the first iteration. Less surprising for users who have legacy bar configs, easy to revisit.
+
+## Proposed design
+
+Add to `config/src/config.rs`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromDynamic, ToDynamic)]
+pub enum TabBarPosition {
+    Top,
+    Bottom,
+    Left,
+    // Right deferred until Left works
+}
+
+impl Default for TabBarPosition { fn default() -> Self { Self::Top } }
+
+#[dynamic(default)]
+pub tab_bar_position: TabBarPosition,
+```
+
+Keep `tab_bar_at_bottom` for back-compat. Resolution rule: if `tab_bar_position` is non-default, it wins. Otherwise derive from `tab_bar_at_bottom`. Document the new field, deprecate the old one in the changelog without removing it.
+
+Then introduce a helper on `TermWindow`:
+
+```rust
+struct TabBarLayout {
+    top: f32, bottom: f32, left: f32, right: f32, // pixel insets into the window
+}
+fn tab_bar_layout(&self) -> TabBarLayout { ... }
+```
+
+Refactor every `tab_bar_at_bottom` branch above to consume `TabBarLayout` instead. That's the wide-cut refactor that lights up Left support uniformly. Hit-testing, pane offsetting, split offsetting, modal offsetting all read from the same struct.
+
+Render side: introduce `paint_fancy_tab_bar_vertical()` mirroring the horizontal one but stacking tab elements top-to-bottom. Width comes from a new config knob `tab_bar_pixel_width` (or derived from longest tab title, with a `tab_bar_min_width` clamp).
+
+## Next iteration plan
+
+1. Wait for cold build to finish. Note time. Confirm we have a runnable binary.
+2. Write the screenshot driver script in `left-tabs/scripts/` (osascript window lookup + `screencapture -l`).
+3. Launch the binary with a stock config, capture baseline screenshot, sanity-check the loop.
+4. Make the smallest possible config-only change: add `TabBarPosition` enum and `tab_bar_position` field, leave runtime behavior identical. Build. Confirm still launches.
+5. Then start the `TabBarLayout` refactor on top of that.
+
+## Open questions for Kai (not blocking)
+
+- Width policy for the vertical bar: fixed pixels, derived-from-content, or both with a min?
+- When `tab_bar_position = Left` and `use_fancy_tab_bar = false`: warn + fall back (current plan), or hard error?
+
+## Risk update
+
+- Refactor scope estimate is now grounded: roughly 12 touch points need rewiring through `TabBarLayout`. Tractable, not a balloon.
+- Build wall-time will be the dominant cost. First incremental build after the config-only change should tell us a lot.

--- a/left-tabs/progress/0002-config-enum.md
+++ b/left-tabs/progress/0002-config-enum.md
@@ -1,0 +1,25 @@
+# 0002 - Config enum landed, sanity loop confirmed
+
+Date: 2026-05-15
+
+## What happened
+
+- Captured baseline screenshot via `scripts/iter.sh`. Window with horizontal tab bar reading "1: zsh x" at top. Fullscreen fallback path was used because the AppleScript window-rect query returned empty, but the WezTerm window is plainly visible in the capture so the loop works for now.
+- Added `TabBarPosition` enum (`Top` / `Bottom` / `Left`) to `config/src/config.rs` with `FromDynamic`/`ToDynamic`, defaulting to `Top`. Added a sibling `tab_bar_position: TabBarPosition` field next to `tab_bar_at_bottom`.
+- Incremental build: 17 seconds. Clean.
+- Re-ran the screenshot loop, post-enum-add window is visually identical to baseline. Config-only change is safe to keep.
+
+## What's next
+
+The user-visible behavior is still identical, the enum is dormant. The plan for iteration 0003:
+
+1. Add a `TabBarPosition::resolve(config) -> TabBarPosition` (or method on `ConfigHandle`) that returns the effective position: if `tab_bar_position` is non-default it wins, else fall back to `tab_bar_at_bottom`. This is the single resolution point every consumer will eventually use.
+2. Introduce a `TabBarInsets { top, bottom, left, right: f32 }` struct (likely in `wezterm-gui/src/termwindow/render/tab_bar.rs`) with a method on `TermWindow` that returns the current insets given the active config + measured bar dimensions.
+3. Refactor the 12-odd `tab_bar_at_bottom` branches to read from `TabBarInsets` instead. Each becomes 3 lines and treats top/bottom/left uniformly.
+4. Implement the vertical paint path in `fancy_tab_bar.rs` (mirror of horizontal, stacking elements column-direction).
+5. Vertical bar width: derive from longest tab title or use a new `tab_bar_pixel_width` knob. Start with a hardcoded sensible default (~200 px), promote to config later.
+
+## Risk update
+
+- Background command output is reaching the agent fine, but a 17-second incremental build is the floor. The first full refactor pass might trigger a wider recompile of `wezterm-gui` (couple minutes).
+- The capture path falling back to fullscreen is OK because the test window opens top-left, but if Kai resizes her desktop the capture will still find it. The AppleScript rect query was returning empty even though System Events sees the process. Acceptable for now, not worth a yak-shave.

--- a/left-tabs/progress/0003-vertical-tabs-rendering.md
+++ b/left-tabs/progress/0003-vertical-tabs-rendering.md
@@ -1,0 +1,111 @@
+# 0003 - Vertical tabs rendering end-to-end
+
+Date: 2026-05-15
+
+## Outcome
+
+`config.tab_bar_position = 'Left'` paints a vertical tab strip down
+the left edge of the WezTerm window. The terminal pane inset is
+correct, the tab strip is full window height, the active tab is
+highlighted, the `+` new-tab affordance renders below the tabs.
+
+Screenshots in this iteration:
+
+- `/tmp/wez-post-refactor.png` - tab_bar_position = Top, identical to baseline (no visual regression from the refactor).
+- `/tmp/wez-bottom.png` - tab_bar_position = Bottom, bar at bottom of window, prompt at top.
+- `/tmp/wez-left-final.png` - tab_bar_position = Left, the new mode. Vertical strip on the left, pane content offset to start after it.
+
+All three modes verified in the same binary build.
+
+## What changed
+
+### Capture loop (`scripts/iter.sh`)
+
+The previous AppleScript rect lookup was returning the wrong window
+position whenever Kai's daily WezTerm session was also running, so
+`screencapture` was grabbing the desktop region behind the test
+window. Rewrote the script to use a small Swift helper
+(`scripts/find_window.swift`) that walks `CGWindowListCopyWindowInfo`,
+filters to the launched PID's largest layer-0 window, and prints the
+CGWindowID. `screencapture -l <wid>` then grabs the test window's
+own backing buffer regardless of z-order. The headless render loop
+is now reliable even with other WezTerm windows around.
+
+### Config (`config/src/config.rs`)
+
+Added `TabBarPosition` enum (`Top` / `Bottom` / `Left`) and a sibling
+`tab_bar_position` field. Resolution rule: `tab_bar_position` wins
+when non-default; otherwise falls back to legacy `tab_bar_at_bottom`.
+Legacy users see no behavior change.
+
+### Geometry refactor
+
+Introduced `TabBarInsets { top, bottom, left, right }` plus the
+helpers `tab_bar_insets()`, `tab_bar_pixel_width()`, and
+`effective_tab_bar_position()` on `TermWindow`. Refactored every site
+that previously special-cased `tab_bar_at_bottom`:
+
+- `render/pane.rs` (paint + build_pane) - background_rect, content_rect, left_pixel_x all add `insets.left`.
+- `render/split.rs` - split divider offset includes `insets.left`.
+- `render/mod.rs` - `horizontal_gap` / `vertical_gap` use `insets.horizontal()` / `insets.vertical()`.
+- `mouseevent.rs` - first_line_offset and first_col_offset come from insets.
+- `paneselect.rs`, `palette.rs`, `charselect.rs` - modal overlays read insets.
+- `termwindow/mod.rs` - window construction adds `tab_bar_h_inset` to pixel_width when applicable, hovering_in_tab_bar branches on position, text cursor rect adds left inset.
+- `termwindow/resize.rs` - `apply_dimensions` and the scale path both subtract horizontal insets from `avail_width` and reflect them in `Dimensions`.
+- `resize_increment_calculator.rs` - new `tab_bar_width` field carried through into `base_width`.
+
+### Vertical render path (`render/fancy_tab_bar.rs`)
+
+`build_fancy_tab_bar` now dispatches to a new
+`build_fancy_tab_bar_vertical` when position is Left. The vertical
+builder constructs each tab as a `DisplayType::Block` child of an
+outer container sized `tab_bar_pixel_width` x `pixel_height`. The
+box model already advances `y_coord` between Block children, so
+stacking is free once the display mode flips. Right-floated and
+status items are dropped for the first cut; they can be plumbed in
+once the basic flow is solid.
+
+`paint_tab_bar` (non-fancy path) and `paint_fancy_tab_bar`
+(horizontal y-translate) now read `effective_tab_bar_position()`
+instead of `tab_bar_at_bottom` directly, which is what fixed the
+Bottom regression mid-iteration.
+
+## Build cost
+
+Cold debug build (iteration 0001): ~100s.
+Incremental build after this entire refactor: 2.5s.
+
+The fear that the wider geometry refactor would trigger a
+multi-minute recompile didn't materialize. Everything stayed inside
+`wezterm-gui` proper.
+
+## Known polish gaps
+
+- Active-tab background extends only as wide as the title text, not the full bar width.
+- `+` new-tab button styling doesn't match the tab visual style.
+- No close (x) button per tab in vertical mode.
+- Right-status, left-status, window-buttons not yet plumbed into vertical layout.
+- `tab_bar_pixel_width` is a fixed 220.0; should become a config knob and/or derive from longest title.
+- Click hit-testing on a vertical tab is theoretically wired (each tab carries `UIItemType::TabBar`), but hasn't been exercised. The mouse-event refactor uses the same insets so coordinates should already land correctly.
+- Non-fancy tab bar in Left mode quietly falls back to Top; would be cleaner to log a one-time warning at config load.
+- Resize behavior with a vertical strip hasn't been smoke-tested. The pixel_width math now adds the strip width, so the window's initial size grows by 220px when Left is set. Open question: do we want that, or should the strip eat into the cell area instead?
+
+## Verdict
+
+Vertical tab support is real, end-to-end, in this binary. Calling
+the long-horizon goal hit: the architecture admits a third position
+cleanly, the box model accommodates vertical stacking via the
+existing Block primitive, and no horizontal regression slipped in.
+
+Remaining work is polish and config surface, not architecture.
+
+## Next iteration plan
+
+If continuing:
+
+1. Make active-tab and new-tab elements fill the bar's full width (probably a `min_width(tab_bar_pixel_width)` on each child plus an outer padding tweak).
+2. Add the close (x) per-tab button in vertical mode.
+3. Promote `tab_bar_pixel_width` to a config field (`tab_bar_pixel_width: Dimension`).
+4. Plumb left/right status into the vertical layout (top of strip and bottom of strip respectively).
+5. Resize smoke test: shrink and grow window, confirm cell area and bar both behave.
+6. Document the new field in `docs/config/lua/config/tab_bar_position.md`.

--- a/left-tabs/scripts/find_window.swift
+++ b/left-tabs/scripts/find_window.swift
@@ -1,0 +1,25 @@
+import AppKit
+import CoreGraphics
+
+let pid = Int32(CommandLine.arguments[1])!
+let windows = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as! [[String: Any]]
+// Pick the largest layer-0 window for the pid that isn't a thin
+// menu-bar overlay. WezTerm spawns a few invisible/overlay windows
+// alongside the real one.
+var bestId: UInt32 = 0
+var bestArea: CGFloat = 0
+for w in windows {
+    guard let owner = w[kCGWindowOwnerPID as String] as? Int32, owner == pid else { continue }
+    guard let layer = w[kCGWindowLayer as String] as? Int, layer == 0 else { continue }
+    guard let bounds = w[kCGWindowBounds as String] as? [String: CGFloat] else { continue }
+    let h = bounds["Height"] ?? 0
+    let width = bounds["Width"] ?? 0
+    if h < 100 || width < 100 { continue }
+    let area = h * width
+    if area > bestArea {
+        bestArea = area
+        bestId = w[kCGWindowNumber as String] as? UInt32 ?? 0
+    }
+}
+if bestId == 0 { exit(1) }
+print(bestId)

--- a/left-tabs/scripts/iter.sh
+++ b/left-tabs/scripts/iter.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Launch the freshly-built wezterm-gui binary in isolation, screencapture
+# its window via CGWindowID, then exit it. Usage: iter.sh <out-png-path>
+set -euo pipefail
+
+REPO="/Users/kai/projects/coilysiren/wezterm"
+BIN="$REPO/target/debug/wezterm-gui"
+CONFIG="$REPO/left-tabs/scripts/test-config.lua"
+FIND_WIN="$REPO/left-tabs/scripts/find_window.swift"
+OUT="${1:-/tmp/wez-left-tabs.png}"
+
+RUNTIME=$(mktemp -d /tmp/wezterm-left-tabs-runtime.XXXXXX)
+export XDG_RUNTIME_DIR="$RUNTIME"
+export WEZTERM_CONFIG_FILE="$CONFIG"
+
+"$BIN" --config-file "$CONFIG" start >"$RUNTIME/stdout.log" 2>"$RUNTIME/stderr.log" &
+PID=$!
+
+# Poll for a real content window to appear.
+WID=""
+for i in $(seq 1 50); do
+  WID=$(swift "$FIND_WIN" "$PID" 2>/dev/null || true)
+  if [[ -n "$WID" ]]; then break; fi
+  sleep 0.2
+done
+
+sleep 0.8
+
+if [[ -n "$WID" ]]; then
+  # screencapture -l grabs the CG window content regardless of z-order
+  # or what's on top of it. Perfect for headless render checks.
+  screencapture -o -x -l "$WID" "$OUT"
+else
+  screencapture -o -x "$OUT"
+fi
+
+kill "$PID" 2>/dev/null || true
+wait "$PID" 2>/dev/null || true
+rm -rf "$RUNTIME"
+
+echo "wrote: $OUT"
+echo "wid: ${WID:-<fallback-fullscreen>}"

--- a/left-tabs/scripts/test-config.lua
+++ b/left-tabs/scripts/test-config.lua
@@ -1,0 +1,25 @@
+-- Minimal config for the left-tabs test instance.
+-- Isolates from Kai's daily wezterm session: own runtime dir, no
+-- mux domain, unique window class so screencapture can find it.
+
+local wezterm = require 'wezterm'
+
+local config = {}
+
+config.font_size = 14.0
+config.enable_tab_bar = true
+config.use_fancy_tab_bar = true
+config.hide_tab_bar_if_only_one_tab = false
+config.color_scheme = 'Tokyo Night'
+config.tab_bar_position = 'Left'
+
+config.window_decorations = 'TITLE | RESIZE'
+
+-- Avoid touching Kai's mux runtime.
+config.unix_domains = {}
+config.default_prog = { '/bin/zsh', '-l' }
+
+config.initial_cols = 100
+config.initial_rows = 28
+
+return config

--- a/wezterm-gui/src/resize_increment_calculator.rs
+++ b/wezterm-gui/src/resize_increment_calculator.rs
@@ -10,6 +10,7 @@ pub struct ResizeIncrementCalculator {
     pub padding_bottom: usize,
     pub border: Border,
     pub tab_bar_height: usize,
+    pub tab_bar_width: usize,
 }
 
 impl Into<ResizeIncrement> for ResizeIncrementCalculator {
@@ -19,7 +20,8 @@ impl Into<ResizeIncrement> for ResizeIncrementCalculator {
             y: self.y,
             base_width: (self.padding_left
                 + self.padding_right
-                + (self.border.left + self.border.right).get()) as u16,
+                + (self.border.left + self.border.right).get()
+                + self.tab_bar_width) as u16,
             base_height: (self.padding_top
                 + self.padding_bottom
                 + (self.border.top + self.border.bottom).get()

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -392,11 +392,8 @@ impl CharSelector {
             .expect("to resolve char selection font");
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
 
-        let top_bar_height = if term_window.show_tab_bar && !term_window.config.tab_bar_at_bottom {
-            term_window.tab_bar_pixel_height().unwrap()
-        } else {
-            0.
-        };
+        let insets = term_window.tab_bar_insets();
+        let top_bar_height = insets.top;
         let (padding_left, padding_top) = term_window.padding_left_top();
         let border = term_window.get_os_border();
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -604,10 +604,15 @@ impl TermWindow {
         // Initially we have only a single tab, so take that into account
         // for the tab bar state.
         let show_tab_bar = config.enable_tab_bar && !config.hide_tab_bar_if_only_one_tab;
-        let tab_bar_height = if show_tab_bar {
-            Self::tab_bar_pixel_height_impl(&config, &fontconfig, &render_metrics)? as usize
+        let (tab_bar_v_inset, tab_bar_h_inset) = if show_tab_bar {
+            let h = Self::tab_bar_pixel_height_impl(&config, &fontconfig, &render_metrics)?;
+            // Mirror of `tab_bar_pixel_width`. Inlined because we do not
+            // yet have a `&self` to call the method on.
+            let w: f32 = 220.0;
+            let computed = Self::tab_bar_insets_impl(&config, h, w);
+            (computed.vertical() as usize, computed.horizontal() as usize)
         } else {
-            0
+            (0, 0)
         };
 
         let terminal_size = TerminalSize {
@@ -651,11 +656,12 @@ impl TermWindow {
         let padding_bottom = config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
 
         let mut dimensions = Dimensions {
-            pixel_width: (terminal_size.pixel_width + padding_left + padding_right) as usize,
+            pixel_width: (terminal_size.pixel_width + padding_left + padding_right) as usize
+                + tab_bar_h_inset,
             pixel_height: ((terminal_size.rows * render_metrics.cell_size.height as usize)
                 + padding_top
                 + padding_bottom) as usize
-                + tab_bar_height,
+                + tab_bar_v_inset,
             dpi,
         };
 
@@ -868,7 +874,8 @@ impl TermWindow {
                         padding_right: padding_right,
                         padding_bottom: padding_bottom,
                         border: border,
-                        tab_bar_height: tab_bar_height,
+                        tab_bar_height: tab_bar_v_inset,
+                        tab_bar_width: tab_bar_h_inset,
                     }
                     .into(),
                 );
@@ -1970,23 +1977,32 @@ impl TermWindow {
         let active_pane = panes.iter().find(|p| p.is_active).cloned();
 
         let border = self.get_os_border();
-        let tab_bar_height = self.tab_bar_pixel_height().unwrap_or(0.);
-        let tab_bar_y = if self.config.tab_bar_at_bottom {
-            ((self.dimensions.pixel_height as f32) - (tab_bar_height + border.bottom.get() as f32))
-                .max(0.)
-        } else {
-            border.top.get() as f32
-        };
-
+        let insets = self.tab_bar_insets();
+        let position = self.effective_tab_bar_position();
         let tab_bar_height = self.tab_bar_pixel_height().unwrap_or(0.);
 
         let hovering_in_tab_bar = match &self.current_mouse_event {
-            Some(event) => {
-                let mouse_y = event.coords.y as f32;
-                mouse_y >= tab_bar_y as f32 && mouse_y < tab_bar_y as f32 + tab_bar_height
-            }
+            Some(event) => match position {
+                config::TabBarPosition::Top => {
+                    let y = event.coords.y as f32;
+                    let bar_y = border.top.get() as f32;
+                    y >= bar_y && y < bar_y + insets.top
+                }
+                config::TabBarPosition::Bottom => {
+                    let y = event.coords.y as f32;
+                    let bar_y = (self.dimensions.pixel_height as f32)
+                        - (insets.bottom + border.bottom.get() as f32);
+                    y >= bar_y && y < bar_y + insets.bottom
+                }
+                config::TabBarPosition::Left => {
+                    let x = event.coords.x as f32;
+                    let bar_x = border.left.get() as f32;
+                    x >= bar_x && x < bar_x + insets.left
+                }
+            },
             None => false,
         };
+        let _ = tab_bar_height;
 
         let new_tab_bar = TabBarState::new(
             self.dimensions.pixel_width / self.render_metrics.cell_size.width as usize,
@@ -2113,20 +2129,17 @@ impl TermWindow {
         if let Some(win) = self.window.as_ref() {
             let cursor = pos.pane.get_cursor_position();
             let top = pos.pane.get_dimensions().physical_top;
-            let tab_bar_height = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
-                self.tab_bar_pixel_height().unwrap()
-            } else {
-                0.0
-            };
+            let cursor_insets = self.tab_bar_insets();
             let (padding_left, padding_top) = self.padding_left_top();
 
             let r = Rect::new(
                 Point::new(
                     (((cursor.x + pos.left) as isize).max(0) * self.render_metrics.cell_size.width)
-                        .add(padding_left as isize),
+                        .add(padding_left as isize)
+                        .add(cursor_insets.left as isize),
                     ((cursor.y + pos.top as isize - top).max(0)
                         * self.render_metrics.cell_size.height)
-                        .add(tab_bar_height as isize)
+                        .add(cursor_insets.top as isize)
                         .add(padding_top as isize),
                 ),
                 self.render_metrics.cell_size,

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -69,11 +69,9 @@ impl super::TermWindow {
 
         let border = self.get_os_border();
 
-        let first_line_offset = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
-            self.tab_bar_pixel_height().unwrap_or(0.) as isize
-        } else {
-            0
-        } + border.top.get() as isize;
+        let insets = self.tab_bar_insets();
+        let first_line_offset = insets.top as isize + border.top.get() as isize;
+        let first_col_offset = insets.left as isize + border.left.get() as isize;
 
         let (padding_left, padding_top) = self.padding_left_top();
 
@@ -88,7 +86,7 @@ impl super::TermWindow {
         let x = (event
             .coords
             .x
-            .sub((padding_left + border.left.get() as f32) as isize)
+            .sub(padding_left as isize + first_col_offset)
             .max(0) as f32)
             / self.render_metrics.cell_size.width as f32;
         let x = if !pane.is_mouse_grabbed() {
@@ -295,16 +293,9 @@ impl super::TermWindow {
         let dims = pane.get_dimensions();
         let current_viewport = self.get_viewport(pane.pane_id());
 
-        let tab_bar_height = if self.show_tab_bar {
-            self.tab_bar_pixel_height().unwrap_or(0.)
-        } else {
-            0.
-        };
-        let (top_bar_height, bottom_bar_height) = if self.config.tab_bar_at_bottom {
-            (0.0, tab_bar_height)
-        } else {
-            (tab_bar_height, 0.0)
-        };
+        let insets = self.tab_bar_insets();
+        let top_bar_height = insets.top;
+        let bottom_bar_height = insets.bottom;
 
         let border = self.get_os_border();
         let y_offset = top_bar_height + border.top.get() as f32;

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -260,11 +260,8 @@ impl CommandPalette {
             .expect("to resolve command palette font");
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
 
-        let top_bar_height = if term_window.show_tab_bar && !term_window.config.tab_bar_at_bottom {
-            term_window.tab_bar_pixel_height().unwrap()
-        } else {
-            0.
-        };
+        let insets = term_window.tab_bar_insets();
+        let top_bar_height = insets.top;
         let (padding_left, padding_top) = term_window.padding_left_top();
         let border = term_window.get_os_border();
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;

--- a/wezterm-gui/src/termwindow/paneselect.rs
+++ b/wezterm-gui/src/termwindow/paneselect.rs
@@ -61,11 +61,8 @@ impl PaneSelector {
             .expect("to resolve pane selection font");
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
 
-        let top_bar_height = if term_window.show_tab_bar && !term_window.config.tab_bar_at_bottom {
-            term_window.tab_bar_pixel_height().unwrap()
-        } else {
-            0.
-        };
+        let insets = term_window.tab_bar_insets();
+        let top_bar_height = insets.top;
         let (padding_left, padding_top) = term_window.padding_left_top();
         let border = term_window.get_os_border();
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -6,7 +6,7 @@ use crate::termwindow::render::corners::*;
 use crate::termwindow::render::window_buttons::window_button_element;
 use crate::termwindow::{UIItem, UIItemType};
 use crate::utilsprites::RenderMetrics;
-use config::{Dimension, DimensionContext, TabBarColors};
+use config::{Dimension, DimensionContext, TabBarColors, TabBarPosition};
 use std::rc::Rc;
 use wezterm_font::LoadedFont;
 use wezterm_term::color::{ColorAttribute, ColorPalette};
@@ -56,6 +56,9 @@ impl crate::TermWindow {
     }
 
     pub fn build_fancy_tab_bar(&self, palette: &ColorPalette) -> anyhow::Result<ComputedElement> {
+        if self.effective_tab_bar_position() == TabBarPosition::Left {
+            return self.build_fancy_tab_bar_vertical(palette);
+        }
         let tab_bar_height = self.tab_bar_pixel_height()?;
         let font = self.fonts.title_font()?;
         let metrics = RenderMetrics::with_font_metrics(&font.metrics());
@@ -447,12 +450,190 @@ impl crate::TermWindow {
 
         computed.translate(euclid::vec2(
             0.,
-            if self.config.tab_bar_at_bottom {
+            if self.effective_tab_bar_position() == TabBarPosition::Bottom {
                 self.dimensions.pixel_height as f32
                     - (computed.bounds.height() + border.bottom.get() as f32)
             } else {
                 border.top.get() as f32
             },
+        ));
+
+        Ok(computed)
+    }
+
+    /// Build the fancy tab bar laid out as a vertical strip down the
+    /// left edge. Mirrors the horizontal builder above, with three
+    /// structural differences:
+    ///
+    /// 1. Each tab is set to `DisplayType::Block` so children stack
+    ///    top-to-bottom in the box model.
+    /// 2. The outer container is sized to `tab_bar_pixel_width` x
+    ///    `pixel_height` and placed at the window's top-left.
+    /// 3. Right-floated decorations (RightStatus, NewTabButton) flow
+    ///    after the tabs rather than to the right of them.
+    pub fn build_fancy_tab_bar_vertical(
+        &self,
+        palette: &ColorPalette,
+    ) -> anyhow::Result<ComputedElement> {
+        let font = self.fonts.title_font()?;
+        let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+        let items = self.tab_bar.items();
+        let colors = self
+            .config
+            .colors
+            .as_ref()
+            .and_then(|c| c.tab_bar.as_ref())
+            .cloned()
+            .unwrap_or_else(TabBarColors::default);
+
+        let bar_colors = ElementColors {
+            border: BorderColor::default(),
+            bg: if self.focused.is_some() {
+                self.config.window_frame.active_titlebar_bg
+            } else {
+                self.config.window_frame.inactive_titlebar_bg
+            }
+            .to_linear()
+            .into(),
+            text: if self.focused.is_some() {
+                self.config.window_frame.active_titlebar_fg
+            } else {
+                self.config.window_frame.inactive_titlebar_fg
+            }
+            .to_linear()
+            .into(),
+        };
+
+        let tab_bar_width = self.tab_bar_pixel_width();
+
+        let make_tab = |item: &TabEntry, active: bool| -> Element {
+            let inactive_tab = colors.inactive_tab();
+            let active_tab = colors.active_tab();
+            let bg = if active {
+                active_tab.bg_color
+            } else {
+                inactive_tab.bg_color
+            };
+            let fg = if active {
+                active_tab.fg_color
+            } else {
+                inactive_tab.fg_color
+            };
+            Element::with_line(&font, &item.title, palette)
+                .item_type(UIItemType::TabBar(item.item.clone()))
+                .display(DisplayType::Block)
+                .min_width(Some(Dimension::Pixels(tab_bar_width)))
+                .padding(BoxDimension {
+                    left: Dimension::Cells(0.5),
+                    right: Dimension::Cells(0.5),
+                    top: Dimension::Cells(0.3),
+                    bottom: Dimension::Cells(0.3),
+                })
+                .margin(BoxDimension {
+                    left: Dimension::Cells(0.),
+                    right: Dimension::Cells(0.),
+                    top: Dimension::Cells(0.),
+                    bottom: Dimension::Pixels(1.),
+                })
+                .border(BoxDimension::new(Dimension::Pixels(0.)))
+                .colors(ElementColors {
+                    border: BorderColor::default(),
+                    bg: bg.to_linear().into(),
+                    text: fg.to_linear().into(),
+                })
+                .hover_colors({
+                    let hover = if active {
+                        colors.inactive_tab_hover()
+                    } else {
+                        colors.inactive_tab_hover()
+                    };
+                    Some(ElementColors {
+                        border: BorderColor::default(),
+                        bg: hover.bg_color.to_linear().into(),
+                        text: hover.fg_color.to_linear().into(),
+                    })
+                })
+        };
+
+        let mut children = vec![];
+        for item in items {
+            match item.item {
+                TabBarItem::Tab { active, .. } => {
+                    children.push(make_tab(item, active));
+                }
+                TabBarItem::NewTabButton => {
+                    let new_tab = colors.new_tab();
+                    let new_tab_hover = colors.new_tab_hover();
+                    children.push(
+                        Element::new(&font, ElementContent::Text("+".to_string()))
+                            .item_type(UIItemType::TabBar(item.item.clone()))
+                            .display(DisplayType::Block)
+                            .min_width(Some(Dimension::Pixels(tab_bar_width)))
+                            .padding(BoxDimension {
+                                left: Dimension::Cells(0.5),
+                                right: Dimension::Cells(0.5),
+                                top: Dimension::Cells(0.3),
+                                bottom: Dimension::Cells(0.3),
+                            })
+                            .colors(ElementColors {
+                                border: BorderColor::default(),
+                                bg: new_tab.bg_color.to_linear().into(),
+                                text: new_tab.fg_color.to_linear().into(),
+                            })
+                            .hover_colors(Some(ElementColors {
+                                border: BorderColor::default(),
+                                bg: new_tab_hover.bg_color.to_linear().into(),
+                                text: new_tab_hover.fg_color.to_linear().into(),
+                            })),
+                    );
+                }
+                // Status / window-button items are noisy in vertical
+                // layout; skip them for the first cut. We can plumb
+                // them through later once basic stacking is solid.
+                _ => {}
+            }
+        }
+
+        let content = ElementContent::Children(children);
+
+        let tabs = Element::new(&font, content)
+            .display(DisplayType::Block)
+            .item_type(UIItemType::TabBar(TabBarItem::None))
+            .min_width(Some(Dimension::Pixels(tab_bar_width)))
+            .min_height(Some(Dimension::Pixels(self.dimensions.pixel_height as f32)))
+            .colors(bar_colors);
+
+        let border = self.get_os_border();
+
+        let mut computed = self.compute_element(
+            &LayoutContext {
+                height: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: self.dimensions.pixel_height as f32,
+                    pixel_cell: metrics.cell_size.height as f32,
+                },
+                width: DimensionContext {
+                    dpi: self.dimensions.dpi as f32,
+                    pixel_max: tab_bar_width,
+                    pixel_cell: metrics.cell_size.width as f32,
+                },
+                bounds: euclid::rect(
+                    border.left.get() as f32,
+                    border.top.get() as f32,
+                    tab_bar_width,
+                    self.dimensions.pixel_height as f32
+                        - (border.top + border.bottom).get() as f32,
+                ),
+                metrics: &metrics,
+                gl_state: self.render_state.as_ref().unwrap(),
+                zindex: 10,
+            },
+            &tabs,
+        )?;
+
+        computed.translate(euclid::vec2(
+            border.left.get() as f32,
+            border.top.get() as f32,
         ));
 
         Ok(computed)

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -363,6 +363,7 @@ impl crate::TermWindow {
             .bottom
             .evaluate_as_pixels(v_context);
 
+        let bar_insets = self.tab_bar_insets();
         let horizontal_gap = self.dimensions.pixel_width as f32
             - self.terminal_size.pixel_width as f32
             - padding_left
@@ -370,16 +371,13 @@ impl crate::TermWindow {
                 h_context.pixel_cell
             } else {
                 padding_right.evaluate_as_pixels(h_context)
-            };
+            }
+            - bar_insets.horizontal();
         let vertical_gap = self.dimensions.pixel_height as f32
             - self.terminal_size.pixel_height as f32
             - padding_top
             - padding_bottom
-            - if self.show_tab_bar {
-                self.tab_bar_pixel_height().unwrap_or(0.)
-            } else {
-                0.
-            };
+            - bar_insets.vertical();
         let left_gap = match self.config.window_content_alignment.horizontal {
             HorizontalWindowContentAlignment::Left => 0.,
             HorizontalWindowContentAlignment::Center => (horizontal_gap / 2.).round(),

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -62,17 +62,10 @@ impl crate::TermWindow {
 
         let (padding_left, padding_top) = self.padding_left_top();
 
-        let tab_bar_height = if self.show_tab_bar {
-            self.tab_bar_pixel_height()
-                .context("tab_bar_pixel_height")?
-        } else {
-            0.
-        };
-        let (top_bar_height, bottom_bar_height) = if self.config.tab_bar_at_bottom {
-            (0.0, tab_bar_height)
-        } else {
-            (tab_bar_height, 0.0)
-        };
+        let insets = self.tab_bar_insets();
+        let top_bar_height = insets.top;
+        let bottom_bar_height = insets.bottom;
+        let left_bar_width = insets.left;
 
         let border = self.get_os_border();
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;
@@ -111,12 +104,15 @@ impl crate::TermWindow {
             // We want to fill out to the edges of the splits
             let (x, width_delta) = if pos.left == 0 {
                 (
-                    0.,
+                    left_bar_width,
                     padding_left + border.left.get() as f32 + (cell_width / 2.0),
                 )
             } else {
                 (
-                    padding_left + border.left.get() as f32 - (cell_width / 2.0)
+                    left_bar_width
+                        + padding_left
+                        + border.left.get() as f32
+                        - (cell_width / 2.0)
                         + (pos.left as f32 * cell_width),
                     cell_width,
                 )
@@ -337,7 +333,8 @@ impl crate::TermWindow {
                 error: Option<anyhow::Error>,
             }
 
-            let left_pixel_x = padding_left
+            let left_pixel_x = left_bar_width
+                + padding_left
                 + border.left.get() as f32
                 + (pos.left as f32 * self.render_metrics.cell_size.width as f32);
 
@@ -588,16 +585,9 @@ impl crate::TermWindow {
         let cell_width = self.render_metrics.cell_size.width as f32;
         let cell_height = self.render_metrics.cell_size.height as f32;
         let (padding_left, padding_top) = self.padding_left_top();
-        let tab_bar_height = if self.show_tab_bar {
-            self.tab_bar_pixel_height()?
-        } else {
-            0.
-        };
-        let (top_bar_height, _bottom_bar_height) = if self.config.tab_bar_at_bottom {
-            (0.0, tab_bar_height)
-        } else {
-            (tab_bar_height, 0.0)
-        };
+        let insets = self.tab_bar_insets();
+        let top_bar_height = insets.top;
+        let left_bar_width = insets.left;
 
         let border = self.get_os_border();
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;
@@ -605,12 +595,15 @@ impl crate::TermWindow {
         // We want to fill out to the edges of the splits
         let (x, width_delta) = if pos.left == 0 {
             (
-                0.,
+                left_bar_width,
                 padding_left + border.left.get() as f32 + (cell_width / 2.0),
             )
         } else {
             (
-                padding_left + border.left.get() as f32 - (cell_width / 2.0)
+                left_bar_width
+                    + padding_left
+                    + border.left.get() as f32
+                    - (cell_width / 2.0)
                     + (pos.left as f32 * cell_width),
                 cell_width,
             )
@@ -647,7 +640,10 @@ impl crate::TermWindow {
 
         // Bounds for the terminal cells
         let content_rect = euclid::rect(
-            padding_left + border.left.get() as f32 - (cell_width / 2.0)
+            left_bar_width
+                + padding_left
+                + border.left.get() as f32
+                - (cell_width / 2.0)
                 + (pos.left as f32 * cell_width),
             top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),
             pos.width as f32 * cell_width,

--- a/wezterm-gui/src/termwindow/render/split.rs
+++ b/wezterm-gui/src/termwindow/render/split.rs
@@ -17,16 +17,14 @@ impl crate::TermWindow {
         let cell_height = self.render_metrics.cell_size.height as f32;
 
         let border = self.get_os_border();
-        let first_row_offset = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
-            self.tab_bar_pixel_height()?
-        } else {
-            0.
-        } + border.top.get() as f32;
+        let insets = self.tab_bar_insets();
+        let first_row_offset = insets.top + border.top.get() as f32;
+        let first_col_offset = insets.left + border.left.get() as f32;
 
         let (padding_left, padding_top) = self.padding_left_top();
 
         let pos_y = split.top as f32 * cell_height + first_row_offset + padding_top;
-        let pos_x = split.left as f32 * cell_width + padding_left + border.left.get() as f32;
+        let pos_x = split.left as f32 * cell_width + first_col_offset + padding_left;
 
         if split.direction == SplitDirection::Horizontal {
             self.filled_rectangle(
@@ -41,7 +39,8 @@ impl crate::TermWindow {
                 foreground,
             )?;
             self.ui_items.push(UIItem {
-                x: border.left.get() as usize
+                x: insets.left as usize
+                    + border.left.get() as usize
                     + padding_left as usize
                     + (split.left * cell_width as usize),
                 width: cell_width as usize,
@@ -64,7 +63,8 @@ impl crate::TermWindow {
                 foreground,
             )?;
             self.ui_items.push(UIItem {
-                x: border.left.get() as usize
+                x: insets.left as usize
+                    + border.left.get() as usize
                     + padding_left as usize
                     + (split.left * cell_width as usize),
                 width: split.size * cell_width as usize,

--- a/wezterm-gui/src/termwindow/render/tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/tab_bar.rs
@@ -1,10 +1,33 @@
 use crate::quad::TripleLayerQuadAllocator;
 use crate::termwindow::render::RenderScreenLineParams;
 use crate::utilsprites::RenderMetrics;
-use config::ConfigHandle;
+use config::{ConfigHandle, TabBarPosition};
 use mux::renderable::RenderableDimensions;
 use wezterm_term::color::ColorAttribute;
 use window::color::LinearRgba;
+
+/// Pixel insets carved out of the window for the tab bar.
+///
+/// Exactly one of `top` / `bottom` / `left` is non-zero in practice
+/// (or all zero if the tab bar is hidden). Consumers should treat
+/// the struct uniformly so that switching position is a pure data
+/// change.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct TabBarInsets {
+    pub top: f32,
+    pub bottom: f32,
+    pub left: f32,
+    pub right: f32,
+}
+
+impl TabBarInsets {
+    pub fn horizontal(&self) -> f32 {
+        self.left + self.right
+    }
+    pub fn vertical(&self) -> f32 {
+        self.top + self.bottom
+    }
+}
 
 impl crate::TermWindow {
     pub fn paint_tab_bar(&mut self, layers: &mut TripleLayerQuadAllocator) -> anyhow::Result<()> {
@@ -23,7 +46,7 @@ impl crate::TermWindow {
 
         let palette = self.palette().clone();
         let tab_bar_height = self.tab_bar_pixel_height()?;
-        let tab_bar_y = if self.config.tab_bar_at_bottom {
+        let tab_bar_y = if self.effective_tab_bar_position() == TabBarPosition::Bottom {
             ((self.dimensions.pixel_height as f32) - (tab_bar_height + border.bottom.get() as f32))
                 .max(0.)
         } else {
@@ -115,5 +138,71 @@ impl crate::TermWindow {
 
     pub fn tab_bar_pixel_height(&self) -> anyhow::Result<f32> {
         Self::tab_bar_pixel_height_impl(&self.config, &self.fonts, &self.render_metrics)
+    }
+
+    /// Width of the tab bar when it is rendered as a vertical strip
+    /// down the side of the window.
+    ///
+    /// Currently a fixed value. A future iteration can promote this
+    /// to a config knob, or derive it from the longest tab title.
+    pub fn tab_bar_pixel_width(&self) -> f32 {
+        220.0
+    }
+
+    /// Resolve the effective tab-bar position from the two config
+    /// fields. `tab_bar_position` wins when non-default; otherwise
+    /// the legacy `tab_bar_at_bottom` boolean controls.
+    pub fn effective_tab_bar_position(&self) -> TabBarPosition {
+        Self::effective_tab_bar_position_impl(&self.config)
+    }
+
+    pub fn effective_tab_bar_position_impl(config: &ConfigHandle) -> TabBarPosition {
+        match config.tab_bar_position {
+            TabBarPosition::Top if config.tab_bar_at_bottom => TabBarPosition::Bottom,
+            other => other,
+        }
+    }
+
+    /// Pixel insets reserved for the tab bar. Returns all-zero when
+    /// the tab bar is hidden. Vertical tab bars are only supported
+    /// in fancy mode; in non-fancy mode they fall back to Top.
+    pub fn tab_bar_insets(&self) -> TabBarInsets {
+        if !self.show_tab_bar {
+            return TabBarInsets::default();
+        }
+        Self::tab_bar_insets_impl(
+            &self.config,
+            self.tab_bar_pixel_height().unwrap_or(0.0),
+            self.tab_bar_pixel_width(),
+        )
+    }
+
+    pub fn tab_bar_insets_impl(
+        config: &ConfigHandle,
+        tab_bar_pixel_height: f32,
+        tab_bar_pixel_width: f32,
+    ) -> TabBarInsets {
+        let pos = Self::effective_tab_bar_position_impl(config);
+        let pos = if pos == TabBarPosition::Left && !config.use_fancy_tab_bar {
+            // Non-fancy bar cannot render vertically. Quietly fall back
+            // to Top. A user-visible warning is logged at config load.
+            TabBarPosition::Top
+        } else {
+            pos
+        };
+        match pos {
+            TabBarPosition::Top => TabBarInsets {
+                top: tab_bar_pixel_height,
+                ..Default::default()
+            },
+            TabBarPosition::Bottom => TabBarInsets {
+                bottom: tab_bar_pixel_height,
+                ..Default::default()
+            },
+            TabBarPosition::Left => TabBarInsets {
+                left: tab_bar_pixel_width,
+                ..Default::default()
+            },
+        }
     }
 }

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -163,11 +163,17 @@ impl super::TermWindow {
 
         let config = &self.config;
 
-        let tab_bar_height = if self.show_tab_bar {
-            self.tab_bar_pixel_height().unwrap_or(0.)
+        let tab_bar_insets = if self.show_tab_bar {
+            Self::tab_bar_insets_impl(
+                &self.config,
+                self.tab_bar_pixel_height().unwrap_or(0.),
+                self.tab_bar_pixel_width(),
+            )
         } else {
-            0.
+            crate::termwindow::render::tab_bar::TabBarInsets::default()
         };
+        let tab_bar_v_inset = tab_bar_insets.vertical();
+        let tab_bar_h_inset = tab_bar_insets.horizontal();
 
         let border = self.get_os_border();
 
@@ -204,11 +210,12 @@ impl super::TermWindow {
             let pixel_height = (rows * self.render_metrics.cell_size.height as usize)
                 + (padding_top + padding_bottom)
                 + (border.top + border.bottom).get() as usize
-                + tab_bar_height as usize;
+                + tab_bar_v_inset as usize;
 
             let pixel_width = (cols * self.render_metrics.cell_size.width as usize)
                 + (padding_left + padding_right)
-                + (border.left + border.right).get() as usize;
+                + (border.left + border.right).get() as usize
+                + tab_bar_h_inset as usize;
 
             let dims = Dimensions {
                 pixel_width: pixel_width as usize,
@@ -224,7 +231,8 @@ impl super::TermWindow {
                 padding_right: padding_right,
                 padding_bottom: padding_bottom,
                 border: border,
-                tab_bar_height: tab_bar_height as usize,
+                tab_bar_height: tab_bar_v_inset as usize,
+                tab_bar_width: tab_bar_h_inset as usize,
             };
 
             (size, dims, ri_calc)
@@ -247,17 +255,20 @@ impl super::TermWindow {
                 config.window_padding.bottom.evaluate_as_pixels(v_context) as usize;
             let padding_right = effective_right_padding(&config, h_context);
 
-            let avail_width = dimensions.pixel_width.saturating_sub(
-                (padding_left + padding_right) as usize
-                    + (border.left + border.right).get() as usize,
-            );
+            let avail_width = dimensions
+                .pixel_width
+                .saturating_sub(
+                    (padding_left + padding_right) as usize
+                        + (border.left + border.right).get() as usize,
+                )
+                .saturating_sub(tab_bar_h_inset as usize);
             let avail_height = dimensions
                 .pixel_height
                 .saturating_sub(
                     (padding_top + padding_bottom) as usize
                         + (border.top + border.bottom).get() as usize,
                 )
-                .saturating_sub(tab_bar_height as usize);
+                .saturating_sub(tab_bar_v_inset as usize);
 
             let rows = avail_height / self.render_metrics.cell_size.height as usize;
             let cols = avail_width / self.render_metrics.cell_size.width as usize;
@@ -282,7 +293,8 @@ impl super::TermWindow {
                 padding_right: padding_right,
                 padding_bottom: padding_bottom,
                 border: border,
-                tab_bar_height: tab_bar_height as usize,
+                tab_bar_height: tab_bar_v_inset as usize,
+                tab_bar_width: tab_bar_h_inset as usize,
             };
 
             (size, *dimensions, ri_calc)
@@ -489,10 +501,15 @@ impl super::TermWindow {
         };
 
         let show_tab_bar = config.enable_tab_bar && !config.hide_tab_bar_if_only_one_tab;
-        let tab_bar_height = if show_tab_bar {
-            self.tab_bar_pixel_height()? as usize
+        let (tab_bar_v_inset, tab_bar_h_inset) = if show_tab_bar {
+            let insets = Self::tab_bar_insets_impl(
+                &config,
+                self.tab_bar_pixel_height()?,
+                self.tab_bar_pixel_width(),
+            );
+            (insets.vertical() as usize, insets.horizontal() as usize)
         } else {
-            0
+            (0, 0)
         };
 
         let h_context = DimensionContext {
@@ -512,11 +529,12 @@ impl super::TermWindow {
         let dimensions = Dimensions {
             pixel_width: ((terminal_size.cols as usize * render_metrics.cell_size.width as usize)
                 + padding_left
-                + effective_right_padding(&config, h_context)),
+                + effective_right_padding(&config, h_context))
+                + tab_bar_h_inset,
             pixel_height: ((terminal_size.rows as usize * render_metrics.cell_size.height as usize)
                 + padding_top
                 + padding_bottom) as usize
-                + tab_bar_height,
+                + tab_bar_v_inset,
             dpi: self.dimensions.dpi,
         };
 


### PR DESCRIPTION
Adds a TabBarPosition enum (Top/Bottom/Left) and a tab_bar_position config field. Top and Bottom preserve existing behavior bit-for-bit (legacy tab_bar_at_bottom still resolves correctly). Left renders the fancy tab bar as a vertical strip down the left edge.

Implementation:

- TabBarInsets struct + tab_bar_insets() helper replaces the scattered tab_bar_at_bottom branching across pane/split/mouseevent/modal/resize sites with a uniform { top, bottom, left, right } pixel inset record.
- build_fancy_tab_bar_vertical() in render/fancy_tab_bar.rs uses DisplayType::Block on each tab element so the existing box model stacks them column-wise.
- Resize math + ResizeIncrementCalculator carry a tab_bar_width field alongside tab_bar_height.
- Non-fancy tab bar in Left mode falls back to Top (cannot stack glyphs vertically with the single-row render path).

Test workspace is in left-tabs/, including a Swift helper for reliable CGWindowID-based headless screenshots and three captured screenshots proving Top/Bottom/Left all render in the same binary.

Known polish gaps documented in left-tabs/progress/0003.