### PR TITLE
fix: prevent infinite loop when pane search regex fails

### DIFF
--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -721,23 +721,33 @@ impl Pane for LocalPane {
                 CompiledPattern::Regex(re) => {
                     // Allow for the regex to contain captures
                     for capture_res in re.captures_iter(&haystack) {
-                        if let Ok(c) = capture_res {
-                            // Look for the captures in reverse order, as index==0 is
-                            // the whole matched string.  We can't just call
-                            // `c.iter().rev()` as the capture iterator isn't double-ended.
-                            for idx in (0..c.len()).rev() {
-                                if let Some(m) = c.get(idx) {
-                                    found_match(
-                                        m.as_str(),
-                                        m.start(),
-                                        lines,
-                                        stable_idx,
-                                        &mut uniq_matches,
-                                        &mut coords,
-                                        &mut results,
-                                    );
-                                    break;
+                        match capture_res {
+                            Ok(c) => {
+                                // Look for the captures in reverse order, as index==0 is
+                                // the whole matched string.  We can't just call
+                                // `c.iter().rev()` as the capture iterator isn't double-ended.
+                                for idx in (0..c.len()).rev() {
+                                    if let Some(m) = c.get(idx) {
+                                        found_match(
+                                            m.as_str(),
+                                            m.start(),
+                                            lines,
+                                            stable_idx,
+                                            &mut uniq_matches,
+                                            &mut coords,
+                                            &mut results,
+                                        );
+                                        break;
+                                    }
                                 }
+                            }
+                            Err(err) => {
+                                // On errors like max backtracking limit reached, fancy_regex does
+                                // NOT advance the iterator position, so silently ignoring Err
+                                // would loop forever.
+                                log::warn!("line {stable_idx} search error: {err}");
+                                log::warn!("stopping collecting matches on line {stable_idx}");
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
`fancy_regex` returns Err (e.g. backtracking limit exceeded) without advancing the iterator position, causing `captures_iter` to loop forever on the same offset. 😬
👉 Break out and warn instead.

Fixes #7773

---
With this config:
```lua
return {
	quick_select_patterns = {
	    "[a-z](?:[_.-]?[a-z]+)*/[a-z]",
	    [[\b]],
	},
}
```

Now this screen:
<img width="859" height="271" alt="image" src="https://github.com/user-attachments/assets/982d22cf-7b4f-472d-a5f1-d0cc09e503a1" />
Gives this on `QuickSelect`:
<img width="887" height="283" alt="image" src="https://github.com/user-attachments/assets/1da03ae8-6011-4441-a93f-8ee449fec8da" />
(because `\b` regex basically matches at every word boundaries)
With warnings like:
```
01:57:16.972  WARN   mux::localpane > line 3 search error: Error executing regex: Max limit for backtracking count exceeded
01:57:16.972  WARN   mux::localpane > stopping collecting matches on line 3
01:57:17.505  WARN   mux::localpane > line 4 search error: Error executing regex: Max limit for backtracking count exceeded
01:57:17.505  WARN   mux::localpane > stopping collecting matches on line 4
```