### PR TITLE
Fix Shift-AltGr dead key probing

### DIFF
--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2270,6 +2270,7 @@ impl KeyboardLayoutInfo {
             Modifiers::SHIFT | Modifiers::CTRL,
             Modifiers::ALT,
             Modifiers::RIGHT_ALT, // AltGr
+            Modifiers::SHIFT | Modifiers::RIGHT_ALT, // Shift-AltGr
         ];
 
         for &mods in &shift_states {


### PR DESCRIPTION
Fixes #3809

On Windows with keyboard layouts where dead keys are accessible via **Shift+AltGr**
(e.g. Czech Programmer layout — characters Ř, Š, Č, Ž, ň), WezTerm fails to produce
the correct characters because the dead key combinations are never recognized.

> Note: This is a reopen of #7795, which was accidentally closed.

## Root cause

`KeyboardLayoutInfo::probe_dead_keys()` in `window/src/os/windows/window.rs` probes
the keyboard layout by iterating over a set of modifier combinations (`shift_states`)
to detect dead keys. The combination `Shift | RIGHT_ALT` (Shift+AltGr) was missing
from this list, so any dead key reachable only via Shift+AltGr was never registered.

## Fix

Add `Modifiers::SHIFT | Modifiers::RIGHT_ALT` to the `shift_states` array.

## Affected layouts

Any Windows keyboard layout with a dead key on Shift+AltGr, including:
- **Czech Programmer** (`cs-CZ`) — Ř, Š, Č, Ž, ň unreachable without this fix
- **Belgian (Period)** — `~` dead key on Ctrl+Alt+Shift+=

## Testing

Tested on Windows 11 with the **Czech Programmer keyboard layout** (`cs-CZ`):
- Before fix: Ř, Š, Č, Ž, ň (and other Shift+AltGr dead key combinations) could not
  be typed at all — WezTerm swallowed the keystroke silently
- After fix: all affected characters type correctly

A pre-built Windows installer with this fix is available for testing:
[WezTerm-20260518-054801-b779f52f-setup.exe](https://github.com/lstefek/wezterm/releases/download/20260515-windows-artifact-test2/WezTerm-20260518-054801-b779f52f-setup.exe)
