### PR TITLE
tab bar: add tab_bar_width config to stretch tabs across the bar

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -508,6 +508,12 @@ pub struct Config {
     #[dynamic(default = "default_tab_max_width")]
     pub tab_max_width: usize,
 
+    /// Controls how tab widths are distributed across the tab bar.
+    /// `Content` (default) sizes each tab to its content; `Stretch` makes
+    /// tabs share the bar width equally so the bar is fully covered.
+    #[dynamic(default)]
+    pub tab_bar_width: TabBarWidth,
+
     /// If true, hide the tab bar if the window only has a single tab.
     #[dynamic(default)]
     pub hide_tab_bar_if_only_one_tab: bool,
@@ -1980,6 +1986,13 @@ pub enum VerticalWindowContentAlignment {
     Top,
     Center,
     Bottom,
+}
+
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+pub enum TabBarWidth {
+    #[default]
+    Content,
+    Stretch,
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, PartialEq, Eq)]

--- a/docs/config/lua/config/tab_bar_width.md
+++ b/docs/config/lua/config/tab_bar_width.md
@@ -8,7 +8,8 @@ tags:
 
 {{since('nightly')}}
 
-Controls how tab widths are distributed across the tab bar.
+Controls how tab widths are distributed across the **fancy** tab bar.
+The classic (non-fancy) tab bar is not affected for now.
 
 Accepted values:
 
@@ -17,7 +18,12 @@ Accepted values:
   fill the bar. This preserves the historical behavior.
 * `"Stretch"` — tabs share the bar width equally so the bar is fully
   covered, eliminating the empty trailing space that otherwise appears
