### PR TITLE
feat: add `ReconnectDomain` key assignment for reconnecting remote domains

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -630,6 +630,7 @@ pub enum KeyAssignment {
     ClearKeyTableStack,
     DetachDomain(SpawnTabDomain),
     AttachDomain(String),
+    ReconnectDomain(SpawnTabDomain),
 
     CopyMode(CopyModeAssignment),
     RotatePanes(RotationDirection),

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -681,6 +681,10 @@ impl Tab {
         self.inner.lock().remove_pane(pane_id)
     }
 
+    pub fn replace_pane(&self, pane_id: PaneId, new_pane: Arc<dyn Pane>) -> bool {
+        self.inner.lock().replace_pane(pane_id, new_pane)
+    }
+
     pub fn can_close_without_prompting(&self, reason: CloseReason) -> bool {
         self.inner.lock().can_close_without_prompting(reason)
     }
@@ -1591,6 +1595,31 @@ impl TabInner {
         !self
             .remove_pane_if(|_, pane| pane.domain_id() == domain, true)
             .is_empty()
+    }
+
+    fn replace_pane(&mut self, pane_id: PaneId, new_pane: Arc<dyn Pane>) -> bool {
+        let mut cursor = self.pane.take().unwrap().cursor();
+        let mut found = false;
+
+        loop {
+            if let Some(leaf) = cursor.leaf_mut() {
+                if leaf.pane_id() == pane_id {
+                    *leaf = new_pane;
+                    found = true;
+                    break;
+                }
+            }
+            match cursor.preorder_next() {
+                Ok(c) => cursor = c,
+                Err(c) => {
+                    cursor = c;
+                    break;
+                }
+            }
+        }
+
+        self.pane.replace(cursor.tree());
+        found
     }
 
     fn remove_pane(&mut self, pane_id: PaneId) -> Option<Arc<dyn Pane>> {

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -1961,6 +1961,38 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["Shell", "Attach"],
             icon: Some("md_pipe"),
         },
+        ReconnectDomain(SpawnTabDomain::CurrentPaneDomain) => CommandDef {
+            brief: "Reconnect the domain of the active pane".into(),
+            doc: "Disconnects and reconnects the domain of the active pane".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Shell", "Reconnect"],
+            icon: Some("md_pipe"),
+        },
+        ReconnectDomain(SpawnTabDomain::DefaultDomain) => CommandDef {
+            brief: "Reconnect the default domain".into(),
+            doc: "Disconnects and reconnects the default domain".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Shell", "Reconnect"],
+            icon: Some("md_pipe"),
+        },
+        ReconnectDomain(SpawnTabDomain::DomainName(name)) => CommandDef {
+            brief: format!("Reconnect the `{name}` domain").into(),
+            doc: format!("Disconnects and reconnects the domain named `{name}`").into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Shell", "Reconnect"],
+            icon: Some("md_pipe"),
+        },
+        ReconnectDomain(SpawnTabDomain::DomainId(id)) => CommandDef {
+            brief: format!("Reconnect the domain with id {id}").into(),
+            doc: format!("Disconnects and reconnects the domain with id {id}").into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Shell", "Reconnect"],
+            icon: Some("md_pipe"),
+        },
         CopyMode(copy_mode) => CommandDef {
             brief: format!("{copy_mode:?}").into(),
             doc: "".into(),
@@ -2039,6 +2071,7 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         CloseCurrentTab { confirm: true },
         CloseCurrentPane { confirm: true },
         DetachDomain(SpawnTabDomain::CurrentPaneDomain),
+        ReconnectDomain(SpawnTabDomain::CurrentPaneDomain),
         ResetTerminal,
         // ----------------- Edit
         #[cfg(not(target_os = "macos"))]

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -40,6 +40,7 @@ use config::{
 };
 use lfucache::*;
 use mlua::{FromLua, LuaSerdeExt, UserData, UserDataFields};
+use mux::domain::DomainState;
 use mux::pane::{
     CachePolicy, CloseReason, Pane, PaneId, Pattern as MuxPattern, PerformAssignmentResult,
 };
@@ -3091,6 +3092,79 @@ impl TermWindow {
                     }
 
                     Result::<(), anyhow::Error>::Ok(())
+                })
+                .detach();
+            }
+            ReconnectDomain(domain_spec) => {
+                let window = self.mux_window_id;
+                let mux = Mux::get();
+                let domain =
+                    mux.resolve_spawn_tab_domain(Some(pane.pane_id()), domain_spec)?;
+                let domain_name = domain.domain_name().to_string();
+                let old_pane_id = pane.pane_id();
+
+                let tab_id = match mux.resolve_pane_id(old_pane_id) {
+                    Some((_domain_id, _window_id, tab_id)) => tab_id,
+                    None => {
+                        log::error!("ReconnectDomain: cannot resolve tab for pane {}", old_pane_id);
+                        return Ok(PerformAssignmentResult::Handled);
+                    }
+                };
+
+                drop(domain);
+                drop(mux);
+
+                promise::spawn::spawn(async move {
+                    let mux = Mux::get();
+                    let domain = match mux.get_domain_by_name(&domain_name) {
+                        Some(d) => d,
+                        None => {
+                            log::error!("ReconnectDomain: domain '{}' not found", domain_name);
+                            return;
+                        }
+                    };
+
+                    if domain.detachable() {
+                        if domain.state() == DomainState::Attached {
+                            if let Err(err) = domain.detach() {
+                                log::error!("ReconnectDomain: detach failed: {:#}", err);
+                                return;
+                            }
+                        }
+
+                        if let Err(err) = domain.attach(Some(window)).await {
+                            log::error!("ReconnectDomain: attach failed: {:#}", err);
+                            return;
+                        }
+                    }
+
+                    let tab = match mux.get_tab(tab_id) {
+                        Some(t) => t,
+                        None => {
+                            log::error!("ReconnectDomain: tab {} no longer exists", tab_id);
+                            return;
+                        }
+                    };
+
+                    let size = tab.get_size();
+                    let new_pane = match domain.spawn_pane(size, None, None).await {
+                        Ok(p) => p,
+                        Err(err) => {
+                            log::error!("ReconnectDomain: spawn_pane failed: {:#}", err);
+                            return;
+                        }
+                    };
+
+                    if let Err(err) = mux.add_pane(&new_pane) {
+                        log::error!("ReconnectDomain: add_pane failed: {:#}", err);
+                        return;
+                    }
+
+                    if tab.replace_pane(old_pane_id, new_pane) {
+                        mux.remove_pane(old_pane_id);
+                    } else {
+                        log::error!("ReconnectDomain: pane {} not found in tab {}", old_pane_id, tab_id);
+                    }
                 })
                 .detach();
             }


