### PR TITLE
fix: encode Composed keys properly in Kitty keyboard protocol

### DIFF
--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -2002,6 +2002,23 @@ impl KeyEvent {
                 format!("{intro};{modifiers}{event_type}{end_char}")
             }
 
+            Composed(s) => {
+                let use_legacy = self.modifiers.is_empty()
+                    && !flags.contains(KittyKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES)
+                    && event_type.is_empty();
+
+                if use_legacy {
+                    s.clone()
+                } else {
+                    // Note: Multi-character IME composed strings are handled by a separate
+                    // text path in keyevent.rs (Key::Composed) and do not reach here.
+                    // This fallback handles single-character Composed keys that were mapped
+                    // to Key::Code, or any potential multichar keys if the layout changes.
+                    let first = s.chars().next().map(|c| c as u32).unwrap_or(0);
+                    format!("\x1b[{first};{modifiers}{event_type}{generated_text}u")
+                }
+            }
+
             _ => {
                 let code = self.raw.as_ref().and_then(|raw| raw.kitty_function_code());
 
@@ -3270,6 +3287,129 @@ mod test {
             }
             .encode_kitty(flags),
             "\x1b[27;1:3u".to_string()
+        );
+    }
+
+    #[test]
+    fn encode_composed_kitty() {
+        // 1. flags = NONE, key_is_down = true -> should encode the composed text as-is
+        let flags = KittyKeyboardFlags::NONE;
+        assert_eq!(
+            KeyEvent {
+                key: KeyCode::Composed("，".to_string()),
+                modifiers: Modifiers::NONE,
+                leds: KeyboardLedStatus::empty(),
+                repeat_count: 1,
+                key_is_down: true,
+                raw: None,
+                #[cfg(windows)]
+                win32_uni_char: None,
+            }
+            .encode_kitty(flags),
+            "，".to_string()
+        );
+
+        // 2. flags = NONE, key_is_down = false -> should encode to empty string
+        assert_eq!(
+            KeyEvent {
+                key: KeyCode::Composed("，".to_string()),
+                modifiers: Modifiers::NONE,
+                leds: KeyboardLedStatus::empty(),
+                repeat_count: 1,
+                key_is_down: false,
+                raw: None,
+                #[cfg(windows)]
+                win32_uni_char: None,
+            }
+            .encode_kitty(flags),
+            "".to_string()
+        );
+
+        // 3. flags = REPORT_ALL_KEYS_AS_ESCAPE_CODES, key_is_down = true -> should encode as CSI-u
+        let flags = KittyKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES;
+        assert_eq!(
+            KeyEvent {
+                key: KeyCode::Composed("，".to_string()),
+                modifiers: Modifiers::NONE,
+                leds: KeyboardLedStatus::empty(),
+                repeat_count: 1,
+                key_is_down: true,
+                raw: None,
+                #[cfg(windows)]
+                win32_uni_char: None,
+            }
+            .encode_kitty(flags),
+            "\x1b[65292;1u".to_string()
+        );
+
+        // 4. flags = REPORT_ALL_KEYS_AS_ESCAPE_CODES | REPORT_ASSOCIATED_TEXT, key_is_down = true -> should include text
+        let flags = KittyKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES | KittyKeyboardFlags::REPORT_ASSOCIATED_TEXT;
+        assert_eq!(
+            KeyEvent {
+                key: KeyCode::Composed("，".to_string()),
+                modifiers: Modifiers::NONE,
+                leds: KeyboardLedStatus::empty(),
+                repeat_count: 1,
+                key_is_down: true,
+                raw: None,
+                #[cfg(windows)]
+                win32_uni_char: None,
+            }
+            .encode_kitty(flags),
+            "\x1b[65292;1;65292u".to_string()
+        );
+
+        // 5. flags = REPORT_EVENT_TYPES, key_is_down = false -> should encode to release CSI-u
+        let flags = KittyKeyboardFlags::REPORT_EVENT_TYPES;
+        assert_eq!(
+            KeyEvent {
+                key: KeyCode::Composed("，".to_string()),
+                modifiers: Modifiers::NONE,
+                leds: KeyboardLedStatus::empty(),
+                repeat_count: 1,
+                key_is_down: false,
+                raw: None,
+                #[cfg(windows)]
+                win32_uni_char: None,
+            }
+            .encode_kitty(flags),
+            "\x1b[65292;1:3u".to_string()
+        );
+
+        // 6. with modifiers (Ctrl), flags = NONE, key_is_down = true -> should encode as CSI-u with modifiers
+        let flags = KittyKeyboardFlags::NONE;
+        assert_eq!(
+            KeyEvent {
+                key: KeyCode::Composed("，".to_string()),
+                modifiers: Modifiers::CTRL,
+                leds: KeyboardLedStatus::empty(),
+                repeat_count: 1,
+                key_is_down: true,
+                raw: None,
+                #[cfg(windows)]
+                win32_uni_char: None,
+            }
+            .encode_kitty(flags),
+            "\x1b[65292;5u".to_string()
+        );
+
+        // 7. Typical real-world flag combination (DISAMBIGUATE | REPORT_EVENT_TYPES | REPORT_ALTERNATE_KEYS), key_is_down = true -> should return raw text
+        let flags = KittyKeyboardFlags::DISAMBIGUATE_ESCAPE_CODES
+            | KittyKeyboardFlags::REPORT_EVENT_TYPES
+            | KittyKeyboardFlags::REPORT_ALTERNATE_KEYS;
+        assert_eq!(
+            KeyEvent {
+                key: KeyCode::Composed("，".to_string()),
+                modifiers: Modifiers::NONE,
+                leds: KeyboardLedStatus::empty(),
+                repeat_count: 1,
+                key_is_down: true,
+                raw: None,
+                #[cfg(windows)]
+                win32_uni_char: None,
+            }
+            .encode_kitty(flags),
+            "，".to_string()
         );
     }
 }


