### PR TITLE
windows: add win32_keep_system_backdrop_when_inactive option

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -581,6 +581,13 @@ pub struct Config {
     #[dynamic(default = "default_win32_acrylic_accent_color")]
     pub win32_acrylic_accent_color: RgbaColor,
 
+    /// Only works on Windows: when enabled, the window keeps rendering
+    /// its configured `win32_system_backdrop` material (Acrylic/Mica/Tabbed)
+    /// while the window is inactive, instead of letting DWM fade the
+    /// backdrop to its solid fallback color.
+    #[dynamic(default)]
+    pub win32_keep_system_backdrop_when_inactive: bool,
+
     /// Specifies the alpha value to use when rendering the background
     /// of the window.  The background is taken either from the
     /// window_background_image, or if there is none, the background

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -73,6 +73,9 @@ As features stabilize some brief notes about them will accumulate here.
 * windows: Improve detection of running in WSL. Thanks to @bew! #7137
 
 #### New
+* [win32_keep_system_backdrop_when_inactive](config/lua/config/win32_keep_system_backdrop_when_inactive.md)
+  option to keep the *Acrylic*/*Mica*/*Tabbed* backdrop material rendered
+  while the window is inactive, instead of fading to a solid color. #5895
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345

--- a/docs/config/lua/config/win32_keep_system_backdrop_when_inactive.md
+++ b/docs/config/lua/config/win32_keep_system_backdrop_when_inactive.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - appearance
+---
+
+# `win32_keep_system_backdrop_when_inactive = false`
+
+{{since('nightly')}}
+
+By default, when a window using a
+[win32_system_backdrop](win32_system_backdrop.md) material (*Acrylic*, *Mica*
+or *Tabbed*) becomes inactive, DWM stops rendering the backdrop material and
+fades it to a solid fallback color, making the window look opaque until it is
+focused again.
+
+Setting this option to `true` keeps the configured backdrop material rendered
+while the window is inactive, so the window stays translucent with the same
+effect regardless of focus:
+
+```lua
+config.window_background_opacity = 0
+config.win32_system_backdrop = 'Acrylic'
+config.win32_keep_system_backdrop_when_inactive = true
+```
+
+This works by reporting the window to DWM as always active for non-client
+rendering purposes (the `WM_NCACTIVATE` state). A side effect is that, when
+using a `window_decorations` style that shows the native title bar, the title
+bar will always render in its active colors.
+
+This option has no effect when `win32_system_backdrop` is `"Auto"` or
+`"Disable"`, and is only meaningful on Windows.

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -1608,6 +1608,38 @@ unsafe fn wm_kill_focus(
     None
 }
 
+unsafe fn wm_ncactivate(hwnd: HWND, msg: UINT, wparam: WPARAM, _lparam: LPARAM) -> Option<LRESULT> {
+    // DWM renders the system backdrop material (win32_system_backdrop:
+    // Acrylic/Mica/Tabbed) in its "inactive" style -- a solid fallback
+    // color -- when the window deactivates.  That state change is driven
+    // by the DefWindowProc handling of WM_NCACTIVATE, so when the user
+    // asked to keep the backdrop while inactive, lie to DWM by always
+    // passing wParam=TRUE (active).  lParam=-1 tells DefWindowProc not
+    // to repaint the non-client area to reflect the (fake) state change.
+    // See https://github.com/wezterm/wezterm/issues/5895
+    let inner = rc_from_hwnd(hwnd)?;
+    let keep = {
+        let inner = inner.borrow();
+        inner.config.win32_keep_system_backdrop_when_inactive
+            && !matches!(
+                inner.config.win32_system_backdrop,
+                SystemBackdrop::Auto | SystemBackdrop::Disable
+            )
+    };
+    if keep && wparam == 0 {
+        // Note: DefWindowProcW may trigger other window messages, so the
+        // borrow above must be dropped before calling it.
+        Some(DefWindowProcW(
+            hwnd,
+            msg,
+            winapi::shared::minwindef::TRUE as WPARAM,
+            -1,
+        ))
+    } else {
+        None
+    }
+}
+
 unsafe fn wm_paint(hwnd: HWND, _msg: UINT, _wparam: WPARAM, _lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let mut inner = inner.borrow_mut();
@@ -2933,6 +2965,7 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
         WM_WINDOWPOSCHANGED => wm_windowposchanged(hwnd, msg, wparam, lparam),
         WM_SETFOCUS => wm_set_focus(hwnd, msg, wparam, lparam),
         WM_KILLFOCUS => wm_kill_focus(hwnd, msg, wparam, lparam),
+        WM_NCACTIVATE => wm_ncactivate(hwnd, msg, wparam, lparam),
         WM_DEADCHAR | WM_KEYDOWN | WM_KEYUP | WM_SYSCHAR | WM_CHAR | WM_IME_CHAR | WM_SYSKEYUP
         | WM_SYSKEYDOWN => key(hwnd, msg, wparam, lparam),
         WM_SIZING => {


### PR DESCRIPTION
## Summary

On Windows, when a window uses a `win32_system_backdrop` material
(`Acrylic`, `Mica` or `Tabbed`), DWM stops rendering the material and
fades it to a solid fallback color as soon as the window becomes
inactive, so the window looks opaque until it regains focus. This is a
long-standing pain point reported in #5895 (and its duplicates #6979,
#1099, #593).

This PR adds an opt-in option, `win32_keep_system_backdrop_when_inactive`,
that keeps the configured backdrop material rendered while the window is
inactive.

## Root cause

The fade is not a hard OS limitation — Windows Terminal keeps its
backdrop while inactive, so an app *can* opt out of it. For the DWM
system backdrop (`DWMWA_SYSTEMBACKDROP_TYPE`, which is what wezterm
uses), the inactive fade is driven by the non-client activation state
that `DefWindowProc` applies when handling `WM_NCACTIVATE`.

## Change

When the option is enabled, `wm_ncactivate` reports the window as always
active for non-client purposes: it forwards `WM_NCACTIVATE` to
`DefWindowProc` with `wParam = TRUE` and `lParam = -1` (the latter tells
`DefWindowProc` not to repaint the non-client area for the faked state
change). DWM then keeps drawing the backdrop material while the window is
inactive.

- **Opt-in**, defaults to `false` — no behavior change for existing
  configs.
- **No-op** when `win32_system_backdrop` is `Auto` or `Disable`.
- **Side effect** (documented): with a native title bar
  (`window_decorations` including `TITLE`), the title bar always renders
  in its active colors. This is inherent to the `WM_NCACTIVATE` approach.

I kept it opt-in rather than changing the default because it alters
long-standing non-client behavior and has the title-bar side effect
above; this way existing setups are untouched and users who want the
effect can enable it.

## Testing

The behavior depends on DWM compositing a real desktop session and on
focus changes, which the test suite doesn't exercise (there are no
automated tests around `win32_system_backdrop` for the same reason). I
validated it manually on Windows 11 (build 28120):

- Option **off**: Acrylic/Mica fades to solid on focus loss (current
  behavior, reproduced).
- Option **on**: the material persists across focus changes.
- `Auto`/`Disable`: no effect, as expected.
- `cargo check`, `cargo fmt --all --check` and `cargo test -p config`
  pass.

Happy to add an automated test if there's an established pattern for
exercising win32 backdrop/focus behavior that I've missed.

## Docs & changelog

- New page:
  `docs/config/lua/config/win32_keep_system_backdrop_when_inactive.md`
- Changelog entry under *Continuous/Nightly → New*.

## Related issue

Refs #5895 — this provides the capability requested there (and in the
duplicates #6979, #1099, #593). I've left it as a reference rather than
an automatic close since the option is opt-in; please close #5895 if you
consider it resolved.
