### PR TITLE
nix: Revert use of `inputs.self.submodules` — breaks `github:` inputs

### DIFF
--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -18,6 +18,57 @@
         "type": "github"
       }
     },
+    "freetype2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1723459814,
+        "narHash": "sha256-4l90lDtpgm5xlh2m7ifrqNy373DTRTULRkAzicrM93c=",
+        "owner": "freetype",
+        "repo": "freetype",
+        "rev": "42608f77f20749dd6ddc9e0536788eaad70ea4b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "freetype",
+        "ref": "VER-2-13-3",
+        "repo": "freetype",
+        "type": "github"
+      }
+    },
+    "harfbuzz": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747068667,
+        "narHash": "sha256-VxN0lsFnW0vHnIXZ806Lg2NU0/ESnE6z249mXPhfas8=",
+        "owner": "harfbuzz",
+        "repo": "harfbuzz",
+        "rev": "33a3f8de60dcad7535f14f07d6710144548853ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "harfbuzz",
+        "ref": "11.2.1",
+        "repo": "harfbuzz",
+        "type": "github"
+      }
+    },
+    "libpng": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1726173884,
+        "narHash": "sha256-gBfHgGaqVYdmhWXoNKZzPyGzyw2rr3zp+DjWmfC41jk=",
+        "owner": "pnggroup",
+        "repo": "libpng",
+        "rev": "f5e92d76973a7a53f517579bc95d61483bf108c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pnggroup",
+        "ref": "v1.6.44",
+        "repo": "libpng",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1780711917,
@@ -37,8 +88,12 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "freetype2": "freetype2",
+        "harfbuzz": "harfbuzz",
+        "libpng": "libpng",
         "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay",
+        "zlib": "zlib"
       }
     },
     "rust-overlay": {
@@ -73,6 +128,23 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "zlib": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705948357,
+        "narHash": "sha256-TkPLWSN5QcPlL9D0kc/yhH0/puE9bFND24aj5NVDKYs=",
+        "owner": "madler",
+        "repo": "zlib",
+        "rev": "51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "madler",
+        "ref": "v1.3.1",
+        "repo": "zlib",
         "type": "github"
       }
     }

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -2,13 +2,41 @@
   description = "A GPU-accelerated cross-platform terminal emulator and multiplexer written by @wez and implemented in Rust";
 
   inputs = {
-    self.submodules = true;
-
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    # NOTE: @2026-06 Since Nix 2.27 we can set `inputs.self.submodules = true;` but it's silently
+    # ignored for all usage of `github:…` flake refs..
+    # refs:
+    # - https://github.com/wezterm/wezterm/pull/7854#issuecomment-4718011398 (previous attempt)
+    # - https://github.com/NixOS/nix/issues/13571
+    # - https://github.com/NixOS/nix/issues/14982
+    #
+    # ... In the meantime we kinda duplicate the dependencies here then replace the submodules with
+    # links to each repo in package sources.
+    #
+    # Try to use tags when possible to increase readability
+    # (note: `git submodule status` in wezterm repo will show the `git describe` result for each
+    # submodule, can help finding a tag if any)
+    freetype2 = {
+      url = "github:freetype/freetype/VER-2-13-3";
+      flake = false;
+    };
+    harfbuzz = {
+      url = "github:harfbuzz/harfbuzz/11.2.1";
+      flake = false;
+    };
+    libpng = {
+      url = "github:pnggroup/libpng/v1.6.44";
+      flake = false;
+    };
+    zlib = {
+      url = "github:madler/zlib/v1.3.1";
+      flake = false;
     };
   };
 
@@ -93,6 +121,16 @@
             lockFile = ../Cargo.lock;
             allowBuiltinFetchGit = true;
           };
+
+          # Inject collected submodules in-place for Nix build
+          prePatch = ''
+            rm -rf deps/freetype/{freetype2,libpng,zlib} deps/harfbuzz/harfbuzz
+
+            ln -s ${inputs.freetype2} deps/freetype/freetype2
+            ln -s ${inputs.libpng} deps/freetype/libpng
+            ln -s ${inputs.zlib} deps/freetype/zlib
+            ln -s ${inputs.harfbuzz} deps/harfbuzz/harfbuzz
+          '';
 
           postPatch = ''
             echo ${finalAttrs.version} > .tag


### PR DESCRIPTION
https://github.com/wezterm/wezterm/pull/7854#issuecomment-4718011398

Closes #7866 