### PR TITLE
feat(search): defer search updates to navigation and preserve viewport

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -515,6 +515,9 @@ pub struct Config {
     #[dynamic(default)]
     pub enable_scroll_bar: bool,
 
+    #[dynamic(default)]
+    pub search_trigger_on_navigate: bool,
+
     #[dynamic(try_from = "crate::units::PixelUnit", default = "default_half_cell")]
     pub min_scroll_bar_height: Dimension,
 

--- a/docs/config/lua/config/search_trigger_on_navigate.md
+++ b/docs/config/lua/config/search_trigger_on_navigate.md
@@ -1,0 +1,18 @@
+---
+tags:
+  - search
+  - navigation
+---
+# `search_trigger_on_navigate`
+
+Controls whether WezTerm's search overlay automatically re-runs the search when new output is printed in the terminal.
+
+When set to `true`, background updates from streaming terminal outputs will not automatically re-run the search query. Instead, the search is only updated when you modify the search pattern (e.g. typing or deleting text) or actively navigate the search matches (e.g. using `PriorMatch` or `NextMatch` key assignments).
+
+This prevents flickering of search highlights and keeps the scrollbar/viewport locked at your current viewing position during fast-flowing outputs.
+
+The default is `false`, which enables eager and automatic background updates.
+
+```lua
+config.search_trigger_on_navigate = true
+```

--- a/wezterm-gui/src/overlay/copy.rs
+++ b/wezterm-gui/src/overlay/copy.rs
@@ -57,6 +57,14 @@ struct Jump {
     target: char,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NavigationAction {
+    PriorMatch,
+    NextMatch,
+    PriorMatchPage,
+    NextMatchPage,
+}
+
 struct CopyRenderable {
     cursor: StableCursorPosition,
     delegate: Arc<dyn Pane>,
@@ -85,6 +93,10 @@ struct CopyRenderable {
     searching: Option<Searching>,
     pending_jump: Option<PendingJump>,
     last_jump: Option<Jump>,
+
+    last_selected_match: Option<SearchResult>,
+    last_pattern: Option<Pattern>,
+    pending_navigation: Option<NavigationAction>,
 }
 
 struct Searching {
@@ -162,6 +174,9 @@ impl CopyOverlay {
             searching: None,
             pending_jump: None,
             last_jump: None,
+            last_selected_match: None,
+            last_pattern: None,
+            pending_navigation: None,
         };
 
         let search_row = render.compute_search_row();
@@ -298,6 +313,18 @@ impl CopyRenderable {
     }
 
     fn update_search(&mut self) {
+        let pattern = self.get_pattern();
+        let pattern_changed = Some(&pattern) != self.last_pattern.as_ref();
+
+        if pattern_changed {
+            self.last_selected_match = None;
+        } else if let Some(pos) = self.result_pos {
+            if pos < self.results.len() {
+                self.last_selected_match = Some(self.results[pos].clone());
+            }
+        }
+        self.last_pattern = Some(pattern.clone());
+
         for idx in self.by_line.keys() {
             self.dirty_results.add(*idx);
         }
@@ -309,7 +336,7 @@ impl CopyRenderable {
         self.by_line.clear();
         self.result_pos.take();
 
-        SAVED_PATTERN.lock().insert(self.tab_id, self.get_pattern());
+        SAVED_PATTERN.lock().insert(self.tab_id, pattern.clone());
 
         let bar_pos = self.compute_search_row();
         self.dirty_results.add(bar_pos);
@@ -370,7 +397,11 @@ impl CopyRenderable {
         let is_first = self.results.is_empty();
         self.incrementally_recompute_results(results);
 
-        if is_first {
+        if let Some(saved_res) = self.last_selected_match.as_ref() {
+            if let Some(pos) = self.results.iter().position(|r| r.start_y == saved_res.start_y && r.start_x == saved_res.start_x) {
+                self.result_pos = Some(pos);
+            }
+        } else if is_first {
             if !self.results.is_empty() {
                 self.activate_match_number(0);
             } else {
@@ -382,6 +413,14 @@ impl CopyRenderable {
         let dims = self.delegate.get_dimensions();
         if range.start == dims.scrollback_top {
             self.searching.take();
+            if let Some(nav) = self.pending_navigation.take() {
+                match nav {
+                    NavigationAction::NextMatch => self.next_match(),
+                    NavigationAction::PriorMatch => self.prior_match(),
+                    NavigationAction::NextMatchPage => self.next_match_page(),
+                    NavigationAction::PriorMatchPage => self.prior_match_page(),
+                }
+            }
             return;
         }
 
@@ -583,6 +622,11 @@ impl CopyRenderable {
 
     /// Move to next match
     fn next_match(&mut self) {
+        if !self.get_pattern().is_empty() && self.delegate.get_current_seqno() > self.last_result_seqno {
+            self.pending_navigation = Some(NavigationAction::NextMatch);
+            self.update_search();
+            return;
+        }
         if let Some(cur) = self.result_pos.as_ref() {
             let prior = if *cur > 0 {
                 cur - 1
@@ -595,6 +639,11 @@ impl CopyRenderable {
 
     /// Move to prior match
     fn prior_match(&mut self) {
+        if !self.get_pattern().is_empty() && self.delegate.get_current_seqno() > self.last_result_seqno {
+            self.pending_navigation = Some(NavigationAction::PriorMatch);
+            self.update_search();
+            return;
+        }
         if let Some(cur) = self.result_pos.as_ref() {
             let next = if *cur + 1 >= self.results.len() {
                 0
@@ -608,6 +657,11 @@ impl CopyRenderable {
     /// Skip this page of matches and move down to the first match from
     /// the next page.
     fn next_match_page(&mut self) {
+        if !self.get_pattern().is_empty() && self.delegate.get_current_seqno() > self.last_result_seqno {
+            self.pending_navigation = Some(NavigationAction::NextMatchPage);
+            self.update_search();
+            return;
+        }
         let dims = self.delegate.get_dimensions();
         if let Some(cur) = self.result_pos {
             let top = self.viewport.unwrap_or(dims.physical_top);
@@ -627,6 +681,11 @@ impl CopyRenderable {
     /// Skip this page of matches and move up to the first match from
     /// the prior page.
     fn prior_match_page(&mut self) {
+        if !self.get_pattern().is_empty() && self.delegate.get_current_seqno() > self.last_result_seqno {
+            self.pending_navigation = Some(NavigationAction::PriorMatchPage);
+            self.update_search();
+            return;
+        }
         let dims = self.delegate.get_dimensions();
         if let Some(cur) = self.result_pos {
             let top = self.viewport.unwrap_or(dims.physical_top);
@@ -1389,7 +1448,9 @@ impl Pane for CopyOverlay {
         // lock erro!
         let mut renderer = self.render.lock();
         if self.delegate.get_current_seqno() > renderer.last_result_seqno {
-            renderer.update_search();
+            if !config::configuration().search_trigger_on_navigate {
+                renderer.update_search();
+            }
         }
         renderer.check_for_resize();
         let dims = self.get_dimensions();
@@ -1508,7 +1569,9 @@ impl Pane for CopyOverlay {
     fn get_lines(&self, lines: Range<StableRowIndex>) -> (StableRowIndex, Vec<Line>) {
         let mut renderer = self.render.lock();
         if self.delegate.get_current_seqno() > renderer.last_result_seqno {
-            renderer.update_search();
+            if !config::configuration().search_trigger_on_navigate {
+                renderer.update_search();
+            }
         }
 
         renderer.check_for_resize();


### PR DESCRIPTION
# Pull Request Description: Defer search updates on navigation and preserve viewport

## Problem

When the terminal pane is receiving fast streaming output (e.g. log streaming, compiling, or `ping -t`), WezTerm's search overlay becomes unusable. Every time new output arrives, the terminal's sequence number (`seqno`) increases, which triggers a complete search re-run. This causes:
1. Significant flickering of matching results.
2. The viewport and scrollbar to be forcefully scrolled back to the 0th match, making it impossible for users to scroll up/down to review previous matches during active output.

## Solution

This PR introduces an option to defer search updates and optimizes search result tracking to preserve the viewport position:

1. **New Lua Configuration**: Added `search_trigger_on_navigate` (boolean, defaults to `false`).
   - When set to `true`, background updates from streaming terminal outputs will **no longer** automatically trigger a search re-run.
   - Searching is only triggered when the user modifies the search pattern (typing, backspace) or actively navigates the matches (e.g. using `PriorMatch` / `NextMatch`).
2. **Viewport & Highlight Preservation**:
   - The search state machine now records the physical coordinates (`start_y`, `start_x`) of the current selected match into `last_selected_match`.
   - When search results are re-computed (on background updates or navigation), it updates the index of the selected match in the new results list and preserves the viewport, avoiding forced scrolling or flickering.
3. **Pending Navigation Queue**:
   - If `search_trigger_on_navigate` is `true` and the terminal outputs change, pressing Up/Down will queue the navigation action (`pending_navigation`) and initiate a search update. Once the asynchronous search is completed, it automatically resolves and executes the queued navigation.

## Configuration

To enable this deferred navigation search mode, add the following to your `wezterm.lua`:

```lua
local wezterm = require 'wezterm'
local config = wezterm.config_builder()

config.search_trigger_on_navigate = true

return config
```
