### PR TITLE
cargo: enable chrono clock feature at the workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ camino = "1.0"
 cassowary = "0.3"
 cc = {version="1.0", features = ["parallel"]}
 cgl = "0.3"
-chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde"]}
+chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde", "clock"]}
 clap = {version="4.0", features=["derive"]}
 clap_complete = "4.4"
 clap_complete_fig = "4.0"


### PR DESCRIPTION
## Summary

Add chrono's `clock` feature to the workspace dependency declaration, so that package-scoped builds (`cargo check -p mux`, `-p wezterm-client`, `-p frecency`, ...) compile.

## Problem

Several workspace crates call `Utc::now()` / `Local::now()`, which chrono only provides with its `clock` feature:

- `mux/src/client.rs`
- `frecency/src/lib.rs`
- `env-bootstrap/src/ringlog.rs`
- `wezterm/src/cli/list_clients.rs`, `wezterm/src/asciicast.rs`
- `lua-api-crates/time-funcs/src/lib.rs`

But the workspace declaration is:

```toml
chrono = {version="0.4", default-features=false, features=["unstable-locales", "serde"]}
```

— no `clock`. These crates only compile today by accident: `spa` (a dependency of `wezterm-gui`) declares `chrono` with `features = ["clock"]`, so full-workspace builds get the feature through unification. Any package-scoped build whose graph doesn't include `wezterm-gui` fails, e.g.:

```
> cargo check -p mux
error[E0599]: no associated function or constant named `now` found for struct `Utc` in the current scope
  --> mux\src\client.rs:61:32
   |
61 |             connected_at: Utc::now(),
   |                                ^^^ associated function or constant not found in `Utc`
```

(three occurrences in `mux/src/client.rs`; the same failure blocks `cargo check -p wezterm-client` and other subsets).

## Fix

Declare the feature the code actually uses: add `"clock"` to the workspace chrono features. This is a no-op for full builds (the feature was already unified in via `spa`) — it only makes package-scoped resolution correct. `Cargo.lock` is unchanged, since `spa` already pins chrono's `clock`-feature dependencies.

## Testing

- `cargo check -p mux` on Windows 11 (MSVC): fails on current `main` with the three E0599 errors above; passes with this change.
- `cargo check -p wezterm-client` (which depends on `mux`): passes with this change.
