### PR TITLE
nix: fix binary locations in macos app

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -146,7 +146,7 @@
               OUT_APP="$out/Applications/WezTerm.app"
               cp -r assets/macos/WezTerm.app "$OUT_APP"
               rm $OUT_APP/*.dylib
-              cp -r assets/shell-integration/* "$OUT_APP"
+              cp -r assets/shell-integration/* "$OUT_APP/Contents/Resources"
               # macOS will only recognize our application bundle
               # if the binaries are inside of it. Move them there
               # and create symbolic links for them in bin/.

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -150,8 +150,9 @@
               # macOS will only recognize our application bundle
               # if the binaries are inside of it. Move them there
               # and create symbolic links for them in bin/.
-              mv $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP"
-              ln -s "$OUT_APP"/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$out/bin"
+              mkdir -p "$OUT_APP/Contents/MacOS"
+              mv $out/bin/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$OUT_APP/Contents/MacOS"
+              ln -s "$OUT_APP/Contents/MacOS"/{wezterm,wezterm-mux-server,wezterm-gui,strip-ansi-escapes} "$out/bin"
             '';
 
           postInstall = ''


### PR DESCRIPTION
previously, the nix build script would incorrectly place some of the files:
- `wezterm`,`wezterm-mux-server`,`wezterm-gui`,`strip-ansi-escapes` were incorrectly placed into `$OUT_APP/` rather than `$OUT_APP/Contents/MacOS/`
- `shell-integration` was placed in `$OUT_APP/` rather than `$OUT_APP/Contents/Resources/`

This PR fixes the behavior so it now matches the correct behavior of macOS app packaging (and the `ci/deploy.sh` script).