### PR DESCRIPTION
feat: add `ReconnectDomain` key assignment for reconnecting remote domains

Add a new `ReconnectDomain` key assignment that allows users to
reconnect a disconnected remote domain by pressing a keyboard shortcut,
replacing the current (dead) pane in-place without spawning a new tab.

## Motivation

When connected to a remote domain (e.g., via SSH) and the network drops,
the pane becomes unresponsive. Previously, users had to navigate through
the launcher menu to manually re-attach the domain. This change provides
a single-keystroke solution to re-establish the connection.

## Implementation

- **New key assignment**: `ReconnectDomain(SpawnTabDomain)` added to the
  `KeyAssignment` enum. It accepts the same `SpawnTabDomain` variants as
  `DetachDomain`: `CurrentPaneDomain`, `DefaultDomain`, `DomainName(String)`,
  and `DomainId(usize)`.

- **Behavior differs by domain type**:
  - For **detachable domains** (ClientDomain, e.g., TLS/multiplexer): the
    handler detaches the domain first (if still in `Attached` state), then
    re-attaches it to re-establish the connection.
  - For **non-detachable domains** (RemoteSshDomain): the handler directly
    spawns a new pane via `spawn_pane()`, which internally detects a dead
    SSH session and creates a fresh one.

- **In-place pane replacement**: Instead of spawning a new tab, the new
  pane replaces the old (dead) pane in the same tab position. This is
  achieved via a new `Tab::replace_pane(pane_id, new_pane)` method that
  traverses the binary tree of panes and swaps the matching leaf node.

## Files changed

- `config/src/keyassignment.rs`: Add `ReconnectDomain(SpawnTabDomain)`
  variant to the `KeyAssignment` enum.
- `mux/src/tab.rs`: Add `Tab::replace_pane()` and `TabInner::replace_pane()`
  methods that replace a pane leaf in the tab's binary tree by pane ID.
- `wezterm-gui/src/termwindow/mod.rs`: Add the key assignment handler with
  domain-type-aware reconnection logic.
- `wezterm-gui/src/commands.rs`: Add `CommandDef` entries for all
  `SpawnTabDomain` variants and register `ReconnectDomain(CurrentPaneDomain)`
  in the built-in command list.

## Configuration

Users can bind the action in their `wezterm.lua`:

```lua
local act = wezterm.action

-- Reconnect a specific named domain
{ key = "r", mods = "ALT", action = act.ReconnectDomain("my_ssh_domain") }

-- Reconnect whatever domain the current pane belongs to
{ key = "r", mods = "ALT", action = act.ReconnectDomain("CurrentPaneDomain") }
```

The action is also available in the command palette as
"Reconnect the domain of the active pane".
