### PR TITLE
InputSelector: add `selected_idx` to set the initially-highlighted entry

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -503,6 +503,11 @@ pub struct InputSelector {
 
     #[dynamic(default = "default_fuzzy_description")]
     pub fuzzy_description: String,
+
+    /// Index of the entry to highlight when the selector first opens.
+    /// Defaults to 0 (the first entry). An out-of-range value falls back to 0.
+    #[dynamic(default)]
+    pub selected_idx: usize,
 }
 
 fn default_num_alphabet() -> String {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -72,6 +72,10 @@ As features stabilize some brief notes about them will accumulate here.
   @mgpinf! #6801
 
 #### New
+* [InputSelector](config/lua/keyassignment/InputSelector.md) now accepts a
+  `selected_idx` field to choose which entry is highlighted when it opens
+  (defaults to the first; out-of-range falls back to 0). The selected row is
+  scrolled into view.
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345

--- a/docs/config/lua/keyassignment/InputSelector.md
+++ b/docs/config/lua/keyassignment/InputSelector.md
@@ -45,6 +45,13 @@ These additional fields are also available:
 * `fuzzy_description` - a string to display when in fuzzy finding mode. Defaults to:
   `"Fuzzy matching: "`.
 
+{{since('nightly')}}
+
+* `selected_idx` - the index (0-based) of the entry to highlight when the
+  selector first opens. Defaults to `0` (the first entry). An out-of-range
+  value falls back to `0`. The selected row is scrolled into view if the list
+  is longer than the visible area.
+
 
 ### Key Assignments
 

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -103,6 +103,15 @@ impl SelectorState {
             self.max_items = max_items;
         }
 
+        // Keep the active row within the visible window. Covers a configured
+        // initial `selected_idx` (set before the first render) as well as any
+        // other change to active_idx that didn't go through move_up/move_down.
+        if self.active_idx < self.top_row {
+            self.top_row = self.active_idx;
+        } else if self.active_idx > self.top_row + max_items {
+            self.top_row = self.active_idx.saturating_sub(max_items);
+        }
+
         let mut changes = vec![
             Change::ClearScreen(ColorAttribute::Default),
             Change::CursorPosition {
@@ -443,6 +452,11 @@ pub fn selector(
     term.set_raw_mode()?;
     term.render(&[Change::Title(state.args.title.to_string())])?;
     state.update_filter();
+    // Honour a configured initial selection, validated against the entry count:
+    // an out-of-range index falls back to 0 (already set above).
+    if state.args.selected_idx < state.filtered_entries.len() {
+        state.active_idx = state.args.selected_idx;
+    }
     state.render(&mut term)?;
     state.run_loop(&mut term)
 }


### PR DESCRIPTION
## What

Adds an optional `selected_idx` field to `InputSelector` that controls which
entry is highlighted when the selector first opens. Defaults to `0` (current
behaviour); an out-of-range value falls back to `0`.

## Why

Today `InputSelector` always opens with the cursor on the first entry
(`active_idx` is hard-coded to `0`), with no way to preselect a different row
from Lua. This makes it impossible to build selectors that open focused on a
contextually-relevant item — e.g. a workspace switcher that opens with the
cursor already on the workspace that needs attention, so the user can just
press Enter, without reordering the list.

## How

- `config`: new `#[dynamic(default)] pub selected_idx: usize` on `InputSelector`.
- `wezterm-gui`: after `update_filter()` populates the entries, set `active_idx`
  to `selected_idx` when it is in range (otherwise it stays `0`). `render()` now
  also keeps the active row within the visible window, so a selection beyond the
  first page is scrolled into view.

Backwards compatible: omitting the field keeps the current behaviour (`0`).
Docs and a changelog entry are included.

## Example

```lua
act.InputSelector {
  title = 'Switch Workspace',
  choices = choices,
  selected_idx = 2, -- open with the 3rd entry highlighted
  action = wezterm.action_callback(function(win, pane, id, label) end),
}
```
