### PR TITLE
fix: repaint tab bar during drag reorder + floating drag preview (builds on #6527)

### DIFF
--- a/docs/config/lua/keyassignment/MoveTabRelative.md
+++ b/docs/config/lua/keyassignment/MoveTabRelative.md
@@ -4,6 +4,8 @@ Move the current tab relative to its peers.  The argument specifies an
 offset. eg: `-1` moves the tab to the left of the current tab, while `1` moves
 the tab to the right.
 
+It is also possible to reorder tabs via left mouse drag on the tab bar entry.
+
 ```lua
 local act = wezterm.action
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -440,6 +440,10 @@ pub struct TermWindow {
 
     ui_items: Vec<UIItem>,
     dragging: Option<(UIItem, MouseEvent)>,
+    /// Pixel offset from the dragged tab's left edge to the mouse cursor,
+    /// captured at the start of a tab-bar drag so the floating preview
+    /// tracks the cursor without snapping.
+    dragging_tab_start_offset: Option<isize>,
 
     modal: RefCell<Option<Rc<dyn Modal>>>,
 
@@ -783,6 +787,7 @@ impl TermWindow {
             semantic_zones: HashMap::new(),
             ui_items: vec![],
             dragging: None,
+            dragging_tab_start_offset: None,
             last_ui_item: None,
             is_click_to_focus_window: false,
             key_table_state: KeyTableState::default(),

--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -131,6 +131,8 @@ impl super::TermWindow {
                 }
                 if press == &MousePress::Left && self.dragging.take().is_some() {
                     // Completed a drag
+                    self.dragging_tab_start_offset = None;
+                    context.invalidate();
                     return;
                 }
             }
@@ -345,6 +347,7 @@ impl super::TermWindow {
         tab_idx: TabId,
         start_event: MouseEvent,
         event: MouseEvent,
+        context: &dyn WindowOps,
     ) {
         let current_x = event.coords.x;
         let drag_right = current_x.saturating_sub(start_event.coords.x) > 0;
@@ -369,6 +372,9 @@ impl super::TermWindow {
         // the overall (from first click that initiated drag), so we always replace
         // the start_event.
         self.dragging.replace((item, event));
+        // The floating drag preview tracks the live cursor position, so
+        // every move needs a repaint, not just moves that trigger a swap.
+        context.invalidate();
     }
 
     fn drag_ui_item(
@@ -388,7 +394,7 @@ impl super::TermWindow {
                 self.drag_scroll_thumb(item, start_event, event, context);
             }
             UIItemType::TabBar(TabBarItem::Tab { tab_idx, .. }) => {
-                self.drag_reorder_tab(item, tab_idx, start_event, event);
+                self.drag_reorder_tab(item, tab_idx, start_event, event, context);
             }
             _ => {
                 log::error!("drag not implemented for {:?}", item);
@@ -507,6 +513,7 @@ impl super::TermWindow {
                 TabBarItem::Tab { tab_idx, .. } => {
                     self.activate_tab(tab_idx as isize).ok();
                     // For reordering tabs
+                    self.dragging_tab_start_offset = Some(event.coords.x - item.x as isize);
                     self.dragging = Some((item, event));
                 }
                 TabBarItem::NewTabButton { .. } => {

--- a/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/fancy_tab_bar.rs
@@ -462,13 +462,71 @@ impl crate::TermWindow {
         let computed = self.fancy_tab_bar.as_ref().ok_or_else(|| {
             anyhow::anyhow!("paint_fancy_tab_bar called but fancy_tab_bar is None")
         })?;
+        // Hit-testing and future layout must be based on the real,
+        // un-dragged positions, so this is computed before any
+        // drag-preview translation below.
         let ui_items = computed.ui_items();
 
         let gl_state = self.render_state.as_ref().unwrap();
-        self.render_element(&computed, gl_state, None)?;
+
+        if let Some(floating) = self.dragged_tab_preview(computed) {
+            self.render_element(&floating, gl_state, None)?;
+        } else {
+            self.render_element(&computed, gl_state, None)?;
+        }
 
         Ok(ui_items)
     }
+
+    /// If a tab is currently being dragged, returns a copy of the tab bar
+    /// with just that tab's element translated so that it visually follows
+    /// the mouse cursor, rendered above its neighbors. Without this, moving
+    /// a tab past its neighbor is invisible until something else happens to
+    /// repaint the window.
+    fn dragged_tab_preview(&self, computed: &ComputedElement) -> Option<ComputedElement> {
+        let (drag_item, drag_event) = self.dragging.as_ref()?;
+        let tab_idx = match &drag_item.item_type {
+            UIItemType::TabBar(TabBarItem::Tab { tab_idx, .. }) => *tab_idx,
+            _ => return None,
+        };
+        let offset = self.dragging_tab_start_offset?;
+        let target_x = (drag_event.coords.x - offset).max(0) as f32;
+
+        let mut floating = computed.clone();
+        if translate_dragged_tab(&mut floating, tab_idx, target_x) {
+            Some(floating)
+        } else {
+            None
+        }
+    }
+}
+
+/// Recursively finds the tab bar element for `target_tab_idx` and shifts it
+/// so its left edge sits at `target_x`, drawing it above its siblings.
+fn translate_dragged_tab(
+    computed: &mut ComputedElement,
+    target_tab_idx: usize,
+    target_x: f32,
+) -> bool {
+    let is_target = matches!(
+        &computed.item_type,
+        Some(UIItemType::TabBar(TabBarItem::Tab { tab_idx, .. })) if *tab_idx == target_tab_idx
+    );
+    if is_target {
+        let delta_x = target_x - computed.bounds.min_x();
+        computed.translate(euclid::Vector2D::new(delta_x, 0.0));
+        computed.zindex = i8::MAX;
+        return true;
+    }
+
+    if let ComputedElementContent::Children(kids) = &mut computed.content {
+        for kid in kids {
+            if translate_dragged_tab(kid, target_tab_idx, target_x) {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn make_x_button(


### PR DESCRIPTION
## Summary

This builds directly on @Jefffrey's #6527, which adds tab reordering via left-mouse-drag. I tested that PR daily for several days and found/fixed one correctness bug and one UX gap that made the feature hard to trust:

1. **Bug: the tab bar never repainted during a drag.** `drag_reorder_tab` calls `move_tab_relative`, which does reorder the tab in the data model, but the function never calls `context.invalidate()`. So the swap was real, but invisible until something else happened to trigger a repaint (a hover change, a resize, etc). In practice this made the feature look completely broken: dragging a tab looked identical to just clicking through tabs one at a time.

2. **UX gap: no visual feedback for what's being dragged.** Even after fixing the repaint, a same-titled tab hopping between positions is hard to track with your eye. There's no sense of "picking up" a tab. This PR adds a floating preview: the dragged tab renders above its neighbors and tracks the cursor in real time, closer to the drag experience in  iTerm2/Chrome/VS Code.

## What changed

- `wezterm-gui/src/termwindow/mouseevent.rs`: invalidate the window on every drag-reorder mouse-move (previously only implicitly, and only sometimes); track the pixel offset from the tab's left edge to the mouse at drag-start so the floating preview doesn't snap to be centered under the cursor.
- `wezterm-gui/src/termwindow/render/fancy_tab_bar.rs`: render a translated, elevated-zindex copy of the dragged tab's element that follows the cursor, without touching the hit-testing/layout used for the actual reorder logic.
- `wezterm-gui/src/termwindow/mod.rs`: new `dragging_tab_start_offset` field backing the above.

## Demo
<img width="1024" height="571" alt="2026-07-13 10 43 05" src="https://github.com/user-attachments/assets/f33624ab-5825-4dde-a2b7-ca4f03be81b7" />

## Testing

- Rebased #6527 onto current `main` (its original submodule pins for freetype/zlib predate a fix needed for current Xcode/macOS SDKs, unrelated to the PR's own code, but worth a rebase regardless since it was ~1.5 years stale)
- Used this WezTerm build for several days in my own workflows to verify everything was working
- Verified with real pane content (not just tab activation) that the underlying tab order actually changes, not just the display

## Relationship to #6527

This is additive on top of Jefffrey's original commit (same branch history, his commit stays intact with full authorship). Happy to have this squashed into #6527 directly if that's preferred, or to close this in favor of that one once it picks up the fix, whichever is easier for you to merge.