-  after the new-tab button.
+  after the new-tab button. Each tab's rendered width is forced to
+  `(pixel_width − new_tab_button_width) / N_tabs`. The glyph-based
+  [`tab_max_width`](tab_max_width.md) limit still caps the title
+  string upstream, but in Stretch mode the pixel slot is typically
+  the tighter constraint and titles longer than the slot are
+  truncated with the standard `…` ellipsis.
 
 ```lua
 config.tab_bar_width = "Stretch"

--- a/docs/config/lua/config/tab_bar_width.md
+++ b/docs/config/lua/config/tab_bar_width.md
@@ -1,0 +1,26 @@
+---
+tags:
+  - appearance
+  - tab_bar
+---
+
+# `tab_bar_width = "Content"`
+
+{{since('nightly')}}
+
+Controls how tab widths are distributed across the tab bar.
+
+Accepted values:
+
+* `"Content"` (default) — each tab is sized to fit its title, leaving
+  empty space after the last tab when the combined tab widths do not
+  fill the bar. This preserves the historical behavior.
+* `"Stretch"` — tabs share the bar width equally so the bar is fully
+  covered, eliminating the empty trailing space that otherwise appears
+  after the new-tab button.
+
+```lua
+config.tab_bar_width = "Stretch"
+```
+
+See also [`tab_max_width`](tab_max_width.md).

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -6,7 +6,7 @@ use crate::termwindow::render::corners::*;
 use crate::termwindow::render::window_buttons::window_button_element;
 use crate::termwindow::{UIItem, UIItemType};
 use crate::utilsprites::RenderMetrics;
-use config::{Dimension, DimensionContext, TabBarColors};
+use config::{Dimension, DimensionContext, TabBarColors, TabBarWidth};
 use std::rc::Rc;
 use wezterm_font::LoadedFont;
 use wezterm_term::color::{ColorAttribute, ColorPalette};
@@ -303,9 +303,27 @@ impl crate::TermWindow {
                 _ => 0.,
             })
             .sum();
-        let max_tab_width = ((self.dimensions.pixel_width as f32 / num_tabs)
-            - (1.5 * metrics.cell_size.width as f32))
-            .max(0.);
+        let max_tab_width = match self.config.tab_bar_width {
+            TabBarWidth::Stretch => {
+                // Subtract the new-tab button's footprint up front so the
+                // remaining space divides evenly across real tabs and no
+                // dead zone is left at the right edge of the bar
+                let new_tab_button_width = 2.0 * metrics.cell_size.width as f32;
+                let tabs_available_pixel_width =
+                    (self.dimensions.pixel_width as f32 - new_tab_button_width).max(0.);
+                let tab_count = (num_tabs - 1.0).max(1.0);
+                (tabs_available_pixel_width / tab_count).max(0.)
+            }
+            TabBarWidth::Content => {
+                // Reserve room at the right edge of the bar for the new-tab
+                // button and any update-right-status content (date / git
+                // branch / pwd / etc) so left-floated tabs don't push them
+                // off-screen
+                ((self.dimensions.pixel_width as f32 / num_tabs)
+                    - (1.5 * metrics.cell_size.width as f32))
+                    .max(0.)
+            }
+        };
 
         // Reserve space for the native titlebar buttons
         if self
@@ -341,6 +359,10 @@ impl crate::TermWindow {
                 TabBarItem::Tab { tab_idx, active } => {
                     let mut elem = item_to_elem(item);
                     elem.max_width = Some(Dimension::Pixels(max_tab_width));
+                    if self.config.tab_bar_width == TabBarWidth::Stretch {
+                        // Stretch the tab to fill the full slot budgeted to it
+                        elem.min_width = Some(Dimension::Pixels(max_tab_width));
+                    }
                     elem.content = match elem.content {
                         ElementContent::Text(_) => unreachable!(),
                         ElementContent::Poly { .. } => unreachable!(),


### PR DESCRIPTION
## Summary

Adds a new `tab_bar_width` opt-in config option (default `"Content"`) that, when set to `"Stretch"`, distributes tab widths equally across the tab bar so the bar is fully covered, eliminating the trailing empty area after the new-tab button.

This is a lightweight alternative to #7591's taffy-based rewrite — ~60 lines, no new dependencies, default behavior unchanged.

## Motivation

Closes #1914 (4-year-old open issue: *"Add 'stretch tabs to fill tab bar' option"*).

The tab bar currently lays out tabs by their natural content width, leaving an empty unusable area between the `+` button and the right edge of the bar. With many tabs the gap grows because the per-tab `1.5 * cell_width` budget subtraction accumulates linearly with N.

## Before (default `tab_bar_width = "Content"`)

The trailing strip on the right is reserved for [`update-right-status`](https://wezterm.org/config/lua/window-events/update-right-status.html) content (date / git branch / pwd / etc) — useful if you surface anything there, wasted space otherwise:

![before](https://raw.githubusercontent.com/znzryb/wezterm/media/1914/content-12tabs-explain.png)

## With `tab_bar_width = "Stretch"`

Stretch mode budgets each tab `(pixel_width − new_tab_button_width) / N_tabs`, so the bar is always exactly covered regardless of how many tabs are open:

<p align="center">
  <img src="https://raw.githubusercontent.com/znzryb/wezterm/media/1914/stretch-2tabs.png" width="60%">
</p>

<p align="center">
  <img src="https://raw.githubusercontent.com/znzryb/wezterm/media/1914/stretch-3tabs.png" width="60%">
</p>

<p align="center">
  <img src="https://raw.githubusercontent.com/znzryb/wezterm/media/1914/stretch-4tabs.png" width="60%">
</p>

## Implementation

Addresses @bew's review feedback:

* New `tab_bar_width` enum with `Content` (default) / `Stretch` variants, following the `tab_bar_` prefix convention of existing tab bar config
* The Stretch arm subtracts the new-tab button's footprint up front via a `tabs_available_pixel_width` variable, so the remainder divides evenly across real tabs and no dead zone is left at the right edge (this also resolves the v1 known limitation about a residual `+` button gap)
* The Content arm preserves the historical `1.5 * cell_width` subtraction; the comment now explains the rationale (room for the new-tab button and any `update-right-status` content like date / git branch / pwd)
* Each tab gets `min_width = max_tab_width` in Stretch mode so tabs fill their budgeted slot rather than just being capped by it

`#[dynamic(default)]` keeps the new field at `Content` by default; existing user configs see zero behavioral change.

## Test plan

- [x] Built locally on macOS (M-series, nightly baseline `20260117-154428-05343b38`)
- [x] Default (`Content`): existing behavior unchanged
- [x] Enabled (`Stretch`): tabs fill bar with 2 / 3 / 4 / 12+ open tabs (see screenshots above)
- [x] `cargo fmt --all` clean
- [x] `cargo test --all --exclude wezterm-ssh --no-fail-fast`: **129 suites OK, 335 tests passed, 0 failures** (the 3 SFTP symlink failures in `wezterm-ssh` are caused by macOS `sftp-server` permissions, orthogonal to this change)

## Out of scope (per @bew's review)

* **Classic (non-fancy) tab bar**: @bew has offered to add the same behavior in a follow-up after this lands, so this PR focuses on the default tab bar
* **`tab_title_alignment` config**: orthogonal to stretch mode (alignment matters in `Content` mode too); better tracked as a separate issue
