### PR TITLE
Fix SIGABRT on window close caused by OpenGL teardown ordering (MacOS)

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -909,6 +909,17 @@ impl TermWindow {
                 // the window is gone and we'll linger forever.
                 // <https://github.com/wezterm/wezterm/issues/3522>
                 self.clear_all_overlays();
+                // Drop OpenGL/render resources while the window surface is still
+                // alive, before NSView dealloc invalidates the GPU drawable.
+                // If deferred until TermWindow::drop, glium's Drop impls
+                // (RawProgram, Context, VertexBuffer, etc.) call make_current
+                // which triggers NSOpenGLContext update on a stale IOSurface,
+                // causing SIGABRT.
+                // Order matters: render_state first (its Drop deletes programs,
+                // buffers, textures via the context), then gl (drops the
+                // context itself, which does FBO/VAO/sampler cleanup).
+                self.render_state.take();
+                self.gl.take();
                 Ok(false)
             }
             WindowEvent::CloseRequested => {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -914,6 +914,17 @@ impl TermWindow {
                 // the window is gone and we'll linger forever.
                 // <https://github.com/wezterm/wezterm/issues/3522>
                 self.clear_all_overlays();
+                // Drop OpenGL/render resources while the window surface is still
+                // alive, before NSView dealloc invalidates the GPU drawable.
+                // If deferred until TermWindow::drop, glium's Drop impls
+                // (RawProgram, Context, VertexBuffer, etc.) call make_current
+                // which triggers NSOpenGLContext update on a stale IOSurface,
+                // causing SIGABRT.
+                // Order matters: render_state first (its Drop deletes programs,
+                // buffers, textures via the context), then gl (drops the
+                // context itself, which does FBO/VAO/sampler cleanup).
+                self.render_state.take();
+                self.gl.take();
                 Ok(false)
             }
             WindowEvent::CloseRequested => {


### PR DESCRIPTION
When a window closes on MacOS (15.x), the GPU drawable/IOSurface gets torn down before NSView dealloc fires. RenderState is still alive at that point, so [glium](https://github.com/glium/glium)'s Drop for RawProgram calls make_current, which walks into NSOpenGLContext update -> CGLUpdateContext -> IOSurface lookup on a dead Mach port. Process aborts. wompwomp.

Thanks to the Wezterm logging and for RustRover for helping debug this, made it muuuuuuuch simpler! (Not paid).

I BELIEVE the fix is dropping `render_state` in the `WindowEvent::Destroyed` handler (which runs from windowWillClose, before dealloc) while the surface is still valid. The field is already Option<RenderState> so .take() does the job.

Crash looks like this:
```
_kernelrpc_mach_port_mod_refs_trap
IOGPUGLDrawableLookupIOSurfaceFromIndex
GLRDrawable::attachDrawable
CGLUpdateContext / glUseProgramObjectARB_Exec
<RawProgram as Drop>::drop
drop_in_place<Option<RenderState>>
WindowView::dealloc
```

Fixes(?): https://github.com/wezterm/wezterm/issues/7265

I've tested this for a week now and haven't crashed once since!!