### PR TITLE
feat(lua): expose link/mouse position under cursor; OpenLinkAtMouseCursor fallback

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -587,7 +587,12 @@ pub enum KeyAssignment {
 
     SelectTextAtMouseCursor(SelectionMode),
     ExtendSelectionToMouseCursor(SelectionMode),
-    OpenLinkAtMouseCursor,
+    /// Open the hyperlink under the mouse cursor, if any.
+    /// When no link is present, optionally perform `fallback` instead.
+    OpenLinkAtMouseCursor {
+        #[dynamic(default)]
+        fallback: Option<Box<KeyAssignment>>,
+    },
     ClearSelection,
     CompleteSelection(ClipboardCopyDestination),
     CompleteSelectionOrOpenLinkAtMouseCursor(ClipboardCopyDestination),
@@ -733,4 +738,61 @@ pub struct KeyTables {
 #[derive(Debug, Clone, PartialEq)]
 pub struct KeyTableEntry {
     pub action: KeyAssignment,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wezterm_dynamic::Value;
+
+    fn obj(pairs: impl IntoIterator<Item = (Value, Value)>) -> Value {
+        Value::Object(pairs.into_iter().collect())
+    }
+
+    #[test]
+    fn open_link_at_mouse_cursor_round_trip_no_fallback() {
+        let original = KeyAssignment::OpenLinkAtMouseCursor { fallback: None };
+        let encoded = original.to_dynamic();
+        let decoded =
+            KeyAssignment::from_dynamic(&encoded, FromDynamicOptions::default()).unwrap();
+        assert_eq!(original, decoded);
+    }
+
+    /// `wezterm.action.OpenLinkAtMouseCursor` (no args) is produced by the
+    /// `Enum::__index` metatable as the empty-table form; it must decode back
+    /// to the variant with no fallback. This is the backward-compatibility
+    /// guarantee for existing configs.
+    #[test]
+    fn open_link_at_mouse_cursor_decodes_empty_table_form() {
+        let empty_table_form = obj(std::iter::once((
+            Value::String("OpenLinkAtMouseCursor".to_string()),
+            obj(std::iter::empty()),
+        )));
+        let decoded =
+            KeyAssignment::from_dynamic(&empty_table_form, FromDynamicOptions::default()).unwrap();
+        assert_eq!(
+            decoded,
+            KeyAssignment::OpenLinkAtMouseCursor { fallback: None }
+        );
+    }
+
+    #[test]
+    fn open_link_at_mouse_cursor_decodes_fallback() {
+        let with_fallback = obj(std::iter::once((
+            Value::String("OpenLinkAtMouseCursor".to_string()),
+            obj(std::iter::once((
+                Value::String("fallback".to_string()),
+                // A unit-variant KeyAssignment encodes as a bare string.
+                Value::String("ClearSelection".to_string()),
+            ))),
+        )));
+        let decoded =
+            KeyAssignment::from_dynamic(&with_fallback, FromDynamicOptions::default()).unwrap();
+        assert_eq!(
+            decoded,
+            KeyAssignment::OpenLinkAtMouseCursor {
+                fallback: Some(Box::new(KeyAssignment::ClearSelection)),
+            }
+        );
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,6 +75,14 @@ As features stabilize some brief notes about them will accumulate here.
   easier to spot the remaining candidates. Thanks to @mr-felixoid and @bew! #7752
 
 #### New
+* Mouse bindings can now branch on what's under the cursor from Lua:
+  [window:get_mouse_position()](config/lua/window/get_mouse_position.md)
+  returns the cell column and stable row under the mouse, and
+  [window:get_hyperlink_at_mouse_cursor()](config/lua/window/get_hyperlink_at_mouse_cursor.md)
+  returns the URI of the hyperlink under the mouse (or `nil`).
+  [OpenLinkAtMouseCursor](config/lua/keyassignment/OpenLinkAtMouseCursor.md)
+  also accepts an optional `fallback` action that runs when no link is
+  present. #7899
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345

--- a/docs/config/lua/keyassignment/OpenLinkAtMouseCursor.md
+++ b/docs/config/lua/keyassignment/OpenLinkAtMouseCursor.md
@@ -3,6 +3,12 @@
 If the current mouse cursor position is over a cell that contains
 a hyperlink, this action causes that link to be opened.
 
+{{since('nightly')}}
+You may set an optional `fallback` action that is performed when the mouse
+is *not* over a hyperlink. This lets a single chord "open whatever's here":
+open the link if one is present, otherwise run the fallback (for example,
+resolve the clicked word as a path or issue reference and open that).
+
 ```lua
 config.mouse_bindings = {
   -- Ctrl-click will open the link under the mouse cursor
@@ -13,3 +19,32 @@ config.mouse_bindings = {
   },
 }
 ```
+
+With a fallback:
+
+```lua
+local wezterm = require 'wezterm'
+
+config.mouse_bindings = {
+  -- Ctrl-click: open the hyperlink under the cursor if there is one,
+  -- otherwise copy the clicked word (e.g. a path or issue ref) so you
+  -- can act on it. Replace the fallback with whatever suits your flow.
+  {
+    event = { Up = { streak = 1, button = 'Left' } },
+    mods = 'CTRL',
+    action = wezterm.action.OpenLinkAtMouseCursor {
+      fallback = wezterm.action_callback(function(window, pane)
+        local link = window:get_hyperlink_at_mouse_cursor()
+        if not link then
+          -- No link: fall back to your own logic here.
+          wezterm.log_info('no link under cursor')
+        end
+      end),
+    },
+  },
+}
+```
+
+If you need to inspect the link (rather than open it), or branch on link
+presence directly in Lua, see
+[window:get_hyperlink_at_mouse_cursor()](../window/get_hyperlink_at_mouse_cursor.md).

--- a/docs/config/lua/window/get_hyperlink_at_mouse_cursor.md
+++ b/docs/config/lua/window/get_hyperlink_at_mouse_cursor.md
@@ -1,0 +1,43 @@
+# `window:get_hyperlink_at_mouse_cursor()`
+
+{{since('nightly')}}
+
+Returns the URI of the hyperlink currently under the mouse cursor as a string,
+or `nil` if the mouse is not over a hyperlink.
+
+The returned URI is exactly what
+[OpenLinkAtMouseCursor](../keyassignment/OpenLinkAtMouseCursor.md) would open,
+and includes both OSC 8 hyperlinks emitted by the terminal application (see
+[Hyperlinks](../../../hyperlinks.md)) and matches against your
+[hyperlink_rules](../config/hyperlink_rules.md).
+
+This lets a `mouse_bindings` callback branch on whether a link is present and
+decide what to do with it, without relying on the (undocumented) side effect of
+the `open-uri` event firing synchronously inside `OpenLinkAtMouseCursor`.
+
+```lua
+local wezterm = require 'wezterm'
+
+config.mouse_bindings = {
+  -- Ctrl-click: if a link is under the cursor, copy it to the clipboard
+  -- instead of opening it. Otherwise, do nothing.
+  {
+    event = { Up = { streak = 1, button = 'Left' } },
+    mods = 'CTRL',
+    action = wezterm.action_callback(function(window, pane)
+      local link = window:get_hyperlink_at_mouse_cursor()
+      if link then
+        window:copy_to_clipboard(link)
+      end
+    end),
+  },
+}
+```
+
+To run one action when a link is present and a different action when there is
+none — without writing a callback — you can use the optional `fallback` of
+[OpenLinkAtMouseCursor](../keyassignment/OpenLinkAtMouseCursor.md).
+
+To find the *cell* under the cursor (for example to feed
+[pane:get_semantic_zone_at(x, y)](../pane/get_semantic_zone_at.md)), see
+[window:get_mouse_position()](get_mouse_position.md).

--- a/docs/config/lua/window/get_mouse_position.md
+++ b/docs/config/lua/window/get_mouse_position.md
@@ -1,0 +1,51 @@
+# `window:get_mouse_position()`
+
+{{since('nightly')}}
+
+Returns the terminal cell currently under the mouse cursor, or `nil` if the
+mouse is not over a pane (for example, before any mouse event has been
+processed in this window).
+
+The result is a table with two fields:
+
+| Field | Type | Meaning                                                                    |
+| ----- | ---- | -------------------------------------------------------------------------- |
+| `x`   | int  | The cell column, where `0` is the left-most column.                        |
+| `y`   | int  | The [stable row index](../pane/get_semantic_zone_at.md) of the hovered row. |
+
+The `x`/`y` values use the same coordinate convention as
+[pane:get_semantic_zone_at(x, y)](../pane/get_semantic_zone_at.md), so the two
+compose directly.
+
+The returned position reflects the most recently processed mouse event in this
+window; it is updated on every mouse move, press, release and wheel event. In a
+`mouse_bindings` callback it is therefore the cell that was just clicked or
+hovered.
+
+```lua
+local wezterm = require 'wezterm'
+
+config.mouse_bindings = {
+  -- Ctrl+Right click: open the semantic zone (e.g. a command's output)
+  -- under the click in `$EDITOR`, like kitty's mouse_show_command_output.
+  {
+    event = { Down = { streak = 1, button = 'Right' } },
+    mods = 'CTRL',
+    action = wezterm.action_callback(function(window, pane)
+      local pos = window:get_mouse_position()
+      if not pos then
+        return
+      end
+      local zone = pane:get_semantic_zone_at(pos.x, pos.y)
+      if zone then
+        local text = pane:get_text_from_semantic_zone(zone)
+        wezterm.log_info('zone under cursor: ' .. text)
+        -- ...open `text` in your `$EDITOR` here...
+      end
+    end),
+  },
+}
+```
+
+To find out whether a hyperlink is under the cursor, see
+[window:get_hyperlink_at_mouse_cursor()](get_hyperlink_at_mouse_cursor.md).

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -1614,9 +1614,11 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["Edit"],
             icon: None,
         },
-        OpenLinkAtMouseCursor => CommandDef {
+        OpenLinkAtMouseCursor { .. } => CommandDef {
             brief: "Open link at mouse cursor".into(),
-            doc: "If there is no link under the mouse cursor, has no effect.".into(),
+            doc: "If there is no link under the mouse cursor, has no effect, \
+                  unless an optional `fallback` action is provided."
+                .into(),
             keys: vec![],
             args: &[ArgType::ActivePane],
             menubar: &["Shell"],
@@ -2142,6 +2144,6 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         OpenUri("https://github.com/wezterm/wezterm/issues/".to_string()),
         ShowDebugOverlay,
         // ----------------- Misc
-        OpenLinkAtMouseCursor,
+        OpenLinkAtMouseCursor { fallback: None },
     ];
 }

--- a/wezterm-gui/src/scripting/guiwin.rs
+++ b/wezterm-gui/src/scripting/guiwin.rs
@@ -11,6 +11,7 @@ use mux::Mux;
 use mux_lua::MuxPane;
 use termwiz_funcs::lines_to_escapes;
 use wezterm_dynamic::{FromDynamic, ToDynamic};
+use wezterm_term::StableRowIndex;
 use wezterm_toast_notification::ToastNotification;
 use window::{Connection, ConnectionOps, DeadKeyStatus, WindowOps, WindowState};
 
@@ -157,6 +158,46 @@ impl UserData for GuiWin {
             let result = rx.recv().await.map_err(mlua::Error::external)?;
             luahelper::dynamic_to_lua_value(lua, result)
         });
+        methods.add_async_method(
+            "get_mouse_position",
+            |lua, this, _: ()| async move {
+                let (tx, rx) = smol::channel::bounded(1);
+                this.window
+                    .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
+                        tx.try_send(
+                            term_window
+                                .current_mouse_position
+                                .map(|pos| (pos.column, pos.stable_row)),
+                        )
+                        .ok();
+                    })));
+                let result: Option<(usize, StableRowIndex)> =
+                    rx.recv().await.map_err(mlua::Error::external)?;
+                match result {
+                    // `x` is the cell column, `y` is the stable row index, matching
+                    // the argument convention of pane:get_semantic_zone_at(x, y).
+                    Some((x, y)) => {
+                        let table = lua.create_table()?;
+                        table.set("x", x)?;
+                        table.set("y", y)?;
+                        Ok(Some(table))
+                    }
+                    None => Ok(None),
+                }
+            },
+        );
+        methods.add_async_method(
+            "get_hyperlink_at_mouse_cursor",
+            |_, this, _: ()| async move {
+                let (tx, rx) = smol::channel::bounded(1);
+                this.window
+                    .notify(TermWindowNotif::Apply(Box::new(move |term_window| {
+                        tx.try_send(term_window.current_hyperlink_uri()).ok();
+                    })));
+                let uri: Option<String> = rx.recv().await.map_err(mlua::Error::external)?;
+                Ok(uri)
+            },
+        );
         methods.add_async_method(
             "perform_action",
             |_, this, (assignment, pane): (KeyAssignment, UserDataRef<MuxPane>)| async move {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -206,6 +206,17 @@ pub struct PaneState {
     pub mouse_terminal_coords: Option<(ClickPosition, StableRowIndex)>,
 }
 
+/// The terminal cell currently under the mouse cursor.
+///
+/// `column` is the cell column (0 = leftmost) and `stable_row` is the
+/// stable row index, matching the coordinate convention used by
+/// `pane:get_semantic_zone_at(x, y)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MousePosition {
+    pub column: usize,
+    pub stable_row: StableRowIndex,
+}
+
 /// Data used when synchronously formatting pane and window titles
 #[derive(Debug, Clone)]
 pub struct TabInformation {
@@ -420,6 +431,10 @@ pub struct TermWindow {
 
     /// The URL over which we are currently hovering
     current_highlight: Option<Arc<Hyperlink>>,
+
+    /// The terminal cell currently under the mouse cursor (column, stable row),
+    /// updated on every mouse event alongside `current_highlight`.
+    pub current_mouse_position: Option<MousePosition>,
 
     quad_generation: usize,
     shape_generation: usize,
@@ -726,6 +741,7 @@ impl TermWindow {
             current_mouse_capture: None,
             last_mouse_click: None,
             current_highlight: None,
+            current_mouse_position: None,
             quad_generation: 0,
             shape_generation: 0,
             shape_cache: RefCell::new(LfuCache::new(
@@ -2828,8 +2844,14 @@ impl TermWindow {
             StartWindowDrag => {
                 self.window_drag_position = self.current_mouse_event.clone();
             }
-            OpenLinkAtMouseCursor => {
-                self.do_open_link_at_mouse_cursor(pane);
+            OpenLinkAtMouseCursor { fallback } => {
+                if self.current_highlight.is_some() {
+                    self.do_open_link_at_mouse_cursor(pane);
+                } else if let Some(fb) = fallback.as_ref() {
+                    // No link under the cursor: run the user-provided
+                    // fallback action (if any) instead of doing nothing.
+                    return self.perform_key_assignment(pane, fb);
+                }
             }
             EmitEvent(name) => {
                 self.emit_window_event(name, None);
@@ -3164,6 +3186,13 @@ impl TermWindow {
             Confirmation(args) => self.show_confirmation(args),
         };
         Ok(PerformAssignmentResult::Handled)
+    }
+
+    /// Returns the URI of the hyperlink currently under the mouse cursor, if any.
+    /// This is the same link that `OpenLinkAtMouseCursor` would open, and
+    /// includes both OSC-8 hyperlinks and matches against `hyperlink_rules`.
+    pub fn current_hyperlink_uri(&self) -> Option<String> {
+        self.current_highlight.as_ref().map(|h| h.uri().to_string())
     }
 
     fn do_open_link_at_mouse_cursor(&self, pane: &Arc<dyn Pane>) {

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -1,6 +1,7 @@
 use crate::tabbar::TabBarItem;
 use crate::termwindow::{
-    GuiWin, MouseCapture, PositionedSplit, ScrollHit, TermWindowNotif, UIItem, UIItemType, TMB,
+    GuiWin, MouseCapture, MousePosition, PositionedSplit, ScrollHit, TermWindowNotif, UIItem,
+    UIItemType, TMB,
 };
 use ::window::{
     MouseButtons as WMB, MouseCursor, MouseEvent, MouseEventKind as WMEK, MousePress,
@@ -784,6 +785,11 @@ impl super::TermWindow {
                 },
                 stable_row,
             ));
+
+        // Track the cell under the mouse so it can be queried from Lua
+        // (window:get_mouse_position()). Uses the same column/stable_row
+        // computed above for hyperlink hit-testing.
+        self.current_mouse_position = Some(MousePosition { column, stable_row });
 
         pane.apply_hyperlinks(stable_row..stable_row + 1, &self.config.hyperlink_rules);
 


### PR DESCRIPTION
Closes #7899.

## What

Lets `mouse_bindings` callbacks branch on what is under the cursor, and adds an optional fallback to `OpenLinkAtMouseCursor`. Implements the "general" + "minimal" tiers from the issue.

## Why

Today a mouse-binding callback can't ask "is there a link under the cursor, and where is the mouse?" `window:current_event()` returns only `{Down/Drag/Up={streak,button}}`, `pane:get_cursor_position()` is the *text* cursor, and the only signal about a hovered link is the synchronous-`open-uri` side channel inside `OpenLinkAtMouseCursor` — undocumented, and unable to distinguish "link present but I want to override" from "no link". This blocks ctrl+click "open whatever's here", semantic-zone-at-click, copy-the-link, custom regexp-link actions, and alternative link actions (use cases 1–5 in #7899).

## Changes

**Two new window methods** — the state already lives on `TermWindow`, so this only exposes it:

- `window:get_mouse_position()` → `{ x = column, y = stable_row } | nil`.
  `x`/`y` use the same convention as `pane:get_semantic_zone_at(x, y)`, so they compose directly:
  ```lua
  local pos = window:get_mouse_position()
  local zone = pane:get_semantic_zone_at(pos.x, pos.y)  -- use case 2
  ```
- `window:get_hyperlink_at_mouse_cursor()` → `uri | nil`.
  Reads the existing `current_highlight`, so it covers **both** OSC-8 hyperlinks and `hyperlink_rules` matches — exactly what `OpenLinkAtMouseCursor` opens. Use cases 1/3/4/5.

**Fallback action** (minimal tier):

- `OpenLinkAtMouseCursor` is now `OpenLinkAtMouseCursor { fallback = <action> }` (fallback optional). When no link is under the cursor, the fallback runs:
  ```lua
  action = wezterm.action.OpenLinkAtMouseCursor {
    fallback = wezterm.action_callback(function(window, pane)
      -- resolve the clicked word as a path / file:line / issue-ref
    end),
  }
  ```
- **Backward compatible**: `wezterm.action.OpenLinkAtMouseCursor` (no args) still works. The `Enum::__index` metatable in `luahelper/src/enumctor.rs` default-constructs the now-struct variant via the empty-table form `{OpenLinkAtMouseCursor={}}`; verified by a dedicated round-trip test. The default key/mouse bindings and the menu item are unchanged in behavior.

## Implementation notes

- The link-resolution block in `mouse_event_impl` runs unconditionally on every mouse event, so `current_highlight` and the tracked mouse cell are fresh at click time.
- A new global `TermWindow::current_mouse_position` field is set alongside the existing per-pane `mouse_terminal_coords`; the window methods read it via the existing `TermWindowNotif::Apply` channel (same pattern as `current_event`).

## Verification

- `cargo test -p config` — 11/11 pass, including 3 new round-trip tests for the variant (`OpenLinkAtMouseCursor{fallback:None}` round-trips; the empty-table no-arg form decodes to `fallback:None`; the fallback form decodes correctly).
- `cargo check` for `config`, `wezterm-gui`, and `wezterm` — clean.
- End-to-end: built `wezterm-gui` and launched it with a scratch config that force-evaluates both action forms under `pcall` + shape assertions — both `wezterm.action.OpenLinkAtMouseCursor` and `wezterm.action.OpenLinkAtMouseCursor{fallback=...}` construct correctly in the real Lua environment.

## Docs

Adds `docs/config/lua/window/get_mouse_position.md`, `docs/config/lua/window/get_hyperlink_at_mouse_cursor.md`, updates `docs/config/lua/keyassignment/OpenLinkAtMouseCursor.md`, and adds a changelog entry.

## Related issues

This provides the Lua primitives that unblock these (linked for cross-reference, not auto-closed — each closes only if a maintainer agrees it's resolved):

- Refs #527 — copy the link under the cursor (now: `get_hyperlink_at_mouse_cursor()` + `window:copy_to_clipboard()`).
- Refs #4371 — alternative actions on a present link (link presence is now queryable in Lua).
- Refs #3791 — custom command for a regexp-matched link (the URI is exposed, but not *which rule matched*).
- Refs discussion #5836 — open the semantic zone under the click (now: `get_mouse_position()` + existing `pane:get_semantic_zone_at(x, y)`).

Out of scope: #7491 / #4536 (hyperlink-open bindings being intercepted by mouse-reporting mode) — a different problem this PR doesn't address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

