### PR TITLE
windows: publish absolute gui sock path so `wezterm cli` connects from any cwd

### DIFF
--- a/wezterm-client/src/discovery.rs
+++ b/wezterm-client/src/discovery.rs
@@ -186,12 +186,22 @@ mod windows {
         /// Publish path as the path for class_name.
         pub fn new(path: &Path, class_name: &str) -> anyhow::Result<Self> {
             let (mutex_name, map_name) = Self::compute_names(class_name);
+            // Publish the full path rather than just the file name.
+            // Unix domain socket connect() on Windows resolves relative
+            // paths against the cwd of the *connecting* process, so a
+            // published bare file name like `gui-sock-1234` is only
+            // connectable when the client happens to have its cwd set
+            // to the runtime dir. Publishing the absolute path makes
+            // `wezterm cli` work from any shell/cwd.
             let path = path
-                .file_name()
-                .ok_or_else(|| anyhow::anyhow!("path has no file_name!?"))?
                 .to_str()
                 .ok_or_else(|| anyhow::anyhow!("path is not UTF8!"))?
                 .to_string();
+            anyhow::ensure!(
+                path.len() < MAX_NAME,
+                "socket path {} is too long to publish",
+                path
+            );
 
             let mutex = NamedMutex::new(&mutex_name)?;
             mutex.with_lock(|| {
@@ -231,6 +241,16 @@ mod windows {
                     .context("reading path from shared memory")?;
 
                 let path: PathBuf = path.into();
+
+                // Compatibility: older GUI instances published just the
+                // socket file name rather than the full path. Anchor such
+                // relative names to the runtime dir so that connecting
+                // works regardless of our current directory.
+                let path = if path.is_absolute() {
+                    path
+                } else {
+                    config::RUNTIME_DIR.join(path)
+                };
 
                 Ok(path)
             })


### PR DESCRIPTION
## Summary

On Windows, `wezterm cli` cannot connect to a running GUI instance via socket discovery unless its cwd happens to be the runtime dir. This fixes the discovery path handling in both directions (publish and resolve) so `wezterm cli` works from any shell, any cwd.

Fixes #4456

## Repro

1. On Windows, launch `wezterm-gui.exe` (any config, including none).
2. From a separate PowerShell / cmd / Git Bash window (i.e. **not** inside a wezterm pane), run `wezterm cli list`.
3. After a few seconds it fails with:

```
ERROR  wezterm > failed to connect to Socket("gui-sock-<pid>"): connecting to gui-sock-<pid>; terminating
```

Running the same command inside a wezterm pane works, because `WEZTERM_UNIX_SOCKET` carries the absolute socket path there and bypasses discovery entirely — which is why this has been easy to miss.

## Root cause

In `wezterm-client/src/discovery.rs` (windows module):

- `NameHolder::new()` publishes only `path.file_name()` (e.g. `gui-sock-1234`) into the `Local\wezterm-sock-<class>` shared-memory slot.
- `NameHolder::resolve()` returns that string verbatim.
- The client then calls `UnixStream::connect()` with a relative path, and AF_UNIX on Windows resolves relative paths against the cwd of the **connecting** process. So the connect only succeeds if the CLI's cwd is the runtime dir (`~/.local/share/wezterm`).

A commenter on #4456 spotted exactly this: discovery finds the right socket *name* but loses the directory.

## Fix

Both sides, so mixed old/new versions keep working:

- **`new()`**: publish the full absolute path (with a `MAX_NAME` length guard) instead of just the file name. Released CLIs use the published value verbatim, so they can now connect to a patched GUI.
- **`resolve()`**: if the published value is relative, anchor it to `config::RUNTIME_DIR`. A patched CLI can therefore also connect to released GUI instances that still publish only the file name.

| GUI publishes | CLI resolves | Result |
|---|---|---|
| file name (released) | verbatim (released) | broken (status quo) |
| absolute (patched) | verbatim (released) | **works** — absolute path used as-is |
| file name (released) | anchored (patched) | **works** — joined to `RUNTIME_DIR` |
| absolute (patched) | anchored (patched) | **works** |

## Relationship to earlier PRs

- #7458 fixed the publish side only (closed by its author, unreviewed). A publish-only fix leaves a patched CLI broken against released GUIs.
- #7698 fixes the resolve side only. A resolve-only fix leaves released CLIs broken against everything until users update, and bakes in the assumption that relative names are the contract.

This PR combines both directions — credit to both authors for their earlier analysis. Happy to incorporate the publish/resolve round-trip regression test from #7698 here if that's preferred.

## Testing

Verified on Windows 11 against a fresh GUI instance, from arbitrary cwds in external shells:

- `wezterm cli list` (patched CLI, via discovery) — succeeds
- `wezterm cli list --format json` — succeeds
- `wezterm cli send-text --pane-id 0 --no-paste "echo hi"` — succeeds
- stock/unpatched `wezterm cli list` against the patched GUI — succeeds (validates the publish-side compatibility direction)
- `cargo check -p wezterm-client` with this patch on current `main` (Windows 11, MSVC) — passes with no new warnings.

Note: a package-scoped `cargo check -p wezterm-client` (or `-p mux`) on current `main` fails on Windows before ever reaching this crate, because `mux/src/client.rs` uses `Utc::now()` while the workspace `chrono` dependency is declared `default-features=false` without the `clock` feature; full-workspace builds appear to unify that feature in via other crates. That is a pre-existing issue unrelated to this change — for the check above I temporarily enabled chrono's `clock` feature locally. Happy to send that one-line workspace fix as a separate PR.

The windows module of `discovery.rs` is unchanged between the 20240203 release and current `main`, so the fix applies identically across versions in the wild.
