### PR TITLE
fix(deps): enable chrono "clock" feature to restore Utc/Local::now()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ camino = "1.0"
 cassowary = "0.3"
 cc = {version="1.0", features = ["parallel"]}
 cgl = "0.3"
-chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde"]}
+chrono = {version="0.4", default-features=false, features=["clock", "unstable-locales", "serde"]}
 clap = {version="4.0", features=["derive"]}
 clap_complete = "4.4"
 clap_complete_fig = "4.0"


### PR DESCRIPTION
## Problem

Building an individual crate such as `cargo build -p mux` fails:

```
error[E0599]: no associated function or constant named `now` found for struct `Utc`
  --> mux/src/client.rs:61:32
   |
61 |             connected_at: Utc::now(),
   |                                ^^^ associated function or constant not found in `Utc`
```

## Root cause

The workspace declares chrono with `default-features=false` and only `["unstable-locales", "serde"]`. Starting with chrono **0.4.43** (the lockfile recently moved 0.4.42 → 0.4.44), `Utc::now()` and `Local::now()` were moved behind a new `now` cargo feature (`#[cfg(feature = "now")]`), which is enabled by the `clock` feature. Neither was enabled here, so those constructors no longer exist.

## Why a full build still worked

Cargo unifies the features of a shared dependency across the whole build graph. Other crates in the tree — `spa` (pulled in by `time-funcs`) and `serde_with`'s `std` feature — request `chrono/clock`, which transitively enabled `now` for every crate and masked the missing feature. Building a subtree that excludes those crates (e.g. `-p mux`) drops the accidental activation and exposes the latent breakage.

## Affected crates

`mux` and `frecency` (`Utc::now()`), `env-bootstrap` and `time-funcs` (`Local::now()`), plus the `wezterm` CLI helpers.

## Fix

Declare `clock` explicitly on the workspace chrono dependency so the feature is available regardless of build scope, removing the fragile implicit activation. `clock` (rather than bare `now`) is required because `Local::now()` needs `iana-time-zone` for local timezone detection.

## Verification

`cargo build -p mux -p env-bootstrap -p time-funcs -p frecency` now compiles cleanly (previously failed on `-p mux`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)