### PR TITLE
nix: Simplify flake.nix; update Nix-related workflows

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -22,15 +22,21 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+
       - name: Cache build artifacts
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
+
       - name: Check flake inputs
+        # note: waiting for a release with node24 upgrade
+        # see: https://github.com/DeterminateSystems/flake-checker-action/pull/110
         uses: DeterminateSystems/flake-checker-action@main
         with:
           flake-lock-path: ./nix/flake.lock
           ignore-missing-flake-lock: false
+
       - name: Build default package
         run: nix build ./nix

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,4 +1,4 @@
-name: Nix
+name: Nix / Build
 
 on:
   pull_request:
@@ -18,8 +18,7 @@ on:
       - 'nix/**'
 
 jobs:
-  lints:
-    name: Build
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/nix-continuous.yml
+++ b/.github/workflows/nix-continuous.yml
@@ -44,7 +44,7 @@ jobs:
           nix build ./nix --json > result.json
 
       - name: Push to Cachix
-        if: ${{ github.event_name == "schedule" || github.event_name == "workflow_dispatch" }}
+        if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
           jq result.json -r '.[].outputs | to_entries[].value' \
           | cachix push wezterm

--- a/.github/workflows/nix-continuous.yml
+++ b/.github/workflows/nix-continuous.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: DeterminateSystems/determinate-nix-action@v3.21.1
 
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@v3

--- a/.github/workflows/nix-continuous.yml
+++ b/.github/workflows/nix-continuous.yml
@@ -1,8 +1,8 @@
-name: nix_continuous
+name: Nix / Continuous Build
 
 on:
   schedule:
-    - cron: "10 3 * * *"
+    - cron: "10 3 * * *" # Every night at 3:10am
   workflow_dispatch:
   push:
     branches:
@@ -13,28 +13,38 @@ on:
       - 'nix/**'
 
 jobs:
-  lints:
-    name: Build
+  build:
     runs-on: ubuntu-latest
     if: github.repository == 'wezterm/wezterm'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
+
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+
       - name: Cache build artifacts
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
+
       - name: Check flake inputs
+        # note: waiting for a release with node24 upgrade
+        # see: https://github.com/DeterminateSystems/flake-checker-action/pull/110
         uses: DeterminateSystems/flake-checker-action@main
         with:
           flake-lock-path: ./nix/flake.lock
           ignore-missing-flake-lock: false
+
       - name: Setup Cachix
         uses: cachix/cachix-action@v16
         with:
           name: wezterm
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: Build default package
         run: |
-          nix build ./nix --json \
-          | jq -r '.[].outputs | to_entries[].value' \
+          nix build ./nix --json > result.json
+
+      - name: Push to Cachix
+        if: ${{ github.event_name == "schedule" || github.event_name == "workflow_dispatch" }}
+        run: |
+          jq result.json -r '.[].outputs | to_entries[].value' \
           | cachix push wezterm

--- a/.github/workflows/nix-update-flake.yml
+++ b/.github/workflows/nix-update-flake.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
+        uses: DeterminateSystems/determinate-nix-action@v3.21.1
 
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@v3

--- a/.github/workflows/nix-update-flake.yml
+++ b/.github/workflows/nix-update-flake.yml
@@ -1,4 +1,4 @@
-name: update-flake-lock
+name: Nix / Update flake.lock
 on:
   workflow_dispatch:
   schedule:
@@ -11,21 +11,26 @@ jobs:
     if: github.repository == 'wezterm/wezterm'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
+
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
+
       - name: Cache build artifacts
-        uses: DeterminateSystems/flakehub-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@v3
+
       - name: Check flake
+        # note: waiting for a release with node24 upgrade
+        # see: https://github.com/DeterminateSystems/flake-checker-action/pull/110
         uses: DeterminateSystems/flake-checker-action@main
+
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@main
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           token: "${{ secrets.FLAKE_LOCK_GH_PAT }}"
-          pr-title: 'Update flake.lock' # Title of PR to be created
-          pr-labels: | # Labels to be set on the PR
+          pr-title: 'nix: Update flake.lock'
+          pr-labels: |
             dependencies
             automated
