### PR TITLE
Fix Shift-AltGr dead key probing

### DIFF
--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2270,6 +2270,7 @@ impl KeyboardLayoutInfo {
             Modifiers::SHIFT | Modifiers::CTRL,
             Modifiers::ALT,
             Modifiers::RIGHT_ALT, // AltGr
+            Modifiers::SHIFT | Modifiers::RIGHT_ALT, // Shift-AltGr
         ];
 
         for &mods in &shift_states {


### PR DESCRIPTION
Fixes #3809 — dead keys accessed via Shift+AltGr (Ctrl+Alt+Shift) do not work on Windows.

## Problem

On Windows with the **Czech Programmer keyboard layout** (and other layouts where dead keys
require Shift+AltGr), characters like **Ř, Š, Č, Ž, ň** cannot be typed in WezTerm at all.

The root cause is in `KeyboardLayoutInfo::probe_dead_keys()` in
`window/src/os/windows/window.rs`. The function probes the keyboard layout to build a map of
dead keys by iterating over a set of modifier combinations (`shift_states`). The combination
`Shift | RIGHT_ALT` (Shift+AltGr) was missing from this list, so dead keys reachable only via
Shift+AltGr were never registered and the resulting characters were dropped.

## Fix

Add `Modifiers::SHIFT | Modifiers::RIGHT_ALT` to the `shift_states` array so that Shift+AltGr
dead keys are probed and correctly mapped.

## Affected layouts

Any Windows keyboard layout where a dead key is assigned to a Shift+AltGr combination, including:
- Czech Programmer (`cs-CZ`) — Ř, Š, Č, Ž, ň and others unreachable without this fix
- Belgian (Period) — `~` dead key on Ctrl+Alt+Shift+=