### PR TITLE
webgpu: clamp surface dimensions to max_texture_dimension_2d

### DIFF
--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -359,11 +359,17 @@ impl WebGpuState {
             vec![]
         };
 
+        let max_dim = device.limits().max_texture_dimension_2d;
+        let (init_width, init_height) = clamp_surface_dimensions(
+            dimensions.pixel_width as u32,
+            dimensions.pixel_height as u32,
+            max_dim,
+        );
         let config = wgpu::SurfaceConfiguration {
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
             format,
-            width: dimensions.pixel_width as u32,
-            height: dimensions.pixel_height as u32,
+            width: init_width,
+            height: init_height,
             present_mode: wgpu::PresentMode::Fifo,
             alpha_mode: if caps
                 .alpha_modes
@@ -547,15 +553,94 @@ impl WebGpuState {
         if dims == *self.dimensions.borrow() {
             return;
         }
+        // Store the unclamped dims: this field is only used to dedup resize
+        // events against the size the window actually requested. Clamping is
+        // applied below, only to the values handed to Surface::configure.
         *self.dimensions.borrow_mut() = dims;
         let mut config = self.config.borrow_mut();
-        config.width = dims.pixel_width as u32;
-        config.height = dims.pixel_height as u32;
+        let max = self.device.limits().max_texture_dimension_2d;
+        let (clamped_width, clamped_height) =
+            clamp_surface_dimensions(dims.pixel_width as u32, dims.pixel_height as u32, max);
+        config.width = clamped_width;
+        config.height = clamped_height;
         if config.width > 0 && config.height > 0 {
             // Avoid reconfiguring with a 0 sized surface, as webgpu will
             // panic in that case
             // <https://github.com/wezterm/wezterm/issues/2881>
             self.surface.configure(&self.device, &config);
         }
+    }
+}
+
+/// Clamp a requested surface size to the adapter's maximum texture dimension.
+///
+/// `Surface::configure` raises a validation error (which becomes a fatal panic
+/// when called from an Objective-C → Rust FFI callback) if either dimension
+/// exceeds `max`. This is reachable on macOS with tiling window managers that
+/// transiently compute window geometry spanning multiple Retina displays.
+fn clamp_surface_dimensions(width: u32, height: u32, max: u32) -> (u32, u32) {
+    // A degenerate adapter reporting max == 0 would clamp everything to zero,
+    // bypassing the > 0 guard that skips surface.configure. Pass through
+    // unchanged in that case and let wgpu surface validation surface the error.
+    if max == 0 {
+        return (width, height);
+    }
+    let clamped_w = width.min(max);
+    let clamped_h = height.min(max);
+    if clamped_w != width || clamped_h != height {
+        log::warn!(
+            "Clamped surface size from {}x{} to {}x{} (max_texture_dimension_2d={})",
+            width,
+            height,
+            clamped_w,
+            clamped_h,
+            max
+        );
+    }
+    (clamped_w, clamped_h)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clamp_surface_dimensions;
+
+    #[test]
+    fn no_clamp_when_within_limit() {
+        assert_eq!(clamp_surface_dimensions(1920, 1080, 16384), (1920, 1080));
+    }
+
+    #[test]
+    fn clamps_width_exceeding_max() {
+        // Reproduces the exact dimensions seen in crash reports:
+        // Aerospace spanning two Retina displays → 19872 x 2260, max = 16384.
+        assert_eq!(clamp_surface_dimensions(19872, 2260, 16384), (16384, 2260));
+    }
+
+    #[test]
+    fn clamps_height_exceeding_max() {
+        assert_eq!(clamp_surface_dimensions(1920, 20000, 16384), (1920, 16384));
+    }
+
+    #[test]
+    fn clamps_both_dimensions() {
+        assert_eq!(clamp_surface_dimensions(20000, 20000, 16384), (16384, 16384));
+    }
+
+    #[test]
+    fn zero_dimensions_pass_through() {
+        // Zero is handled separately by the > 0 guard before surface.configure.
+        assert_eq!(clamp_surface_dimensions(0, 0, 16384), (0, 0));
+    }
+
+    #[test]
+    fn degenerate_max_zero_passes_through() {
+        // If the adapter reports max == 0, don't clamp everything to zero —
+        // pass through and let wgpu surface validation handle it.
+        assert_eq!(clamp_surface_dimensions(1920, 1080, 0), (1920, 1080));
+    }
+
+    #[test]
+    fn exact_limit_is_not_clamped() {
+        assert_eq!(clamp_surface_dimensions(16384, 16384, 16384), (16384, 16384));
     }
 }

