### PR TITLE
fix: emit text for Composed keys under kitty keyboard protocol

### DIFF
--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -2012,7 +2012,13 @@ impl KeyEvent {
                     (Some(code), true) => {
                         format!("\x1b[{code};{modifiers}{event_type}{generated_text}u")
                     }
-                    _ => String::new(),
+                    _ => {
+                        if let KeyCode::Composed(s) = &self.key {
+                            s.clone()
+                        } else {
+                            String::new()
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
When the kitty keyboard protocol is active, KeyCode::Composed values (eg. IME composition results such as full-width punctuation) were encoded to an empty string and silently dropped. This made IME input disappear in applications that enable the kitty keyboard protocol (eg. fish), while working fine in shells that don't (eg. bash).

Only substitute the composed text in the fallback branch that would otherwise return an empty string, so keys that have a real kitty encoding remain unaffected.