### PR TITLE
fix(term): avoid divide-by-zero crashes in inline image placement

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -272,6 +272,11 @@ As features stabilize some brief notes about them will accumulate here.
   limit. Thanks to @bew! #7864
 * Fix ESC key encoding in kitty mode with disambiguate flag enabled.
   Thanks to @Felixoid and @the-mikedavis! #7787
+* Fixed two divide-by-zero crashes in inline image placement: a Kitty graphics
+  escape requesting a zero-sized placement (eg: `w=0`/`h=0`), and displaying a
+  cell-sized image on a pane whose pty reported no pixel dimensions (eg: tmux
+  or other domains that report a zero pixel size). Such images are now refused
+  instead of taking down the pane. #6344
 
 #### Updated
 * Bundled conpty.dll and OpenConsole.exe to build 1.22.250204002.nupkg

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -272,11 +272,10 @@ As features stabilize some brief notes about them will accumulate here.
   limit. Thanks to @bew! #7864
 * Fix ESC key encoding in kitty mode with disambiguate flag enabled.
   Thanks to @Felixoid and @the-mikedavis! #7787
-* Fixed two divide-by-zero crashes in inline image placement: a Kitty graphics
-  escape requesting a zero-sized placement (eg: `w=0`/`h=0`), and displaying a
-  cell-sized image on a pane whose pty reported no pixel dimensions (eg: tmux
-  or other domains that report a zero pixel size). Such images are now refused
-  instead of taking down the pane. #6344
+* Fixed two divide-by-zero crashes in Kitty inline image placement when a program requests
+  a zero-sized placement (e.g. `w=0`/`h=0`), or displaying a cell-sized image on a pane
+  whose pty reported no pixel dimensions (e.g. in `tmux -CC` domain).
+  Such images are now refused instead of taking down the pane. Thanks to @zakrad! #6344
 
 #### Updated
 * Bundled conpty.dll and OpenConsole.exe to build 1.22.250204002.nupkg

