### PR TITLE
Fix PaneFocused notification feedback loop - take 3 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ camino = "1.0"
 cassowary = "0.3"
 cc = {version="1.0", features = ["parallel"]}
 cgl = "0.3"
-chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde"]}
+chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde", "clock"]}
 clap = {version="4.0", features=["derive"]}
 clap_complete = "4.4"
 clap_complete_fig = "4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ camino = "1.0"
 cassowary = "0.3"
 cc = {version="1.0", features = ["parallel"]}
 cgl = "0.3"
+# `clock` is required for the `mux` crate to build standalone
+# mux/src/client.rs calls `Utc::now()`, which needs chrono's clock feature.
 chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde", "clock"]}
 clap = {version="4.0", features=["derive"]}
 clap_complete = "4.4"

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -559,6 +559,9 @@ impl Mux {
             .get_tab(tab_id)
             .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
 
+        // Reconcile local focus to a change already decided elsewhere; must not
+        // emit PaneFocused, or we'd re-broadcast (and, for client panes, echo it
+        // back to the server). See <https://github.com/wezterm/wezterm/issues/4390>
         tab.set_active_pane_with_notify(&pane, NotifyMux::No);
 
         Ok(())

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::client::{ClientId, ClientInfo};
 use crate::pane::{CachePolicy, Pane, PaneId};
 use crate::ssh_agent::AgentProxy;
-use crate::tab::{SplitRequest, Tab, TabId};
+use crate::tab::{NotifyMux, SplitRequest, Tab, TabId};
 use crate::window::{Window, WindowId};
 use anyhow::{anyhow, Context, Error};
 use config::keyassignment::SpawnTabDomain;
@@ -559,7 +559,7 @@ impl Mux {
             .get_tab(tab_id)
             .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
 
-        tab.set_active_pane(&pane);
+        tab.set_active_pane_with_notify(&pane, NotifyMux::No);
 
         Ok(())
     }

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -2226,6 +2226,13 @@ mod test {
     use wezterm_term::color::ColorPalette;
     use wezterm_term::{KeyCode, KeyModifiers, Line, MouseEvent, StableRowIndex};
 
+    // The mux is a process-global singleton (`Mux::set_mux`), and focus
+    // notifications dispatch through `Mux::get()`. Tests that install a mux must
+    // therefore run serially; cargo's default parallel runner would otherwise let
+    // them clobber each other's global and cross-deliver notifications. Hold this
+    // guard for the lifetime of any such test.
+    static MUX_TEST_GUARD: Mutex<()> = Mutex::new(());
+
     struct FakePane {
         id: PaneId,
         size: Mutex<TerminalSize>,
@@ -2538,6 +2545,7 @@ mod test {
 
     #[test]
     fn set_active_pane_can_suppress_mux_notification() {
+        let _guard = MUX_TEST_GUARD.lock();
         let size = TerminalSize {
             rows: 24,
             cols: 80,
@@ -2583,6 +2591,60 @@ mod test {
 
         // Assert: the active pane changed, but not a single PaneFocused was emitted.
         assert_eq!(Vec::<PaneId>::new(), *notified_panes.lock());
+        assert_eq!(1, tab.get_active_pane().unwrap().pane_id());
+
+        Mux::shutdown();
+    }
+
+    #[test]
+    fn set_active_pane_notifies_mux_by_default() {
+        let _guard = MUX_TEST_GUARD.lock();
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+
+        let mux = Arc::new(Mux::new(None));
+        Mux::set_mux(&mux);
+
+        // Record every PaneFocused the mux broadcasts. `recorded` is the clone
+        // moved into the subscriber; `notified_panes` is read by the assertion.
+        let notified_panes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&notified_panes);
+        mux.subscribe(move |notification| {
+            if let MuxNotification::PaneFocused(pane_id) = notification {
+                recorded.lock().push(pane_id);
+            }
+            true
+        });
+
+        // Build a tab with two side-by-side panes (pane 2 becomes active on split).
+        let tab = Tab::new(&size);
+        let pane_1 = FakePane::new(1, size);
+        tab.assign_pane(&pane_1);
+        let pane_2 = FakePane::new(2, size);
+        let split = tab
+            .compute_split_size(
+                0,
+                SplitRequest {
+                    direction: SplitDirection::Horizontal,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        tab.split_and_insert(0, SplitRequest::default(), Arc::clone(&pane_2))
+            .unwrap();
+        pane_1.resize(split.first).unwrap();
+
+        // Act: switch the active pane back to pane 1 via the default helper,
+        // which requests a mux notification.
+        tab.set_active_pane(&pane_1);
+
+        // Assert: the active pane changed and exactly one PaneFocused was emitted.
+        assert_eq!(vec![1], *notified_panes.lock());
         assert_eq!(1, tab.get_active_pane().unwrap().pane_id());
 
         Mux::shutdown();

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -20,6 +20,12 @@ pub type Cursor = bintree::Cursor<Arc<dyn Pane>, SplitDirectionAndSize>;
 static TAB_ID: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(0);
 pub type TabId = usize;
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum NotifyMux {
+    Yes,
+    No,
+}
+
 #[derive(Default)]
 struct Recency {
     count: usize,
@@ -699,7 +705,11 @@ impl Tab {
     }
 
     pub fn set_active_pane(&self, pane: &Arc<dyn Pane>) {
-        self.inner.lock().set_active_pane(pane)
+        self.set_active_pane_with_notify(pane, NotifyMux::Yes)
+    }
+
+    pub fn set_active_pane_with_notify(&self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
+        self.inner.lock().set_active_pane(pane, notify)
     }
 
     pub fn set_active_idx(&self, pane_index: usize) {
@@ -1747,7 +1757,7 @@ impl TabInner {
         self.active
     }
 
-    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>) {
+    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
         let prior = self.get_active_pane();
 
         if is_pane(pane, &prior.as_ref()) {
@@ -1768,22 +1778,26 @@ impl TabInner {
         {
             self.active = item.index;
             self.recency.tag(item.index);
-            self.advise_focus_change(prior);
+            self.advise_focus_change(prior, notify);
         }
     }
 
-    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>) {
+    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>, notify: NotifyMux) {
         let mux = Mux::get();
         let current = self.get_active_pane();
         match (prior, current) {
             (Some(prior), Some(current)) if prior.pane_id() != current.pane_id() => {
                 prior.focus_changed(false);
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (None, Some(current)) => {
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (Some(prior), None) => {
                 prior.focus_changed(false);
@@ -1798,7 +1812,7 @@ impl TabInner {
         let prior = self.get_active_pane();
         self.active = pane_index;
         self.recency.tag(pane_index);
-        self.advise_focus_change(prior);
+        self.advise_focus_change(prior, NotifyMux::Yes);
     }
 
     fn assign_pane(&mut self, pane: &Arc<dyn Pane>) {
@@ -1861,7 +1875,7 @@ impl TabInner {
         if keep_focus {
             self.set_active_idx(pane_index);
         } else {
-            self.advise_focus_change(Some(pane));
+            self.advise_focus_change(Some(pane), NotifyMux::Yes);
         }
         None
     }
@@ -2279,7 +2293,7 @@ mod test {
         fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
             Ok(None)
         }
-        fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+        fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
             unimplemented!()
         }
         fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {
@@ -2515,6 +2529,53 @@ mod test {
         assert_eq!(24, panes[2].height);
         assert_eq!(400, panes[2].pixel_width);
         assert_eq!(600, panes[2].pixel_height);
+    }
+
+    #[test]
+    fn set_active_pane_can_suppress_mux_notification() {
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+
+        let mux = Arc::new(Mux::new(None));
+        Mux::set_mux(&mux);
+
+        let notifications = Arc::new(Mutex::new(Vec::new()));
+        let seen = Arc::clone(&notifications);
+        mux.subscribe(move |notification| {
+            if let MuxNotification::PaneFocused(pane_id) = notification {
+                seen.lock().push(pane_id);
+            }
+            true
+        });
+
+        let tab = Tab::new(&size);
+        let pane_1 = FakePane::new(1, size);
+        tab.assign_pane(&pane_1);
+        let pane_2 = FakePane::new(2, size);
+        let split = tab
+            .compute_split_size(
+                0,
+                SplitRequest {
+                    direction: SplitDirection::Horizontal,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        tab.split_and_insert(0, SplitRequest::default(), Arc::clone(&pane_2))
+            .unwrap();
+
+        pane_1.resize(split.first).unwrap();
+        tab.set_active_pane_with_notify(&pane_1, NotifyMux::No);
+
+        assert_eq!(Vec::<PaneId>::new(), *notifications.lock());
+        assert_eq!(1, tab.get_active_pane().unwrap().pane_id());
+
+        Mux::shutdown();
     }
 
     fn is_send_and_sync<T: Send + Sync>() -> bool {

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -704,12 +704,17 @@ impl Tab {
         self.inner.lock().get_active_idx()
     }
 
+    /// Activate `pane` and broadcast a `PaneFocused` mux notification.
+    /// Use this for genuine, user-initiated activations. Call sites that emit
+    /// their own `PaneFocused` should use [`Tab::set_active_pane_with_notify`]
+    /// with [`NotifyMux::No`] to avoid doubling it.
+    /// See <https://github.com/wezterm/wezterm/issues/4390>
     pub fn set_active_pane(&self, pane: &Arc<dyn Pane>) {
         self.set_active_pane_with_notify(pane, NotifyMux::Yes)
     }
 
-    pub fn set_active_pane_with_notify(&self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
-        self.inner.lock().set_active_pane(pane, notify)
+    pub fn set_active_pane_with_notify(&self, pane: &Arc<dyn Pane>, notify_mux: NotifyMux) {
+        self.inner.lock().set_active_pane(pane, notify_mux)
     }
 
     pub fn set_active_idx(&self, pane_index: usize) {
@@ -1757,7 +1762,7 @@ impl TabInner {
         self.active
     }
 
-    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>, notify: NotifyMux) {
+    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>, notify_mux: NotifyMux) {
         let prior = self.get_active_pane();
 
         if is_pane(pane, &prior.as_ref()) {
@@ -1778,24 +1783,24 @@ impl TabInner {
         {
             self.active = item.index;
             self.recency.tag(item.index);
-            self.advise_focus_change(prior, notify);
+            self.advise_focus_change(prior, notify_mux);
         }
     }
 
-    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>, notify: NotifyMux) {
+    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>, notify_mux: NotifyMux) {
         let mux = Mux::get();
         let current = self.get_active_pane();
         match (prior, current) {
             (Some(prior), Some(current)) if prior.pane_id() != current.pane_id() => {
                 prior.focus_changed(false);
                 current.focus_changed(true);
-                if notify == NotifyMux::Yes {
+                if notify_mux == NotifyMux::Yes {
                     mux.notify(MuxNotification::PaneFocused(current.pane_id()));
                 }
             }
             (None, Some(current)) => {
                 current.focus_changed(true);
-                if notify == NotifyMux::Yes {
+                if notify_mux == NotifyMux::Yes {
                     mux.notify(MuxNotification::PaneFocused(current.pane_id()));
                 }
             }
@@ -2544,15 +2549,18 @@ mod test {
         let mux = Arc::new(Mux::new(None));
         Mux::set_mux(&mux);
 
-        let notifications = Arc::new(Mutex::new(Vec::new()));
-        let seen = Arc::clone(&notifications);
+        // Record every PaneFocused the mux broadcasts. `recorded` is the clone
+        // moved into the subscriber; `notified_panes` is read by the assertion.
+        let notified_panes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&notified_panes);
         mux.subscribe(move |notification| {
             if let MuxNotification::PaneFocused(pane_id) = notification {
-                seen.lock().push(pane_id);
+                recorded.lock().push(pane_id);
             }
             true
         });
 
+        // Build a tab with two side-by-side panes (pane 2 becomes active on split).
         let tab = Tab::new(&size);
         let pane_1 = FakePane::new(1, size);
         tab.assign_pane(&pane_1);
@@ -2568,11 +2576,13 @@ mod test {
             .unwrap();
         tab.split_and_insert(0, SplitRequest::default(), Arc::clone(&pane_2))
             .unwrap();
-
         pane_1.resize(split.first).unwrap();
+
+        // Act: switch the active pane back to pane 1, requesting NO mux notification.
         tab.set_active_pane_with_notify(&pane_1, NotifyMux::No);
 
-        assert_eq!(Vec::<PaneId>::new(), *notifications.lock());
+        // Assert: the active pane changed, but not a single PaneFocused was emitted.
+        assert_eq!(Vec::<PaneId>::new(), *notified_panes.lock());
         assert_eq!(1, tab.get_active_pane().unwrap().pane_id());
 
         Mux::shutdown();

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -344,6 +344,8 @@ impl TmuxDomainState {
                             // We fire our own PaneFocused on the next line;
                             // suppress the duplicate advise_focus_change would emit.
                             // See <https://github.com/wezterm/wezterm/issues/4390>
+                            // TODO: can we skip the unconditional mux.notify and use active_pane to notify,
+                            // or will that cause clients to drift out of sync in some cases?
                             tab.set_active_pane_with_notify(&local_pane, NotifyMux::No);
                             mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
                         }

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -341,6 +341,9 @@ impl TmuxDomainState {
 
                     match mux.get_tab(local_tab.tab_id) {
                         Some(tab) => {
+                            // We fire our own PaneFocused on the next line;
+                            // suppress the duplicate advise_focus_change would emit.
+                            // See <https://github.com/wezterm/wezterm/issues/4390>
                             tab.set_active_pane_with_notify(&local_pane, NotifyMux::No);
                             mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
                         }

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -1,7 +1,7 @@
 use crate::domain::{DomainId, WriterWrapper};
 use crate::localpane::LocalPane;
 use crate::pane::{alloc_pane_id, PaneId};
-use crate::tab::{SplitDirection, SplitRequest, SplitSize, Tab, TabId};
+use crate::tab::{NotifyMux, SplitDirection, SplitRequest, SplitSize, Tab, TabId};
 use crate::tmux::{AttachState, TmuxDomain, TmuxDomainState, TmuxRemotePane, TmuxTab};
 use crate::tmux_pty::{TmuxChild, TmuxPty};
 use crate::{Mux, MuxNotification, Pane};
@@ -341,7 +341,7 @@ impl TmuxDomainState {
 
                     match mux.get_tab(local_tab.tab_id) {
                         Some(tab) => {
-                            tab.set_active_pane(&local_pane);
+                            tab.set_active_pane_with_notify(&local_pane, NotifyMux::No);
                             mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
                         }
                         None => {}

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -226,12 +226,10 @@ impl ClientPane {
                 // it here.
                 log::trace!("advised of remote pane focus: {pane_id}");
 
-                // Match the server's focus state before applying it locally.
-                // `focus_pane_and_containing_tab` calls through to
-                // `focus_changed(true)`, and for remote panes that normally
-                // advises the server of the new focus. Without this guard, a
-                // server-originated focus notification can be echoed back as a
-                // fresh `SetFocusedPane` request.
+                // Mark the pane focused on the server side before reconciling:
+                // `focus_pane_and_containing_tab` calls `focus_changed(true)`,
+                // which would otherwise echo this back as a fresh `SetFocusedPane`.
+                // See <https://github.com/wezterm/wezterm/issues/4390>
                 {
                     let mut focused = self.client.focused_remote_pane_id.lock().unwrap();
                     *focused = Some(pane_id);

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -226,6 +226,17 @@ impl ClientPane {
                 // it here.
                 log::trace!("advised of remote pane focus: {pane_id}");
 
+                // Match the server's focus state before applying it locally.
+                // `focus_pane_and_containing_tab` calls through to
+                // `focus_changed(true)`, and for remote panes that normally
+                // advises the server of the new focus. Without this guard, a
+                // server-originated focus notification can be echoed back as a
+                // fresh `SetFocusedPane` request.
+                {
+                    let mut focused = self.client.focused_remote_pane_id.lock().unwrap();
+                    *focused = Some(pane_id);
+                }
+
                 let mux = Mux::get();
                 if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
                     log::error!("Error reconciling remote PaneFocused notification: {err:#}");

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -78,11 +78,10 @@ impl GuiFrontEnd {
                     .detach();
                 }
                 MuxNotification::PaneFocused(pane_id) => {
-                    // Skip notifications for panes the mux has already destroyed
-                    // (e.g. backlog draining after a domain detach). Prevents the
-                    // UI thread from being flooded with no-op reconciliation tasks
-                    // when many panes go away at once.
-                    // See https://github.com/wezterm/wezterm/issues/4390
+                    // Skip panes the mux has already destroyed (e.g. backlog
+                    // draining after a domain detach), so we don't flood the UI
+                    // thread with no-op reconciliation tasks.
+                    // See <https://github.com/wezterm/wezterm/issues/4390>
                     if Mux::get().get_pane(pane_id).is_some() {
                         promise::spawn::spawn_into_main_thread(async move {
                             let mux = Mux::get();

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -78,13 +78,20 @@ impl GuiFrontEnd {
                     .detach();
                 }
                 MuxNotification::PaneFocused(pane_id) => {
-                    promise::spawn::spawn_into_main_thread(async move {
-                        let mux = Mux::get();
-                        if let Err(err) = mux.focus_pane_and_containing_tab(pane_id) {
-                            log::error!("Error reconciling PaneFocused notification: {err:#}");
-                        }
-                    })
-                    .detach();
+                    // Skip notifications for panes the mux has already destroyed
+                    // (e.g. backlog draining after a domain detach). Prevents the
+                    // UI thread from being flooded with no-op reconciliation tasks
+                    // when many panes go away at once.
+                    // See https://github.com/wezterm/wezterm/issues/4390
+                    if Mux::get().get_pane(pane_id).is_some() {
+                        promise::spawn::spawn_into_main_thread(async move {
+                            let mux = Mux::get();
+                            if let Err(err) = mux.focus_pane_and_containing_tab(pane_id) {
+                                log::error!("Error reconciling PaneFocused notification: {err:#}");
+                            }
+                        })
+                        .detach();
+                    }
                 }
                 MuxNotification::TabTitleChanged { .. } => {}
                 MuxNotification::WindowTitleChanged { .. } => {}

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -358,6 +358,9 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(tab_id)
                                 .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
+                            // We emit our own PaneFocused below; suppress the
+                            // duplicate advise_focus_change would emit.
+                            // See <https://github.com/wezterm/wezterm/issues/4390>
                             tab.set_active_pane_with_notify(&pane, NotifyMux::No);
 
                             mux.record_focus_for_current_identity(pane_id);

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -6,7 +6,7 @@ use mux::client::ClientId;
 use mux::domain::SplitSource;
 use mux::pane::{CachePolicy, Pane, PaneId};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
-use mux::tab::TabId;
+use mux::tab::{NotifyMux, TabId};
 use mux::{Mux, MuxNotification};
 use promise::spawn::spawn_into_main_thread;
 use std::collections::HashMap;
@@ -358,7 +358,7 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(tab_id)
                                 .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
-                            tab.set_active_pane(&pane);
+                            tab.set_active_pane_with_notify(&pane, NotifyMux::No);
 
                             mux.record_focus_for_current_identity(pane_id);
                             mux.notify(mux::MuxNotification::PaneFocused(pane_id));


### PR DESCRIPTION
Following up from #7763 - see that PR for the explanation.

Addressed the review comments on that PR - no real changes, just comments and variable renames.
Tested rapidly switching panes manually, and with cli - did not see the issues from #4390 (also #4737) with these changes.
Some janky diagrams explaining it [here](https://github.com/ankitson/wezterm/blob/main/investigations/sshmux-panefocused-storm/DIAGRAMS.md)

Fixes #4390
Closes #7763