### PR TITLE
ci/cd: Update nix-related workflows

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -22,15 +22,21 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+
       - name: Cache build artifacts
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
+
       - name: Check flake inputs
+        # note: waiting for a release with node24 upgrade
+        # see: https://github.com/DeterminateSystems/flake-checker-action/pull/110
         uses: DeterminateSystems/flake-checker-action@main
         with:
           flake-lock-path: ./nix/flake.lock
           ignore-missing-flake-lock: false
+
       - name: Build default package
         run: nix build ./nix

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,4 +1,4 @@
-name: Nix
+name: Nix / Build
 
 on:
   pull_request:
@@ -18,8 +18,7 @@ on:
       - 'nix/**'
 
 jobs:
-  lints:
-    name: Build
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nix-continuous.yml
+++ b/.github/workflows/nix-continuous.yml
@@ -44,7 +44,7 @@ jobs:
           nix build ./nix --json > result.json
 
       - name: Push to Cachix
-        if: ${{ github.event_name == "schedule" || github.event_name == "workflow_dispatch" }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
           jq result.json -r '.[].outputs | to_entries[].value' \
           | cachix push wezterm

--- a/.github/workflows/nix-continuous.yml
+++ b/.github/workflows/nix-continuous.yml
@@ -1,8 +1,8 @@
-name: nix_continuous
+name: Nix / Continuous Build
 
 on:
   schedule:
-    - cron: "10 3 * * *"
+    - cron: "10 3 * * *" # Every night at 3:10am
   workflow_dispatch:
   push:
     branches:
@@ -13,28 +13,38 @@ on:
       - 'nix/**'
 
 jobs:
-  lints:
-    name: Build
+  build:
     runs-on: ubuntu-latest
     if: github.repository == 'wezterm/wezterm'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+
       - name: Cache build artifacts
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
+
       - name: Check flake inputs
+        # note: waiting for a release with node24 upgrade
+        # see: https://github.com/DeterminateSystems/flake-checker-action/pull/110
         uses: DeterminateSystems/flake-checker-action@main
         with:
           flake-lock-path: ./nix/flake.lock
           ignore-missing-flake-lock: false
+
       - name: Setup Cachix
         uses: cachix/cachix-action@v16
         with:
           name: wezterm
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: Build default package
         run: |
-          nix build ./nix --json \
-          | jq -r '.[].outputs | to_entries[].value' \
+          nix build ./nix --json > result.json
+
+      - name: Push to Cachix
+        if: ${{ github.event_name == "schedule" || github.event_name == "workflow_dispatch" }}
+        run: |
+          jq result.json -r '.[].outputs | to_entries[].value' \
           | cachix push wezterm

--- a/.github/workflows/nix-update-flake.yml
+++ b/.github/workflows/nix-update-flake.yml
@@ -1,4 +1,4 @@
-name: update-flake-lock
+name: Nix / Update flake.lock
 on:
   workflow_dispatch:
   schedule:
@@ -11,21 +11,26 @@ jobs:
     if: github.repository == 'wezterm/wezterm'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+
       - name: Cache build artifacts
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
+
       - name: Check flake
+        # note: waiting for a release with node24 upgrade
+        # see: https://github.com/DeterminateSystems/flake-checker-action/pull/110
         uses: DeterminateSystems/flake-checker-action@main
+
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@main
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           token: "${{ secrets.FLAKE_LOCK_GH_PAT }}"
-          pr-title: 'Update flake.lock' # Title of PR to be created
-          pr-labels: | # Labels to be set on the PR
+          pr-title: 'nix: Update flake.lock'
+          pr-labels: |
             dependencies
             automated
-          pr-assignees: happenslol,gabyx,emiller88
           pr-reviewers: bew
           path-to-flake-dir: 'nix/'


### PR DESCRIPTION
Review pass on the Nix-related workflows.
- lock actions to a major branch, at least
- various tweaks and readability improvements
- only push built result to Cachix if workflow triggered by `schedule` or manual `workflow_dispatch` event

Note @happenslol @gabyx @emiller88: I've removed you from auto-assigned role on flake.lock update PRs, I don't think you recently participated there. But if you're still interested we can talk about it!