--- a/term/src/terminalstate/image.rs
+++ b/term/src/terminalstate/image.rs
@@ -72,18 +72,17 @@ impl TerminalState {
         let cell_pixel_width = self.pixel_width / physical_cols;
         let cell_pixel_height = self.pixel_height / physical_rows;
 
-        // If the pty never reported a pixel size then the per-cell pixel
-        // dimensions are zero. This is the case for the default `PtySize` and
-        // for tmux/headless domains, which report a zero pixel size. A
-        // cell-sized image (one without explicit `c=`/`r=`) would then divide
-        // by zero when computing how many cells it spans. There is no sane way
-        // to place a pixel-addressed image without a cell size, so refuse the
-        // placement rather than panicking and taking down the terminal.
+        // !!! Guard against missing per-cell pixel dimensions, prevent divide by zero.
+        // If pty has no specified pixel size then the per-cell pixel dimensions are zero.
+        // A cell-sized image (without explicit `c=`/`r=`) would then divide by zero when computing
+        // how many cells it spans.
+        // (e.g. the default `PtySize`, as well as for tmux/headless domains)
+        // There is no sane way to place a pixel-addressed image without a cell size.
+        // => Refuse the image placement instead of panicking and taking down the terminal.
         // <https://github.com/wezterm/wezterm/issues/6344>
         anyhow::ensure!(
             cell_pixel_width != 0 && cell_pixel_height != 0,
-            "refusing to display image: terminal has no pixel dimensions \
-             (cell size {}x{})",
+            "refusing to display image: terminal has no cell pixel dimensions (WxH: {}x{})",
             cell_pixel_width,
             cell_pixel_height
         );
@@ -106,14 +105,15 @@ impl TerminalState {
             .unwrap_or(image_max_height)
             .min(image_max_height);
 
-        // A zero-sized drawable region (eg: a Kitty graphic with an explicit
-        // `w=0`/`h=0`, or a source origin that lies outside the image bounds)
-        // leaves nothing to display and would divide by zero when computing the
-        // per-cell pixel deltas below. Refuse the placement rather than
-        // panicking and taking down the terminal. <https://github.com/wezterm/wezterm/issues/6344>
+        // !!! Guard against a zero-sized image, nothing to draw.
+        // A zero-sized drawable region leaves nothing to display and would divide by zero when
+        // computing the per-cell pixel deltas below.
+        // (e.g. an image with explicit `w=0`/`h=0`, or a source origin outside the image bounds)
+        // => Refuse the image placement instead of panicking and taking down the terminal.
+        // <https://github.com/wezterm/wezterm/issues/6344>
         anyhow::ensure!(
             draw_width != 0 && draw_height != 0,
-            "refusing to display image with zero draw dimensions ({}x{})",
+            "refusing to display image with zero draw dimensions (WxH: {}x{})",
             draw_width,
             draw_height
         );

--- a/term/src/terminalstate/image.rs
+++ b/term/src/terminalstate/image.rs
@@ -71,6 +71,23 @@ impl TerminalState {
         let physical_rows = self.screen().physical_rows;
         let cell_pixel_width = self.pixel_width / physical_cols;
         let cell_pixel_height = self.pixel_height / physical_rows;
+
+        // If the pty never reported a pixel size then the per-cell pixel
+        // dimensions are zero. This is the case for the default `PtySize` and
+        // for tmux/headless domains, which report a zero pixel size. A
+        // cell-sized image (one without explicit `c=`/`r=`) would then divide
+        // by zero when computing how many cells it spans. There is no sane way
+        // to place a pixel-addressed image without a cell size, so refuse the
+        // placement rather than panicking and taking down the terminal.
+        // <https://github.com/wezterm/wezterm/issues/6344>
+        anyhow::ensure!(
+            cell_pixel_width != 0 && cell_pixel_height != 0,
+            "refusing to display image: terminal has no pixel dimensions \
+             (cell size {}x{})",
+            cell_pixel_width,
+            cell_pixel_height
+        );
+
         let cell_padding_left = params
             .cell_padding_left
             .min(cell_pixel_width.saturating_sub(1) as u16);
@@ -88,6 +105,18 @@ impl TerminalState {
             .source_height
             .unwrap_or(image_max_height)
             .min(image_max_height);
+
+        // A zero-sized drawable region (eg: a Kitty graphic with an explicit
+        // `w=0`/`h=0`, or a source origin that lies outside the image bounds)
+        // leaves nothing to display and would divide by zero when computing the
+        // per-cell pixel deltas below. Refuse the placement rather than
+        // panicking and taking down the terminal. <https://github.com/wezterm/wezterm/issues/6344>
+        anyhow::ensure!(
+            draw_width != 0 && draw_height != 0,
+            "refusing to display image with zero draw dimensions ({}x{})",
+            draw_width,
+            draw_height
+        );
 
         let (fullcells_width, remainder_width_cell, x_delta_divisor) = params
             .columns

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -1,0 +1,72 @@
+//! Tests for inline image protocol handling
+
+use super::*;
+
+/// A tiny but valid 11x11 PNG, base64 encoded.
+/// Taken from the reproduction in
+/// <https://github.com/wezterm/wezterm/issues/6344>.
+const TINY_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAACXBIWXMAAAGKAAABigEzlzBYAAAAOUlEQVQYlZXOwQ0AMAzCQEdi7yaT0xWAN7JuDCac2PQKYxflycOoICOKtPIuqFCg4/LzKxiz6xjyAYh9DR1sLUN1AAAAAElFTkSuQmCC";
+
+/// Feeding a Kitty graphics escape that requests a zero-sized placement
+/// (here `r=0,h=0`) must not panic the terminal.  Prior to the fix for
+/// <https://github.com/wezterm/wezterm/issues/6344> this divided by zero
+/// while computing the per-cell pixel deltas and took down the whole pane.
+#[test]
+fn kitty_zero_dimension_image_does_not_panic() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    // a=T: transmit and display, t=d: data is directly embedded,
+    // f=100: PNG, r=0/h=0: zero rows / zero source height.
+    let seq = format!("\x1b_Gr=0,h=0,a=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
+    term.print(seq.as_bytes());
+
+    // The image is refused, so the cursor never moved; printing normal text
+    // and observing it confirms we recovered rather than crashing.
+    term.print(b"ok");
+    assert_visible_contents(&term, file!(), line!(), &["ok", "", ""]);
+}
+
+/// A well-formed Kitty graphic with non-zero dimensions should continue to be
+/// accepted (ie: the zero-dimension guard does not reject valid images). The
+/// test passes as long as processing the image does not panic and the terminal
+/// remains usable afterwards.
+#[test]
+fn kitty_valid_image_is_accepted() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    let seq = format!("\x1b_Ga=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
+    term.print(seq.as_bytes());
+
+    term.print(b"ok");
+}
+
+/// When the pty never reported a pixel size, `cell_pixel_width`/
+/// `cell_pixel_height` are zero. This is the case for the default `PtySize`
+/// and for tmux/headless domains. Displaying an image sized in cells (ie:
+/// without explicit `c=`/`r=`) must not divide by zero. This is a distinct
+/// crash from the zero-dimension image above and is not caught by that guard.
+/// See <https://github.com/wezterm/wezterm/issues/6344>.
+#[test]
+fn kitty_image_with_zero_pixel_dimensions_does_not_panic() {
+    let mut term = Terminal::new(
+        TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 0,
+            pixel_height: 0,
+            dpi: 0,
+        },
+        Arc::new(TestTermConfig { scrollback: 0 }),
+        "WezTerm",
+        "O_o",
+        Box::new(Vec::new()),
+    );
+
+    // No `c=`/`r=`, so the placement is computed from the (zero) cell pixel
+    // size, exercising the divide that previously panicked.
+    let seq = format!("\x1b_Ga=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
+    term.advance_bytes(seq.as_bytes());
+
+    // The terminal must remain usable.
+    term.advance_bytes(b"ok");
+}

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -3,13 +3,12 @@
 use super::*;
 
 /// A tiny but valid 11x11 PNG, base64 encoded.
-/// Taken from the reproduction in
-/// <https://github.com/wezterm/wezterm/issues/6344>.
+/// Taken from the reproduction in <https://github.com/wezterm/wezterm/issues/6344>.
 const TINY_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAACXBIWXMAAAGKAAABigEzlzBYAAAAOUlEQVQYlZXOwQ0AMAzCQEdi7yaT0xWAN7JuDCac2PQKYxflycOoICOKtPIuqFCg4/LzKxiz6xjyAYh9DR1sLUN1AAAAAElFTkSuQmCC";
 
-/// Feeding a Kitty graphics escape that requests a zero-sized placement
-/// (here `r=0,h=0`) must not panic the terminal.  Prior to the fix for
-/// <https://github.com/wezterm/wezterm/issues/6344> this divided by zero
+/// Feeding a Kitty graphics escape that requests a zero-sized placement (here `r=0,h=0`)
+/// must not panic the terminal.
+/// Prior to the fix for <https://github.com/wezterm/wezterm/issues/6344> this divided by zero
 /// while computing the per-cell pixel deltas and took down the whole pane.
 #[test]
 fn kitty_zero_dimension_image_does_not_panic() {
@@ -20,16 +19,14 @@ fn kitty_zero_dimension_image_does_not_panic() {
     let seq = format!("\x1b_Gr=0,h=0,a=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
     term.print(seq.as_bytes());
 
-    // The image is refused, so the cursor never moved; printing normal text
-    // and observing it confirms we recovered rather than crashing.
+    // The image is refused, so the cursor never moved;
+    // Printing normal text and observing it confirms we recovered rather than crashing.
     term.print(b"ok");
     assert_visible_contents(&term, file!(), line!(), &["ok", "", ""]);
 }
 
-/// A well-formed Kitty graphic with non-zero dimensions should continue to be
-/// accepted (ie: the zero-dimension guard does not reject valid images). The
-/// test passes as long as processing the image does not panic and the terminal
-/// remains usable afterwards.
+/// A well-formed Kitty graphic with non-zero dimensions should continue to be accepted.
+/// The test passes as long as processing the image does not panic and the terminal remains usable.
 #[test]
 fn kitty_valid_image_is_accepted() {
     let mut term = TestTerm::new(3, 10, 0);
@@ -37,21 +34,22 @@ fn kitty_valid_image_is_accepted() {
     let seq = format!("\x1b_Ga=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
     term.print(seq.as_bytes());
 
+    // Printing normal text and observing it shifted confirms the terminal is usable.
     term.print(b"ok");
+    assert_visible_contents(&term, file!(), line!(), &["  ok", "", ""]);
 }
 
-/// When the pty never reported a pixel size, `cell_pixel_width`/
-/// `cell_pixel_height` are zero. This is the case for the default `PtySize`
-/// and for tmux/headless domains. Displaying an image sized in cells (ie:
-/// without explicit `c=`/`r=`) must not divide by zero. This is a distinct
-/// crash from the zero-dimension image above and is not caught by that guard.
+/// When the pty has no pixel size, `cell_pixel_width`/`cell_pixel_height` are zero.
+/// Displaying an image sized in cells (ie: without explicit `c=`/`r=`) must not divide by zero.
+/// This is a distinct crash from the zero-dimension image above and is not caught by that guard.
 /// See <https://github.com/wezterm/wezterm/issues/6344>.
 #[test]
 fn kitty_image_with_zero_pixel_dimensions_does_not_panic() {
     let mut term = Terminal::new(
         TerminalSize {
-            rows: 24,
+            rows: 3,
             cols: 80,
+            // No pixel size!
             pixel_width: 0,
             pixel_height: 0,
             dpi: 0,
@@ -67,6 +65,8 @@ fn kitty_image_with_zero_pixel_dimensions_does_not_panic() {
     let seq = format!("\x1b_Ga=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
     term.advance_bytes(seq.as_bytes());
 
-    // The terminal must remain usable.
+    // The image is refused, so the cursor never moved;
+    // Printing normal text and observing it confirms we recovered rather than crashing.
     term.advance_bytes(b"ok");
+    assert_visible_contents(&term, file!(), line!(), &["ok", "", ""]);
 }

--- a/term/src/test/mod.rs
+++ b/term/src/test/mod.rs
@@ -6,6 +6,7 @@ mod c0;
 use bitflags::bitflags;
 mod c1;
 mod csi;
+mod image;
 // mod selection; FIXME: port to render layer
 use crate::color::ColorPalette;
 use k9::assert_equal as assert_eq;
@@ -53,6 +54,10 @@ impl TerminalConfiguration for TestTermConfig {
 
     fn color_palette(&self) -> ColorPalette {
         ColorPalette::default()
+    }
+
+    fn enable_kitty_graphics(&self) -> bool {
+        true
     }
 }
 


### PR DESCRIPTION
## Problem

`assign_image_to_cells` contained two unguarded divisions that panic with
`attempt to divide by zero`, taking down the pane (and, under the mux, the
pane's pty reader thread — the backtrace runs through `mux::read_from_pane_pty`).
Both are reachable purely from terminal output, so any source of bytes (a
`cat`-ed file, an SSH host, a log line, an AI agent emitting image escapes) can
trigger them.

### 1. Zero-sized placement (the reported issue, #6344)

A Kitty graphics escape requesting a zero-sized placement (an explicit
`w=0`/`h=0`, or a source origin outside the image bounds) yields
`draw_width`/`draw_height == 0`, used as a divisor at `image.rs:98`/`:114`.

```bash
echo -e '\e_Gr=0,h=0,a=T,t=d,f=100;iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAACXBIWXMAAAGKAAABigEzlzBYAAAAOUlEQVQYlZXOwQ0AMAzCQEdi7yaT0xWAN7JuDCac2PQKYxflycOoICOKtPIuqFCg4/LzKxiz6xjyAYh9DR1sLUN1AAAAAElFTkSuQmCC\e\'
```
```
panic at term/src/terminalstate/image.rs:114:21 - attempt to divide by zero
```

### 2. Zero pixel dimensions (found while fixing the above)

Displaying a cell-sized image (one without explicit `c=`/`r=`) makes
`cell_pixel_width`/`cell_pixel_height == 0` when the pty reported no pixel size,
which is then used as a divisor at `image.rs:103`/`:119`. A zero pixel size is
the **default** `PtySize` (`pty/src/lib.rs:81`) and is what tmux/headless
domains report (`mux/src/tmux_pty.rs:141`, `mux/src/tmux_commands.rs`), so a
perfectly valid image crashes there with no malformed input.

## Fix

Refuse the placement (via `anyhow::ensure!`) when either the drawable region or
the cell pixel size is zero — there is nothing sensible to draw in either case.
The returned `Err` flows into the existing handlers (the Kitty path propagates
to `performer`'s `log::error!`; the iTerm/Sixel paths already log), so no
callers change. Real GUI panes always have a non-zero pixel size, so valid
images are unaffected.

## Tests

Added `term/src/test/image.rs`:

- `kitty_zero_dimension_image_does_not_panic` — case 1.
- `kitty_image_with_zero_pixel_dimensions_does_not_panic` — case 2 (constructs
  a terminal with `pixel_width = pixel_height = 0`).
- `kitty_valid_image_is_accepted` — guards against the new checks rejecting
  valid images.

Each crash test panics on `main` at the documented line and passes with the
fix. Kitty graphics is disabled by default in `TestTermConfig`, so the test
config now enables it to exercise the path.

`cargo test -p wezterm-term` is green and `cargo fmt --all -- --check` is clean.

Closes #6344
