### PR TITLE
Windows: Fix drag lock and resize loop when dragging across DPI boundary

### DIFF
--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -58,8 +58,14 @@ impl super::TermWindow {
         }
 
         // For simple, user-interactive resizes where the dpi doesn't change,
-        // skip our scaling recalculation
-        if live_resizing && self.dimensions.dpi == dimensions.dpi {
+        // skip our scaling recalculation. During a live resize where DPI changes,
+		// we should also skip scaling_changed(). This can issue a SetWindowPos mid-drag, 
+		// which on Windows fights the user's drag & OS's suggested resize rect, causing a feedback loop
+		// that can lock the drag up / make the window repeatedly resize itself unexpectedly.
+        if live_resizing {
+			if self.dimensions.dpi != dimensions.dpi {
+				self.apply_scale_change(&dimensions, self.fonts.get_font_scale());
+			}
             self.apply_dimensions(&dimensions, None, window);
         } else {
             self.scaling_changed(dimensions, self.fonts.get_font_scale(), window);


### PR DESCRIPTION
## Problem

If you try to drag wezterm across two different DPI monitors on Windows, the drag will get locked and the terminal will resize itself to the extremes due to a feedback loop in the resizing path. This makes it quite difficult to move the terminal between monitors. This is at least partially brought up in #1983 by some windows users, and this change should at least address that part of the issue.

_**Technically speaking:**_

When dragging across a monitor boundary with different scale factors, the DPI change caused `live_resizing` to fall through to `scaling_changed()`, which calls `set_inner_size()` to preserve cell counts. Issuing a `SetWindowPos` mid-drag fights both the user's drag and Windows' own DPI-suggested rect, producing a feedback loop that can lock the drag and cause the terminal to resize itself unexpectedly.

## Fix

This change covers DPI changes on the `live_resizing` path; update font metrics via `apply_scale_change()` then fit the terminal to the actual OS-given size. Non-interactive DPI changes still use `scaling_changed()`.

## Notes

- The live_resizing branch change affects all platforms, though this change targets Windows specifically. 
  - The behaviour is probably more correct everywhere though -- the OS should arguably own window geometry during an active drag.
 - After a cross-DPI drag the window may be a few pixels off cell-alignment until the next manual resize. 
   - Didn't notice this at all in my own testing.

---

Ref: #1983