-          pr-assignees: happenslol,gabyx,emiller88
           pr-reviewers: bew
           path-to-flake-dir: 'nix/'

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/determinate-nix-action@v3.17.0
+        uses: DeterminateSystems/determinate-nix-action@v3.15.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/determinate-nix-action@v3.12.0
+        uses: DeterminateSystems/determinate-nix-action@v3.11.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v3.20.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/determinate-nix-action@v3.11.0
+        uses: DeterminateSystems/determinate-nix-action@v3.10.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/determinate-nix-action@v3.20.0
+        uses: DeterminateSystems/determinate-nix-action@v3.10.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/determinate-nix-action@v3.15.0
+        uses: DeterminateSystems/determinate-nix-action@v3.12.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/determinate-nix-action@v3.10.0
+        uses: DeterminateSystems/determinate-nix-action@v3.17.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install nix
-        uses: DeterminateSystems/nix-installer-action@v3.20.0
+        uses: DeterminateSystems/determinate-nix-action@v3.20.0
       - name: Cache build artifacts
         uses: DeterminateSystems/flakehub-cache-action@main
       - name: Check flake inputs

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -18,57 +18,6 @@
         "type": "github"
       }
     },
-    "freetype2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1723459814,
-        "narHash": "sha256-4l90lDtpgm5xlh2m7ifrqNy373DTRTULRkAzicrM93c=",
-        "owner": "freetype",
-        "repo": "freetype",
-        "rev": "42608f77f20749dd6ddc9e0536788eaad70ea4b5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "freetype",
-        "ref": "VER-2-13-3",
-        "repo": "freetype",
-        "type": "github"
-      }
-    },
-    "harfbuzz": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1747068667,
-        "narHash": "sha256-VxN0lsFnW0vHnIXZ806Lg2NU0/ESnE6z249mXPhfas8=",
-        "owner": "harfbuzz",
-        "repo": "harfbuzz",
-        "rev": "33a3f8de60dcad7535f14f07d6710144548853ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "harfbuzz",
-        "ref": "11.2.1",
-        "repo": "harfbuzz",
-        "type": "github"
-      }
-    },
-    "libpng": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1726173884,
-        "narHash": "sha256-gBfHgGaqVYdmhWXoNKZzPyGzyw2rr3zp+DjWmfC41jk=",
-        "owner": "pnggroup",
-        "repo": "libpng",
-        "rev": "f5e92d76973a7a53f517579bc95d61483bf108c0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pnggroup",
-        "ref": "v1.6.44",
-        "repo": "libpng",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780711917,
@@ -88,12 +37,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "freetype2": "freetype2",
-        "harfbuzz": "harfbuzz",
-        "libpng": "libpng",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay",
-        "zlib": "zlib"
+        "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
@@ -128,23 +73,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "zlib": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1705948357,
-        "narHash": "sha256-TkPLWSN5QcPlL9D0kc/yhH0/puE9bFND24aj5NVDKYs=",
-        "owner": "madler",
-        "repo": "zlib",
-        "rev": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "madler",
-        "ref": "v1.3.1",
-        "repo": "zlib",
         "type": "github"
       }
     }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -2,39 +2,13 @@
   description = "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";
 
   inputs = {
+    self.submodules = true;
+
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    # NOTE: @2024-05 Nix flakes does not support getting git submodules of 'self'.
-    # refs:
-    # - https://discourse.nixos.org/t/get-nix-flake-to-include-git-submodule/30324
-    # - https://github.com/NixOS/nix/pull/7862
-    #
-    # ... In the meantime we kinda duplicate the dependencies here then replace the submodules with
-    # links to each repo in package sources.
-    #
-    # Try to use tags when possible to increase readability
-    # (note: `git submodule status` in wezterm repo will show the `git describe` result for each
-    # submodule, can help finding a tag if any)
-    freetype2 = {
-      url = "github:freetype/freetype/VER-2-13-3";
-      flake = false;
-    };
-    harfbuzz = {
-      url = "github:harfbuzz/harfbuzz/11.2.1";
-      flake = false;
-    };
-    libpng = {
-      url = "github:pnggroup/libpng/v1.6.44";
-      flake = false;
-    };
-    zlib = {
-      url = "github:madler/zlib/v1.3.1";
-      flake = false;
     };
   };
 
