### PR TITLE
feat(wayland): allow hiding fallback frame

### DIFF
--- a/config/src/color.rs
+++ b/config/src/color.rs
@@ -567,6 +567,17 @@ fn default_window_close() -> String {
 
 #[derive(Debug, Clone, FromDynamic, ToDynamic)]
 pub struct WindowFrameConfig {
+    /// Hide the Wayland fallback client-side decoration frame.
+    ///
+    /// This is useful on compositors where `window_decorations = "NONE"`
+    /// negotiates server-side decorations, but `window_decorations = "RESIZE"`
+    /// causes the fallback frame to draw an unwanted title bar.
+    ///
+    /// This also disables the fallback resize borders; use compositor-provided
+    /// keyboard or pointer shortcuts to move and resize the window.
+    #[dynamic(default)]
+    pub hidden: bool,
+
     #[dynamic(default = "default_inactive_titlebar_bg")]
     pub inactive_titlebar_bg: RgbaColor,
     #[dynamic(default = "default_active_titlebar_bg")]
@@ -615,6 +626,7 @@ const fn default_zero_pixel() -> Dimension {
 impl Default for WindowFrameConfig {
     fn default() -> Self {
         Self {
+            hidden: false,
             inactive_titlebar_bg: default_inactive_titlebar_bg(),
             active_titlebar_bg: default_active_titlebar_bg(),
             inactive_titlebar_fg: default_inactive_titlebar_fg(),

--- a/docs/config/lua/config/window_frame.md
+++ b/docs/config/lua/config/window_frame.md
@@ -28,6 +28,26 @@ config.window_frame = {
 }
 ```
 
+
+{{since('nightly')}}
+
+You may hide the Wayland fallback client-side decoration frame:
+
+```lua
+config.window_decorations = "RESIZE"
+config.window_frame = {
+  hidden = true,
+}
+```
+
+This is useful on compositors where
+[`window_decorations = "NONE"`](window_decorations.md) negotiates server-side
+decorations, but `window_decorations = "RESIZE"` causes the fallback frame to
+draw an unwanted title bar.
+
+This hides both the fallback title bar and the fallback resize borders. Use
+your compositor's keyboard or pointer shortcuts to move and resize the window.
+
 {{since('20220903-194523-3bb1ed61')}}
 
 You may explicitly add a border around the window area:

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -264,7 +264,7 @@ impl WaylandWindow {
                 .expect("failed to create csd frame")
         };
         let hidden = match decor_mode {
-            Some(DecorationMode::Client) => false,
+            Some(DecorationMode::Client) => config.window_frame.hidden,
             _ => true,
         };
         window_frame.set_hidden(hidden);


### PR DESCRIPTION
## Summary

- add `window_frame.hidden` to let Wayland users hide WezTerm's fallback client-side decoration frame
- keep the default unchanged so client-side decorations remain visible unless explicitly disabled
- document the option together with `window_decorations = "RESIZE"`, including the resize-border tradeoff

## Context

On compositors that support server-side decorations, `window_decorations = "NONE"` can negotiate compositor-provided decorations. Using `window_decorations = "RESIZE"` selects client-side decorations, but currently always displays Smithay's fallback frame. This option lets users keep native Wayland while opting out of that fallback frame.

## Testing

- `nix develop ./nix -c cargo test --all`
- `nix develop ./nix -c cargo fmt --all`