### PR DESCRIPTION
# fix: encode Composed keys properly in Kitty keyboard protocol

## Summary

This PR fixes a bug where single-character IME inputs (e.g., CJK punctuation like `，` or single characters like `你`) are encoded as empty strings `""` when the Kitty keyboard protocol is active on Windows, making CJK typing impossible in terminal applications (such as [pi](https://github.com/earendil-works/pi)) that request this protocol.

## Cause of the Bug

When Windows IME commits a single character, WezTerm triggers a `KeyEvent` with `key` set to `KeyCode::Composed(String)`. 
Under the Kitty keyboard protocol, WezTerm routes this event to `encode_kitty(flags)`. However, `encode_kitty` fell back to the default `_` match branch, which returned an empty string `""` because the event had no physical raw key code (`self.raw` is `None`). 

This empty string `""` was then wrapped as `Some("")` by `encode_kitty_input` and returned to the caller in `keyevent.rs` (simplified for illustration):
```rust
} else if let Some(encoded) = self.encode_kitty_input(&pane, &window_key) {
    // We get here because `encoded` is `Some("")`.
    // It writes the empty string to the PTY, and halts processing.
    pane.writer().write_all(encoded.as_bytes()).ok();
} else {
    // The default fallback (which writes raw characters to PTY) is bypassed/short-circuited.
    pane.key_down(key, modifiers)
}
```
This short-circuits the default text-fallback path (`pane.key_down`), causing the committed character to be entirely swallowed.

## Proposed Fix

We add a dedicated `KeyCode::Composed(s)` branch inside the main `match &self.key` loop in `encode_kitty`:
1. **Legacy Fallback**: If no modifiers are present, `REPORT_ALL_KEYS_AS_ESCAPE_CODES` is not active, and the event does not require event-type formatting (e.g., not a key-release event), we directly return the raw Unicode string `s` as-is. This aligns perfectly with how simple `Char` inputs are encoded.
2. **CSI-u Formatting**: Otherwise, we format it into a proper CSI-u sequence `\x1b[{first};{modifiers}{event_type}{generated_text}u`.
   - The primary key code is the Unicode code point of the first character in the composed text.
   - The associated text (`generated_text`) contains the code points for all characters in the string, formatted as `;code1:code2`.

## How to Reproduce

You can reproduce this behavior using a clean setup on Windows 11 with Microsoft Pinyin IME:

1. Create a minimal WezTerm configuration `wezterm-debug-kitty.lua`:
   ```lua
   local wezterm = require 'wezterm'
   local config = wezterm.config_builder()
   config.enable_kitty_keyboard = true
   config.debug_key_events = true
   return config
   ```
2. Start WezTerm using this config:
   ```powershell
   wezterm --config-file wezterm-debug-kitty.lua start
   ```
3. Inside the new WezTerm window, run the following standalone Node.js script to simulate a Kitty protocol handshake and capture inputs:
   ```javascript
   const stdin = process.stdin, stdout = process.stdout;
   if (!stdin.setRawMode) { console.error("raw mode not supported"); process.exit(1); }
   
   // Send Kitty keyboard protocol handshake sequences
   stdout.write("\x1b[>7u\x1b[?u\x1b[c");
   stdin.setRawMode(true); stdin.setEncoding("utf8"); stdin.resume();
   
   let gotHandshake = false;
   stdin.on("data", (data) => {
       const s = String(data);
       if (s === "\x03") { stdin.setRawMode(false); process.exit(0); }
       if (!gotHandshake) { gotHandshake = true; return; } // swallow handshake response
       const hex = [...Buffer.from(s, "utf8")].map(b => "\\x" + b.toString(16).padStart(2, "0")).join("");
       stdout.write(`[Received] ${hex}\r\n`);
   });
   ```
4. Switch to CJK IME, and press `,` once (committing `，`).
   - **Before this fix**: The script receives absolutely nothing for the key press (and WezTerm logs `kitty: Encoded input as ""`).
   - **After this fix**: The script correctly receives the UTF-8 bytes `\xef\xbc\x8c` of `，`.

## Testing & Verification

We added a robust test suite `encode_composed_kitty` in `wezterm-input-types/src/lib.rs` verifying 7 distinct Kitty protocol encoding scenarios for composed keys:
1. **Plain Input** (`flags = NONE`, `key_is_down = true`) → returns `"，"` (raw text).
2. **Plain Release** (`flags = NONE`, `key_is_down = false`) → returns `""`.
3. **All Keys as Escapes** (`flags = REPORT_ALL_KEYS_AS_ESCAPE_CODES`) → returns `\x1b[65292;1u`.
4. **Associated Text** (`flags = REPORT_ALL_KEYS_AS_ESCAPE_CODES | REPORT_ASSOCIATED_TEXT`) → returns `\x1b[65292;1;65292u`.
5. **Event-Type Release** (`flags = REPORT_EVENT_TYPES`, `key_is_down = false`) → returns `\x1b[65292;1:3u`.
6. **With Modifier** (`modifiers = CTRL`, `flags = NONE`) → returns `\x1b[65292;5u`.
7. **Typical Real-world Combo** (`flags = DISAMBIGUATE | REPORT_EVENT_TYPES | REPORT_ALTERNATE_KEYS`) → returns `"，"` (raw text).

All 14 tests in the `wezterm-input-types` package pass successfully.

---

## Proposed Changelog Entry

```markdown
- **Fixed**: Windows: Fixed single-character CJK/IME inputs (e.g., punctuation `，`) being swallowed when the Kitty keyboard protocol is active.
```