@@ -96,29 +70,32 @@
         };
       in
       {
-        packages.default = rustPlatform.buildRustPackage rec {
+        packages.default = rustPlatform.buildRustPackage (finalAttrs: {
           inherit buildInputs nativeBuildInputs;
 
-          name = "wezterm";
+          pname = "wezterm";
           src = ./..;
-          version = self.shortRev or "dev";
+
+          # Rebuild the usual version number of the project from info of commit being built.
+          # Format: `<date>-<time>-<shorthash>` (Example: `20200608-110940-3fb3a61`)
+          # note: adds `-dirty` when the build includes uncomitted changes
+          version = builtins.break (
+            builtins.concatStringsSep "-" (
+              # note: `self.lastModifiedDate` looks like `20240209045744`
+              # So this match gives list with 2 items: `20240209` (date) & `045744` (time)
+              builtins.match "(.{8})(.{6})" self.lastModifiedDate
+              ++ [ (builtins.substring 0 8 self.rev or self.dirtyRev) ]
+              ++ lib.lists.optional (self ? dirtyRev) "dirty"
+            )
+          );
 
           cargoLock = {
             lockFile = ../Cargo.lock;
             allowBuiltinFetchGit = true;
           };
 
-          prePatch = ''
-            rm -rf deps/freetype/{freetype2,libpng,zlib} deps/harfbuzz/harfbuzz
-
-            ln -s ${inputs.freetype2} deps/freetype/freetype2
-            ln -s ${inputs.libpng} deps/freetype/libpng
-            ln -s ${inputs.zlib} deps/freetype/zlib
-            ln -s ${inputs.harfbuzz} deps/harfbuzz/harfbuzz
-          '';
-
           postPatch = ''
-            echo ${version} > .tag
+            echo ${finalAttrs.version} > .tag
 
             # tests are failing with: Unable to exchange encryption keys
             rm -r wezterm-ssh/tests
@@ -154,9 +131,13 @@
               ln -s "$OUT_APP"/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$out/bin"
             '';
 
+          preBuild = ''
+            echo "Building Wezterm ${finalAttrs.version}..."
+          '';
+
           postInstall = ''
             mkdir -p $out/nix-support
-            echo "${passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
+            echo "${finalAttrs.passthru.terminfo}" >> $out/nix-support/propagated-user-env-packages
 
             install -Dm644 assets/icon/terminal.png $out/share/icons/hicolor/128x128/apps/org.wezfurlong.wezterm.png
             install -Dm644 assets/wezterm.desktop $out/share/applications/org.wezfurlong.wezterm.desktop
@@ -175,7 +156,7 @@
             # the headless variant is useful when deploying wezterm's mux server on remote severs
             headless = rustPlatform.buildRustPackage {
               pname = "wezterm-headless";
-              inherit
+              inherit (finalAttrs)
                 version
                 src
                 postPatch
@@ -198,23 +179,23 @@
 
               postInstall = ''
                 install -Dm644 assets/shell-integration/wezterm.sh -t $out/etc/profile.d
-                install -Dm644 ${passthru.terminfo}/share/terminfo/w/wezterm -t $out/share/terminfo/w
+                install -Dm644 ${finalAttrs.passthru.terminfo}/share/terminfo/w/wezterm -t $out/share/terminfo/w
               '';
             };
 
             terminfo =
-              pkgs.runCommand "wezterm-terminfo"
+              pkgs.runCommand "wezterm-terminfo-${finalAttrs.version}"
                 {
                   nativeBuildInputs = [ pkgs.ncurses ];
                 }
                 ''
                   mkdir -p $out/share/terminfo $out/nix-support
-                  tic -x -o $out/share/terminfo ${src}/termwiz/data/wezterm.terminfo
+                  tic -x -o $out/share/terminfo ${finalAttrs.src}/termwiz/data/wezterm.terminfo
                 '';
           };
 
           meta.mainProgram = "wezterm";
-        };
+        });
 
         devShell = pkgs.mkShell {
           name = "wezterm-shell";

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -79,7 +79,7 @@
           # Rebuild the usual version number of the project from info of commit being built.
           # Format: `<date>-<time>-<shorthash>` (Example: `20200608-110940-3fb3a61`)
           # note: adds `-dirty` when the build includes uncomitted changes
-          version = builtins.break (
+          version = (
             builtins.concatStringsSep "-" (
               # note: `self.lastModifiedDate` looks like `20240209045744`
               # So this match gives list with 2 items: `20240209` (date) & `045744` (time)


### PR DESCRIPTION
With recent enough Nix we can now remove the explicit submodules dependencies and let Nix do the git actions.

Includes #4986 with comments, for nicer package version And a few other improvements to match modern Nix standards (`finalAttrs`).

Also includes #7841 to update Nix-related workflows:
- lock actions to a major branch, at least
- various tweaks and readability improvements
- only push built result to Cachix if workflow triggered by schedule or manual workflow_dispatch event