### PR TITLE
fix: allow navigation to non-admin symlinks on Windows

### DIFF
--- a/ci/windows-installer.iss
+++ b/ci/windows-installer.iss
@@ -35,6 +35,8 @@ WizardStyle=modern
 ; Build 1809 is required for pty support
 MinVersion=10.0.17763
 ChangesEnvironment=true
+; Allow wezterm to visit junctions/symlinks created by non-admin users
+RedirectionGuard=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
On Windows 11 it's now possible to create symbolic links on NTFS
filesystems, including allowing non-Admnistrators to do it with policy
modifications.

Using symlinks make it easier to adopt versioned dotfiles like in Linux
by symlinking the `~/.config/wezterm` directory on either platform.

Unfortunatelly the Nightly installer causes problems when
`~/.config/wezterm` is a symlink with the following error message:

```
Error opening C:\Users\bltav\.config\wezterm\wezterm.lua: The path cannot be
traversed because it contains an untrusted mount point. (os error 448)
```

The child (cmd) process cannot navigate to it either:

```cmd
C:\Users\bltav>cd .config\wezterm
The path cannot be traversed because it contains an untrusted mount point.
```

This is a mitigation introduced by the INNO Installer and [enabled by
default](https://jrsoftware.org/ishelp/index.php?topic=setup_redirectionguard)

> The RedirectionGuard mitigation [external link], available on Windows
> 11 and Windows 10 22H2, blocks traversal of NTFS junctions and symbolic
> links created by unprivileged users (or any non-elevated processes).

This protection is only enabled in the Nightly Installer version, as
Stable release is a bit stale, and the binary/portable executable does
not have the protection applied.

- `winget install`: Works as expected
- `wezterm-windows-nightly.zip`: Works as expected
- `wezterm-nightly-setup.exe`: Triggers symlink traversal error

It's possible to workaround the installer limitation at this moment by
callin it with `/NOREDIRECTIONGUARD` flag:

```cmd
Downloads> Wezterm-nightly-setup.exe /NOREDIRECTIONGUARD
```

I guess non-admin symlinks on Windows are unusual setup than Linux, but
this protection seems to not make much sense on a Terminal where symlink
traversal is typical.

This commit changes the INNO Installer configuration to produce
installers that allow non-admin symlink traversals by default, so (the
uncommon) users of the installer don't have surprises anymore.
