### PR TITLE
fix(tmux): send typed keys as raw bytes via send-keys -H

### DIFF
--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -1024,7 +1024,11 @@ impl TmuxCommand for SendKeys {
         for &byte in self.keys.iter() {
             write!(&mut s, "0x{:X} ", byte).expect("unable to write key");
         }
-        format!("send-keys -t %{} {}\r", self.pane, s)
+        // `-H` tells tmux each `0xNN` argument is a raw byte. Without it tmux
+        // treats them as Unicode code points, so a typed multi-byte UTF-8 char
+        // (e.g. 'é' = C3 A9) gets double-encoded into mojibake ("Ã©"). See
+        // wezterm issue #7162.
+        format!("send-keys -H -t %{} {}\r", self.pane, s)
     }
 
     fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
@@ -1034,6 +1038,25 @@ impl TmuxCommand for SendKeys {
             anyhow::bail!("{error}");
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod send_keys_tests {
+    use super::*;
+
+    /// A typed 'é' arrives as UTF-8 bytes C3 A9. tmux's `send-keys` interprets a
+    /// bare `0xNN` argument as a *Unicode code point*, so without `-H` it turns
+    /// 0xC3 into U+00C3 (Ã) and 0xA9 into U+00A9 (©), re-encoding each to UTF-8
+    /// and producing the mojibake "Ã©" (wezterm issue #7162). The `-H` flag makes
+    /// tmux treat each value as a raw byte, preserving the UTF-8 sequence.
+    #[test]
+    fn send_keys_uses_hex_byte_mode() {
+        let cmd = SendKeys {
+            keys: vec![0xC3, 0xA9],
+            pane: 1,
+        };
+        assert_eq!(cmd.get_command(0), "send-keys -H -t %1 0xC3 0xA9 \r");
     }
 }
 


### PR DESCRIPTION
## Problem

Typing a multi-byte UTF-8 character in tmux control mode (`tmux -CC`) produces mojibake —
e.g. pressing `é` inserts `Ã©`. Plain `tmux` and a direct (non -CC) shell are unaffected.
This is #7162.

## Root cause

`SendKeys::get_command` (`mux/src/tmux_commands.rs`) sends each typed byte as a separate
`send-keys` argument in `0xNN` form, e.g. for `é` (UTF-8 `C3 A9`):

```
send-keys -t %0 0xC3 0xA9
```

Without `-H`, tmux interprets a bare `0xNN` as a **Unicode code point**, not a byte:
`0xC3` → U+00C3 (Ã), `0xA9` → U+00A9 (©), each then re-encoded to UTF-8, yielding the
double-encoded `Ã©`.

## Fix

Pass `-H`, so tmux treats each `0xNN` as a raw byte and the original UTF-8 sequence is
preserved. ASCII is unaffected (byte == code point below 0x80), so control keys, escape
sequences and ordinary letters are unchanged.

## Testing

- New unit test `send_keys_uses_hex_byte_mode` pins the `-H` form.
- Verified against real tmux 3.4: `send-keys -H 0xC3 0xA9` delivers bytes `c3 a9` (`é`),
  whereas the old `send-keys 0xC3 0xA9` delivered `c3 83 c2 a9` (`Ã©`).
- Confirmed end-to-end in a WezTerm + `tmux -CC` session: accented input now types correctly.

Fixes: #7162