--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -572,21 +572,26 @@ impl WebGpuState {
     }
 }
 
-/// Clamp a requested surface size to the adapter's maximum texture dimension.
+/// Clamp a requested surface size to a maximum.
+/// (e.g. the GPU adapter's maximum texture dimension)
 ///
-/// `Surface::configure` raises a validation error (which becomes a fatal panic
-/// when called from an Objective-C → Rust FFI callback) if either dimension
-/// exceeds `max`. This is reachable on macOS with tiling window managers that
-/// transiently compute window geometry spanning multiple Retina displays.
-fn clamp_surface_dimensions(width: u32, height: u32, max: u32) -> (u32, u32) {
-    // A degenerate adapter reporting max == 0 would clamp everything to zero,
-    // bypassing the > 0 guard that skips surface.configure. Pass through
-    // unchanged in that case and let wgpu surface validation surface the error.
-    if max == 0 {
+/// This is necessary before `Surface::configure` as it raises a validation error if either
+/// dimension exceeds the GPU supported max dimension.
+///
+/// This can happen on macOS with tiling window managers that transiently compute
+/// window geometry spanning multiple Retina displays.
+///  (which becomes a fatal panic when called from an Objective-C → Rust FFI callback)
+/// See https://github.com/wezterm/wezterm/issues/7819.
+fn clamp_surface_dimensions(width: u32, height: u32, max_texture_dimension_2d: u32) -> (u32, u32) {
+    // A degenerate adapter reporting max_texture_dimension_2d == 0 would clamp
+    // everything to zero, bypassing the > 0 guard that skips surface.configure.
+    // Pass through unchanged in that case and let wgpu surface validation
+    // surface the error.
+    if max_texture_dimension_2d == 0 {
         return (width, height);
     }
-    let clamped_w = width.min(max);
-    let clamped_h = height.min(max);
+    let clamped_w = width.min(max_texture_dimension_2d);
+    let clamped_h = height.min(max_texture_dimension_2d);
     if clamped_w != width || clamped_h != height {
         log::warn!(
             "Clamped surface size from {}x{} to {}x{} (max_texture_dimension_2d={})",
@@ -594,7 +599,7 @@ fn clamp_surface_dimensions(width: u32, height: u32, max: u32) -> (u32, u32) {
             height,
             clamped_w,
             clamped_h,
-            max
+            max_texture_dimension_2d
         );
     }
     (clamped_w, clamped_h)
@@ -604,32 +609,51 @@ fn clamp_surface_dimensions(width: u32, height: u32, max: u32) -> (u32, u32) {
 mod tests {
     use super::clamp_surface_dimensions;
 
+    /// Apple Silicon's `max_texture_dimension_2d`, and the limit hit in the
+    /// crash reports this fix addresses.
+    const MAX_TEXTURE_DIMENSION_2D: u32 = 16384;
+
     #[test]
     fn no_clamp_when_within_limit() {
-        assert_eq!(clamp_surface_dimensions(1920, 1080, 16384), (1920, 1080));
+        assert_eq!(
+            clamp_surface_dimensions(1920, 1080, MAX_TEXTURE_DIMENSION_2D),
+            (1920, 1080)
+        );
     }
 
     #[test]
     fn clamps_width_exceeding_max() {
         // Reproduces the exact dimensions seen in crash reports:
         // Aerospace spanning two Retina displays → 19872 x 2260, max = 16384.
-        assert_eq!(clamp_surface_dimensions(19872, 2260, 16384), (16384, 2260));
+        assert_eq!(
+            clamp_surface_dimensions(19872, 2260, MAX_TEXTURE_DIMENSION_2D),
+            (MAX_TEXTURE_DIMENSION_2D, 2260)
+        );
     }
 
     #[test]
     fn clamps_height_exceeding_max() {
-        assert_eq!(clamp_surface_dimensions(1920, 20000, 16384), (1920, 16384));
+        assert_eq!(
+            clamp_surface_dimensions(1920, 20000, MAX_TEXTURE_DIMENSION_2D),
+            (1920, MAX_TEXTURE_DIMENSION_2D)
+        );
     }
 
     #[test]
     fn clamps_both_dimensions() {
-        assert_eq!(clamp_surface_dimensions(20000, 20000, 16384), (16384, 16384));
+        assert_eq!(
+            clamp_surface_dimensions(20000, 20000, MAX_TEXTURE_DIMENSION_2D),
+            (MAX_TEXTURE_DIMENSION_2D, MAX_TEXTURE_DIMENSION_2D)
+        );
     }
 
     #[test]
     fn zero_dimensions_pass_through() {
         // Zero is handled separately by the > 0 guard before surface.configure.
-        assert_eq!(clamp_surface_dimensions(0, 0, 16384), (0, 0));
+        assert_eq!(
+            clamp_surface_dimensions(0, 0, MAX_TEXTURE_DIMENSION_2D),
+            (0, 0)
+        );
     }
 
     #[test]
@@ -641,6 +665,13 @@ mod tests {
 
     #[test]
     fn exact_limit_is_not_clamped() {
-        assert_eq!(clamp_surface_dimensions(16384, 16384, 16384), (16384, 16384));
+        assert_eq!(
+            clamp_surface_dimensions(
+                MAX_TEXTURE_DIMENSION_2D,
+                MAX_TEXTURE_DIMENSION_2D,
+                MAX_TEXTURE_DIMENSION_2D
+            ),
+            (MAX_TEXTURE_DIMENSION_2D, MAX_TEXTURE_DIMENSION_2D)
+        );
     }
 }

--- a/wezterm-gui/src/termwindow/webgpu.rs
+++ b/wezterm-gui/src/termwindow/webgpu.rs
@@ -609,14 +609,14 @@ fn clamp_surface_dimensions(width: u32, height: u32, max_texture_dimension_2d: u
 mod tests {
     use super::clamp_surface_dimensions;
 
-    /// Apple Silicon's `max_texture_dimension_2d`, and the limit hit in the
-    /// crash reports this fix addresses.
-    const MAX_TEXTURE_DIMENSION_2D: u32 = 16384;
+    /// Apple Silicon's `max_texture_dimension_2d`, the value seen in the
+    /// crash reports in <https://github.com/wezterm/wezterm/issues/7819>.
+    const SAMPLE_MAX_TEXTURE_DIMENSION_2D: u32 = 16384;
 
     #[test]
     fn no_clamp_when_within_limit() {
         assert_eq!(
-            clamp_surface_dimensions(1920, 1080, MAX_TEXTURE_DIMENSION_2D),
+            clamp_surface_dimensions(1920, 1080, SAMPLE_MAX_TEXTURE_DIMENSION_2D),
             (1920, 1080)
         );
     }
@@ -626,24 +626,27 @@ mod tests {
         // Reproduces the exact dimensions seen in crash reports:
         // Aerospace spanning two Retina displays → 19872 x 2260, max = 16384.
         assert_eq!(
-            clamp_surface_dimensions(19872, 2260, MAX_TEXTURE_DIMENSION_2D),
-            (MAX_TEXTURE_DIMENSION_2D, 2260)
+            clamp_surface_dimensions(19872, 2260, SAMPLE_MAX_TEXTURE_DIMENSION_2D),
+            (SAMPLE_MAX_TEXTURE_DIMENSION_2D, 2260)
         );
     }
 
     #[test]
     fn clamps_height_exceeding_max() {
         assert_eq!(
-            clamp_surface_dimensions(1920, 20000, MAX_TEXTURE_DIMENSION_2D),
-            (1920, MAX_TEXTURE_DIMENSION_2D)
+            clamp_surface_dimensions(1920, 20000, SAMPLE_MAX_TEXTURE_DIMENSION_2D),
+            (1920, SAMPLE_MAX_TEXTURE_DIMENSION_2D)
         );
     }
 
     #[test]
     fn clamps_both_dimensions() {
         assert_eq!(
-            clamp_surface_dimensions(20000, 20000, MAX_TEXTURE_DIMENSION_2D),
-            (MAX_TEXTURE_DIMENSION_2D, MAX_TEXTURE_DIMENSION_2D)
+            clamp_surface_dimensions(20000, 20000, SAMPLE_MAX_TEXTURE_DIMENSION_2D),
+            (
+                SAMPLE_MAX_TEXTURE_DIMENSION_2D,
+                SAMPLE_MAX_TEXTURE_DIMENSION_2D
+            )
         );
     }
 
@@ -651,7 +654,7 @@ mod tests {
     fn zero_dimensions_pass_through() {
         // Zero is handled separately by the > 0 guard before surface.configure.
         assert_eq!(
-            clamp_surface_dimensions(0, 0, MAX_TEXTURE_DIMENSION_2D),
+            clamp_surface_dimensions(0, 0, SAMPLE_MAX_TEXTURE_DIMENSION_2D),
             (0, 0)
         );
     }
@@ -667,11 +670,14 @@ mod tests {
     fn exact_limit_is_not_clamped() {
         assert_eq!(
             clamp_surface_dimensions(
-                MAX_TEXTURE_DIMENSION_2D,
-                MAX_TEXTURE_DIMENSION_2D,
-                MAX_TEXTURE_DIMENSION_2D
+                SAMPLE_MAX_TEXTURE_DIMENSION_2D,
+                SAMPLE_MAX_TEXTURE_DIMENSION_2D,
+                SAMPLE_MAX_TEXTURE_DIMENSION_2D
             ),
-            (MAX_TEXTURE_DIMENSION_2D, MAX_TEXTURE_DIMENSION_2D)
+            (
+                SAMPLE_MAX_TEXTURE_DIMENSION_2D,
+                SAMPLE_MAX_TEXTURE_DIMENSION_2D
+            )
         );
     }
 }


### PR DESCRIPTION
Fix: https://github.com/wezterm/wezterm/issues/7819 

Surface::configure raises a wgpu validation error if either dimension exceeds the adapter's max_texture_dimension_2d (16384 on Apple Silicon). When this happens inside the did_resize Objective-C → Rust FFI callback, Rust cannot unwind and the process aborts.

This is reproducible on macOS with tiling window managers (e.g. Aerospace) that transiently compute window geometry spanning multiple Retina displays on wake from sleep or workspace re-tile. The requested width in all observed crashes was consistently 19872 px (two displays combined under their scale factors), exceeding the 16384 px GPU limit.

Guard both the initial SurfaceConfiguration in new_impl() and the live resize() path by clamping to device.limits().max_texture_dimension_2d, mirroring the existing zero-size guard added in #2881. The stored self.dimensions value is left unclamped so the resize dedup guard keeps comparing against the size the window actually requested; clamping is applied only to the values handed to Surface::configure.

Add unit tests covering the exact crash dimensions, boundary cases, and a degenerate max==0 adapter, including a regression test that fails against the unfixed code.

AI usage: Claude Opus 4.8