### PR TITLE
mux: answer capability queries and bound the hold while a synchronized update is open

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -411,6 +411,13 @@ pub struct Config {
     #[dynamic(default = "default_mux_output_parser_coalesce_delay_ms")]
     pub mux_output_parser_coalesce_delay_ms: u64,
 
+    /// How many ms a synchronized update (DEC private mode 2026) may
+    /// hold back output before wezterm stops waiting for the closing
+    /// sequence and applies the buffered output anyway, so that a
+    /// stalled application cannot freeze the pane indefinitely
+    #[dynamic(default = "default_mux_synchronized_output_timeout_ms")]
+    pub mux_synchronized_output_timeout_ms: u64,
+
     #[dynamic(default = "default_mux_env_remove")]
     pub mux_env_remove: Vec<String>,
 
@@ -1661,6 +1668,10 @@ fn default_swallow_mouse_click_on_window_focus() -> bool {
 
 fn default_mux_output_parser_coalesce_delay_ms() -> u64 {
     3
+}
+
+fn default_mux_synchronized_output_timeout_ms() -> u64 {
+    1000
 }
 
 fn default_mux_output_parser_buffer_size() -> usize {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -276,6 +276,11 @@ As features stabilize some brief notes about them will accumulate here.
   a zero-sized placement (e.g. `w=0`/`h=0`), or displaying a cell-sized image on a pane
   whose pty reported no pixel dimensions (e.g. in `tmux -CC` domain).
   Such images are now refused instead of taking down the pane. Thanks to @zakrad! #6344
+* Capability queries (DA1, the kitty keyboard probe, etc.) are now answered
+  while a synchronized update is open, and an update held open for too long
+  now times out; see
+  [mux_synchronized_output_timeout_ms](config/lua/config/mux_synchronized_output_timeout_ms.md).
+  Thanks to @luizribeiro! #7918
 
 #### Updated
 * Bundled conpty.dll and OpenConsole.exe to build 1.22.250204002.nupkg

--- a/docs/config/lua/config/mux_synchronized_output_timeout_ms.md
+++ b/docs/config/lua/config/mux_synchronized_output_timeout_ms.md
@@ -1,0 +1,22 @@
+---
+tags:
+  - multiplexing
+---
+# `mux_synchronized_output_timeout_ms = 1000`
+
+{{since('nightly')}}
+
+Specifies how long, in milliseconds, an application may keep a synchronized
+update (DEC private mode 2026) open before wezterm stops waiting for the
+closing sequence and applies the buffered output anyway.
+
+While a synchronized update is open, wezterm holds back output so that the
+pane can be repainted as a single atomic frame. Without a bound on that hold,
+an application that opens an update and then stalls would freeze its pane
+indefinitely. When the timeout expires the buffered output is applied and the
+eventual closing sequence is a no-op.
+
+You should not normally need to change this. Raising it gives slow
+applications more time to complete an atomic frame; lowering it makes wezterm
+give up on stalled updates sooner. Setting it to `0` expires every update
+immediately, which effectively disables synchronized output handling.

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -7,7 +7,9 @@ use anyhow::{anyhow, Context, Error};
 use config::keyassignment::SpawnTabDomain;
 use config::{configuration, ExitBehavior, GuiPosition};
 use domain::{Domain, DomainId, DomainState, SplitSource};
-use filedescriptor::{poll, pollfd, socketpair, AsRawSocketDescriptor, FileDescriptor, POLLIN};
+use filedescriptor::{
+    poll, pollfd, socketpair, AsRawSocketDescriptor, Error as FdError, FileDescriptor, POLLIN,
+};
 #[cfg(unix)]
 use libc::{c_int, SOL_SOCKET, SO_RCVBUF, SO_SNDBUF};
 use log::error;
@@ -167,6 +169,18 @@ fn is_passthrough_query(action: &Action) -> bool {
     }
 }
 
+/// The poll timeout is a c_int of milliseconds on the platforms this
+/// runs on, and the deadline is Instant arithmetic; clamp the configured
+/// value (to ~24.8 days) so that an absurdly large setting can't wrap
+/// into a negative poll timeout or overflow the deadline
+fn hold_timeout_from(config: &config::ConfigHandle) -> Duration {
+    Duration::from_millis(
+        config
+            .mux_synchronized_output_timeout_ms
+            .min(i32::MAX as u64),
+    )
+}
+
 fn parse_buffered_data(pane: Weak<dyn Pane>, dead: &Arc<AtomicBool>, mut rx: FileDescriptor) {
     let mut buf = vec![0; configuration().mux_output_parser_buffer_size];
     let mut parser = termwiz::escape::parser::Parser::new();
@@ -175,8 +189,62 @@ fn parse_buffered_data(pane: Weak<dyn Pane>, dead: &Arc<AtomicBool>, mut rx: Fil
     let mut action_size = 0;
     let mut delay = Duration::from_millis(configuration().mux_output_parser_coalesce_delay_ms);
     let mut deadline = None;
+    let mut hold_timeout = hold_timeout_from(&configuration());
+    let mut hold_deadline: Option<Instant> = None;
 
     loop {
+        if hold {
+            let target = *hold_deadline.get_or_insert_with(|| Instant::now() + hold_timeout);
+            let expired = match target.checked_duration_since(Instant::now()) {
+                Some(remaining) => {
+                    let mut pfd = [pollfd {
+                        fd: rx.as_socket_descriptor(),
+                        events: POLLIN,
+                        revents: 0,
+                    }];
+                    match poll(&mut pfd, Some(remaining)) {
+                        Ok(0) => true,
+                        Ok(_) => false,
+                        // Interrupted before the deadline; recompute the
+                        // remaining time and poll again. The error variant
+                        // depends on the backend: poll(2) reports
+                        // FdError::Poll, while the macOS select(2) shim and
+                        // Windows WSAPoll report FdError::Io
+                        Err(FdError::Poll(err) | FdError::Io(err))
+                            if err.kind() == std::io::ErrorKind::Interrupted =>
+                        {
+                            continue;
+                        }
+                        Err(err) => {
+                            // Polling is what enforces the deadline, so if
+                            // it is broken the only way to keep the promise
+                            // that a stalled client cannot freeze the pane
+                            // is to fail open and release the hold
+                            log::error!(
+                                "error polling for pane output while a \
+                                 synchronized update is open: {err:#}; \
+                                 releasing the hold"
+                            );
+                            true
+                        }
+                    }
+                }
+                None => true,
+            };
+            if expired {
+                // The synchronized update has been open for longer than
+                // the configured timeout; release the hold so that a
+                // stalled application cannot freeze the pane indefinitely
+                hold = false;
+                hold_deadline = None;
+                if !actions.is_empty() {
+                    send_actions_to_mux(&pane, &dead, std::mem::take(&mut actions));
+                    action_size = 0;
+                }
+                continue;
+            }
+        }
+
         match rx.read(&mut buf) {
             Ok(size) if size == 0 => {
                 dead.store(true, Ordering::Relaxed);
@@ -197,22 +265,30 @@ fn parse_buffered_data(pane: Weak<dyn Pane>, dead: &Arc<AtomicBool>, mut rx: Fil
                         Action::CSI(CSI::Mode(Mode::SetDecPrivateMode(DecPrivateMode::Code(
                             DecPrivateModeCode::SynchronizedOutput,
                         )))) => {
-                            hold = true;
+                            // Setting the mode while it is already active is
+                            // idempotent: the update keeps its original
+                            // deadline and the frame held so far stays held
+                            if !hold {
+                                hold = true;
+                                hold_deadline = Some(Instant::now() + hold_timeout);
 
-                            // Flush prior actions
-                            if !actions.is_empty() {
-                                send_actions_to_mux(&pane, &dead, std::mem::take(&mut actions));
-                                action_size = 0;
+                                // Flush prior actions
+                                if !actions.is_empty() {
+                                    send_actions_to_mux(&pane, &dead, std::mem::take(&mut actions));
+                                    action_size = 0;
+                                }
                             }
                         }
                         Action::CSI(CSI::Mode(Mode::ResetDecPrivateMode(
                             DecPrivateMode::Code(DecPrivateModeCode::SynchronizedOutput),
                         ))) => {
                             hold = false;
+                            hold_deadline = None;
                             flush = true;
                         }
                         Action::CSI(CSI::Device(dev)) if matches!(**dev, Device::SoftReset) => {
                             hold = false;
+                            hold_deadline = None;
                             flush = true;
                         }
                         _ => {}
@@ -263,6 +339,7 @@ fn parse_buffered_data(pane: Weak<dyn Pane>, dead: &Arc<AtomicBool>, mut rx: Fil
                 let config = configuration();
                 buf.resize(config.mux_output_parser_buffer_size, 0);
                 delay = Duration::from_millis(config.mux_output_parser_coalesce_delay_ms);
+                hold_timeout = hold_timeout_from(&config);
             }
         }
     }

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
-use termwiz::escape::csi::{DecPrivateMode, DecPrivateModeCode, Device, Mode};
+use termwiz::escape::csi::{DecPrivateMode, DecPrivateModeCode, Device, Keyboard, Mode};
 use termwiz::escape::{Action, CSI};
 use thiserror::*;
 use wezterm_term::{Clipboard, ClipboardSelection, DownloadHandler, TerminalSize};
@@ -44,6 +44,8 @@ pub mod ssh;
 pub mod ssh_agent;
 pub mod tab;
 pub mod termwiztermtab;
+#[cfg(test)]
+mod test;
 pub mod tmux;
 pub mod tmux_commands;
 mod tmux_pty;
@@ -137,6 +139,34 @@ fn send_actions_to_mux(pane: &Weak<dyn Pane>, dead: &Arc<AtomicBool>, actions: V
     histogram!("send_actions_to_mux.rate").record(1.);
 }
 
+/// Returns true for queries that are safe to answer while a synchronized
+/// update (DEC private mode 2026) is holding back the output stream:
+/// their responses reflect terminal capabilities rather than screen state,
+/// so they don't need to wait for the held actions to be applied.
+/// Applications commonly block waiting for these responses, and would
+/// otherwise stall until the update closes.
+fn is_passthrough_query(action: &Action) -> bool {
+    match action {
+        Action::CSI(CSI::Device(dev)) => matches!(
+            **dev,
+            Device::RequestPrimaryDeviceAttributes
+                | Device::RequestSecondaryDeviceAttributes
+                | Device::RequestTertiaryDeviceAttributes
+                | Device::RequestTerminalNameAndVersion
+                | Device::StatusReport
+        ),
+        // The query is answered eagerly, but kitty state mutations stay
+        // held: the keyboard stacks live on the screens themselves, so a
+        // held screen switch or reset could route an eager mutation to
+        // the wrong screen's stack.
+        Action::CSI(CSI::Keyboard(Keyboard::QueryKittySupport)) => true,
+        // Notably, CPR and DECRQM stay held: their answers (the cursor
+        // position, the state of a mode) may be changed by the actions
+        // that are being held back.
+        _ => false,
+    }
+}
+
 fn parse_buffered_data(pane: Weak<dyn Pane>, dead: &Arc<AtomicBool>, mut rx: FileDescriptor) {
     let mut buf = vec![0; configuration().mux_output_parser_buffer_size];
     let mut parser = termwiz::escape::parser::Parser::new();
@@ -158,6 +188,10 @@ fn parse_buffered_data(pane: Weak<dyn Pane>, dead: &Arc<AtomicBool>, mut rx: Fil
             }
             Ok(size) => {
                 parser.parse(&buf[0..size], |action| {
+                    if hold && is_passthrough_query(&action) {
+                        send_actions_to_mux(&pane, &dead, vec![action]);
+                        return;
+                    }
                     let mut flush = false;
                     match &action {
                         Action::CSI(CSI::Mode(Mode::SetDecPrivateMode(DecPrivateMode::Code(

--- a/mux/src/test/mod.rs
+++ b/mux/src/test/mod.rs
@@ -128,7 +128,9 @@ impl Pane for RecordingPane {
 // run concurrently with each other.
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 
-fn start_parser() -> (FileDescriptor, Arc<RecordingPane>, thread::JoinHandle<()>) {
+fn start_parser(
+    mux_synchronized_output_timeout_ms: u64,
+) -> (FileDescriptor, Arc<RecordingPane>, thread::JoinHandle<()>) {
     static SCHEDULER: Once = Once::new();
     SCHEDULER.call_once(|| {
         // send_actions_to_mux notifies the mux via
@@ -145,7 +147,9 @@ fn start_parser() -> (FileDescriptor, Arc<RecordingPane>, thread::JoinHandle<()>
         );
     });
 
-    config::use_this_configuration(config::Config::default_config());
+    let mut config = config::Config::default_config();
+    config.mux_synchronized_output_timeout_ms = mux_synchronized_output_timeout_ms;
+    config::use_this_configuration(config);
 
     let (tx, rx) = socketpair().unwrap();
     let pane = Arc::new(RecordingPane::new());

--- a/mux/src/test/mod.rs
+++ b/mux/src/test/mod.rs
@@ -1,0 +1,191 @@
+//! Test support for the mux crate: a Pane implementation that records
+//! the action batches performed against it, and a harness that feeds
+//! bytes to parse_buffered_data through a socketpair.
+use crate::pane::{CachePolicy, ForEachPaneLogicalLine, LogicalLine, Pane, PaneId, WithPaneLines};
+use crate::renderable::{RenderableDimensions, StableCursorPosition};
+use crate::{parse_buffered_data, DomainId};
+use filedescriptor::{socketpair, FileDescriptor};
+use parking_lot::{MappedMutexGuard, Mutex};
+use rangeset::RangeSet;
+use std::ops::Range;
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Once, Weak};
+use std::thread;
+use std::time::{Duration, Instant};
+use termwiz::escape::Action;
+use termwiz::surface::{Line, SequenceNo};
+use url::Url;
+use wezterm_term::color::ColorPalette;
+use wezterm_term::{KeyCode, KeyModifiers, MouseEvent, StableRowIndex, TerminalSize};
+
+mod sync_update;
+
+pub(crate) struct RecordingPane {
+    batches: Mutex<Vec<Vec<Action>>>,
+}
+
+impl RecordingPane {
+    fn new() -> Self {
+        Self {
+            batches: Mutex::new(vec![]),
+        }
+    }
+
+    fn flattened_actions(&self) -> Vec<Action> {
+        self.batches.lock().iter().flatten().cloned().collect()
+    }
+
+    fn recorded_batches(&self) -> Vec<Vec<Action>> {
+        self.batches.lock().clone()
+    }
+}
+
+impl Pane for RecordingPane {
+    fn perform_actions(&self, actions: Vec<Action>) {
+        self.batches.lock().push(actions);
+    }
+
+    fn pane_id(&self) -> PaneId {
+        0
+    }
+    fn is_dead(&self) -> bool {
+        false
+    }
+    fn get_cursor_position(&self) -> StableCursorPosition {
+        unreachable!()
+    }
+    fn get_current_seqno(&self) -> SequenceNo {
+        unreachable!()
+    }
+    fn get_changed_since(
+        &self,
+        _lines: Range<StableRowIndex>,
+        _seqno: SequenceNo,
+    ) -> RangeSet<StableRowIndex> {
+        unreachable!()
+    }
+    fn get_lines(&self, _lines: Range<StableRowIndex>) -> (StableRowIndex, Vec<Line>) {
+        unreachable!()
+    }
+    fn with_lines_mut(&self, _lines: Range<StableRowIndex>, _with_lines: &mut dyn WithPaneLines) {
+        unreachable!()
+    }
+    fn for_each_logical_line_in_stable_range_mut(
+        &self,
+        _lines: Range<StableRowIndex>,
+        _for_line: &mut dyn ForEachPaneLogicalLine,
+    ) {
+        unreachable!()
+    }
+    fn get_logical_lines(&self, _lines: Range<StableRowIndex>) -> Vec<LogicalLine> {
+        unreachable!()
+    }
+    fn get_dimensions(&self) -> RenderableDimensions {
+        unreachable!()
+    }
+    fn get_title(&self) -> String {
+        unreachable!()
+    }
+    fn send_paste(&self, _text: &str) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
+        unreachable!()
+    }
+    fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
+        unreachable!()
+    }
+    fn resize(&self, _size: TerminalSize) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    fn key_down(&self, _key: KeyCode, _mods: KeyModifiers) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    fn key_up(&self, _key: KeyCode, _mods: KeyModifiers) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    fn mouse_event(&self, _event: MouseEvent) -> anyhow::Result<()> {
+        unreachable!()
+    }
+    fn palette(&self) -> ColorPalette {
+        unreachable!()
+    }
+    fn domain_id(&self) -> DomainId {
+        unreachable!()
+    }
+    fn get_current_working_dir(&self, _policy: CachePolicy) -> Option<Url> {
+        unreachable!()
+    }
+    fn is_mouse_grabbed(&self) -> bool {
+        false
+    }
+    fn is_alt_screen_active(&self) -> bool {
+        false
+    }
+}
+
+// The tests mutate the process-global configuration, so they must not
+// run concurrently with each other.
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+fn start_parser() -> (FileDescriptor, Arc<RecordingPane>, thread::JoinHandle<()>) {
+    static SCHEDULER: Once = Once::new();
+    SCHEDULER.call_once(|| {
+        // send_actions_to_mux notifies the mux via
+        // spawn_into_main_thread, which panics unless a scheduler is
+        // configured. There is no mux in these tests, so running the
+        // notification inline is a no-op.
+        promise::spawn::set_schedulers(
+            Box::new(|runnable| {
+                runnable.run();
+            }),
+            Box::new(|runnable| {
+                runnable.run();
+            }),
+        );
+    });
+
+    config::use_this_configuration(config::Config::default_config());
+
+    let (tx, rx) = socketpair().unwrap();
+    let pane = Arc::new(RecordingPane::new());
+    let pane_for_parser: Weak<dyn Pane> = Arc::downgrade(&(pane.clone() as Arc<dyn Pane>));
+    let parser = thread::spawn(move || {
+        let dead = Arc::new(AtomicBool::new(false));
+        parse_buffered_data(pane_for_parser, &dead, rx);
+    });
+    (tx, pane, parser)
+}
+
+// Dropping the write end closes the socketpair, which the parser
+// thread observes as EOF and exits
+fn stop_parser(tx: FileDescriptor, parser: thread::JoinHandle<()>) {
+    drop(tx);
+    parser.join().unwrap();
+}
+
+fn wait_for(mut condition: impl FnMut() -> bool, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if condition() {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+}
+
+fn contains_print(actions: &[Action], text: &str) -> bool {
+    actions.iter().any(|action| match action {
+        Action::PrintString(s) => s.contains(text),
+        Action::Print(c) => text.contains(*c),
+        _ => false,
+    })
+}
+
+const DA1_QUERY: &[u8] = b"\x1b[c";
+const KITTY_QUERY: &[u8] = b"\x1b[?u";
+const BSU: &[u8] = b"\x1b[?2026h";
+const ESU: &[u8] = b"\x1b[?2026l";

--- a/mux/src/test/sync_update.rs
+++ b/mux/src/test/sync_update.rs
@@ -1,0 +1,161 @@
+use super::*;
+use std::io::Write;
+use termwiz::escape::csi::{Cursor, Device, Keyboard, Mode, CSI};
+
+#[test]
+fn queries_pass_through_a_synchronized_update() {
+    let _guard = TEST_LOCK.lock();
+    let (mut tx, pane, parser) = start_parser();
+
+    tx.write_all(BSU).unwrap();
+    tx.write_all(b"hello").unwrap();
+    tx.write_all(DA1_QUERY).unwrap();
+    tx.write_all(KITTY_QUERY).unwrap();
+
+    let da1 = Action::CSI(CSI::Device(Box::new(
+        Device::RequestPrimaryDeviceAttributes,
+    )));
+    let kitty = Action::CSI(CSI::Keyboard(Keyboard::QueryKittySupport));
+    assert!(
+        wait_for(
+            || {
+                let actions = pane.flattened_actions();
+                actions.contains(&da1) && actions.contains(&kitty)
+            },
+            Duration::from_secs(5)
+        ),
+        "queries should be answered while the update is held, got {:?}",
+        pane.flattened_actions()
+    );
+    assert!(
+        pane.recorded_batches()
+            .iter()
+            .any(|batch| batch.as_slice() == [da1.clone()]),
+        "a passed-through query must form its own batch, got {:?}",
+        pane.recorded_batches()
+    );
+    assert!(
+        !contains_print(&pane.flattened_actions(), "hello"),
+        "held output must not leak out with the queries"
+    );
+
+    tx.write_all(ESU).unwrap();
+    assert!(
+        wait_for(
+            || contains_print(&pane.flattened_actions(), "hello"),
+            Duration::from_secs(5)
+        ),
+        "closing the update should flush the held output"
+    );
+
+    stop_parser(tx, parser);
+}
+
+#[test]
+fn kitty_state_mutations_stay_held() {
+    let _guard = TEST_LOCK.lock();
+    let (mut tx, pane, parser) = start_parser();
+
+    tx.write_all(BSU).unwrap();
+    // A held switch to the alternate screen; the keyboard stacks are
+    // per-screen, so applying the push before the switch would land
+    // it on the wrong screen's stack
+    tx.write_all(b"\x1b[?1049h").unwrap();
+    tx.write_all(b"\x1b[>1u").unwrap();
+    tx.write_all(KITTY_QUERY).unwrap();
+
+    let query = Action::CSI(CSI::Keyboard(Keyboard::QueryKittySupport));
+    let is_push = |action: &Action| {
+        matches!(
+            action,
+            Action::CSI(CSI::Keyboard(Keyboard::PushKittyState { .. }))
+        )
+    };
+    assert!(wait_for(
+        || pane.flattened_actions().contains(&query),
+        Duration::from_secs(5)
+    ));
+    assert!(
+        !pane.flattened_actions().iter().any(is_push),
+        "kitty state mutations must wait for the update to close"
+    );
+
+    tx.write_all(ESU).unwrap();
+    assert!(wait_for(
+        || pane.flattened_actions().iter().any(is_push),
+        Duration::from_secs(5)
+    ));
+
+    stop_parser(tx, parser);
+}
+
+#[test]
+fn decrqm_stays_held() {
+    let _guard = TEST_LOCK.lock();
+    let (mut tx, pane, parser) = start_parser();
+
+    let is_decrqm = |action: &Action| {
+        matches!(
+            action,
+            Action::CSI(CSI::Mode(Mode::QueryDecPrivateMode(_) | Mode::QueryMode(_)))
+        )
+    };
+
+    tx.write_all(BSU).unwrap();
+    // Hide the cursor, then ask whether it is visible; the answer
+    // depends on the held action, so it must wait for the update
+    tx.write_all(b"\x1b[?25l").unwrap();
+    tx.write_all(b"\x1b[?25$p").unwrap();
+    tx.write_all(DA1_QUERY).unwrap();
+
+    let da1 = Action::CSI(CSI::Device(Box::new(
+        Device::RequestPrimaryDeviceAttributes,
+    )));
+    assert!(wait_for(
+        || pane.flattened_actions().contains(&da1),
+        Duration::from_secs(5)
+    ));
+    assert!(
+        !pane.flattened_actions().iter().any(is_decrqm),
+        "DECRQM depends on held mode changes, so it must wait for the update to close"
+    );
+
+    tx.write_all(ESU).unwrap();
+    assert!(wait_for(
+        || pane.flattened_actions().iter().any(is_decrqm),
+        Duration::from_secs(5)
+    ));
+
+    stop_parser(tx, parser);
+}
+
+#[test]
+fn cursor_position_reports_stay_held() {
+    let _guard = TEST_LOCK.lock();
+    let (mut tx, pane, parser) = start_parser();
+
+    tx.write_all(BSU).unwrap();
+    tx.write_all(b"\x1b[6n").unwrap();
+    tx.write_all(DA1_QUERY).unwrap();
+
+    let da1 = Action::CSI(CSI::Device(Box::new(
+        Device::RequestPrimaryDeviceAttributes,
+    )));
+    assert!(wait_for(
+        || pane.flattened_actions().contains(&da1),
+        Duration::from_secs(5)
+    ));
+    let cpr = Action::CSI(CSI::Cursor(Cursor::RequestActivePositionReport));
+    assert!(
+        !pane.flattened_actions().contains(&cpr),
+        "CPR depends on the held actions, so it must wait for the update to close"
+    );
+
+    tx.write_all(ESU).unwrap();
+    assert!(wait_for(
+        || pane.flattened_actions().contains(&cpr),
+        Duration::from_secs(5)
+    ));
+
+    stop_parser(tx, parser);
+}

--- a/mux/src/test/sync_update.rs
+++ b/mux/src/test/sync_update.rs
@@ -1,11 +1,133 @@
 use super::*;
+use crate::{configuration, hold_timeout_from};
 use std::io::Write;
 use termwiz::escape::csi::{Cursor, Device, Keyboard, Mode, CSI};
 
 #[test]
+fn a_synchronized_update_expires_after_the_configured_timeout() {
+    let _guard = TEST_LOCK.lock();
+    let (mut tx, pane, parser) = start_parser(500);
+
+    tx.write_all(BSU).unwrap();
+    tx.write_all(b"hello").unwrap();
+
+    assert!(
+        wait_for(
+            || contains_print(&pane.flattened_actions(), "hello"),
+            Duration::from_secs(5)
+        ),
+        "expiring the hold should flush the buffered output"
+    );
+
+    // A hold released by the timeout must not hold up later output
+    // either: the closing sequence for the expired update is a no-op
+    // and new output flows through immediately.
+    tx.write_all(ESU).unwrap();
+    tx.write_all(b"world").unwrap();
+    assert!(wait_for(
+        || contains_print(&pane.flattened_actions(), "world"),
+        Duration::from_secs(5)
+    ));
+
+    stop_parser(tx, parser);
+}
+
+#[test]
+fn repeating_the_set_sequence_does_not_leak_the_held_frame() {
+    let _guard = TEST_LOCK.lock();
+    let (mut tx, pane, parser) = start_parser(60_000);
+
+    tx.write_all(BSU).unwrap();
+    tx.write_all(b"part one").unwrap();
+    tx.write_all(BSU).unwrap();
+    tx.write_all(b"part two").unwrap();
+    // A passed-through query acts as a barrier proving the parser has
+    // consumed everything written above
+    tx.write_all(DA1_QUERY).unwrap();
+
+    let da1 = Action::CSI(CSI::Device(Box::new(
+        Device::RequestPrimaryDeviceAttributes,
+    )));
+    assert!(wait_for(
+        || pane.flattened_actions().contains(&da1),
+        Duration::from_secs(5)
+    ));
+    assert!(
+        !contains_print(&pane.flattened_actions(), "part one"),
+        "a repeated set of mode 2026 must not flush the frame held so far"
+    );
+
+    tx.write_all(ESU).unwrap();
+    assert!(wait_for(
+        || {
+            let actions = pane.flattened_actions();
+            contains_print(&actions, "part one") && contains_print(&actions, "part two")
+        },
+        Duration::from_secs(5)
+    ));
+
+    stop_parser(tx, parser);
+}
+
+#[test]
+fn a_new_update_gets_a_fresh_deadline() {
+    let _guard = TEST_LOCK.lock();
+    let (mut tx, pane, parser) = start_parser(2_000);
+
+    let da1 = Action::CSI(CSI::Device(Box::new(
+        Device::RequestPrimaryDeviceAttributes,
+    )));
+    let da1_count = |pane: &RecordingPane, want: usize| {
+        let da1 = da1.clone();
+        let actions = pane.flattened_actions();
+        actions.iter().filter(|action| **action == da1).count() >= want
+    };
+
+    tx.write_all(BSU).unwrap();
+    tx.write_all(b"first frame").unwrap();
+    // Barrier: once this query is answered the parser has consumed the
+    // opening sequence above
+    tx.write_all(DA1_QUERY).unwrap();
+    assert!(wait_for(|| da1_count(&pane, 1), Duration::from_secs(5)));
+    // A second barrier that can only arrive through a subsequent read
+    // proves the parser got back to the top of its read loop with the
+    // update's deadline running
+    tx.write_all(DA1_QUERY).unwrap();
+    assert!(wait_for(|| da1_count(&pane, 2), Duration::from_secs(5)));
+    thread::sleep(Duration::from_millis(1_500));
+
+    // Close the first update and open the next one within a single
+    // write, so both transitions happen inside one parse call. The
+    // new update must not inherit the 500ms left on the old deadline.
+    let mut esu_bsu = ESU.to_vec();
+    esu_bsu.extend_from_slice(BSU);
+    esu_bsu.extend_from_slice(b"second frame");
+    esu_bsu.extend_from_slice(DA1_QUERY);
+    tx.write_all(&esu_bsu).unwrap();
+    assert!(wait_for(
+        || contains_print(&pane.flattened_actions(), "first frame") && da1_count(&pane, 3),
+        Duration::from_secs(5)
+    ));
+
+    thread::sleep(Duration::from_millis(1_000));
+    assert!(
+        !contains_print(&pane.flattened_actions(), "second frame"),
+        "the second update inherited the first update's deadline"
+    );
+
+    tx.write_all(ESU).unwrap();
+    assert!(wait_for(
+        || contains_print(&pane.flattened_actions(), "second frame"),
+        Duration::from_secs(5)
+    ));
+
+    stop_parser(tx, parser);
+}
+
+#[test]
 fn queries_pass_through_a_synchronized_update() {
     let _guard = TEST_LOCK.lock();
-    let (mut tx, pane, parser) = start_parser();
+    let (mut tx, pane, parser) = start_parser(60_000);
 
     tx.write_all(BSU).unwrap();
     tx.write_all(b"hello").unwrap();
@@ -52,9 +174,21 @@ fn queries_pass_through_a_synchronized_update() {
 }
 
 #[test]
+fn the_hold_timeout_is_clamped_against_extreme_values() {
+    let _guard = TEST_LOCK.lock();
+    let mut config = config::Config::default_config();
+    config.mux_synchronized_output_timeout_ms = u64::MAX;
+    config::use_this_configuration(config);
+    assert_eq!(
+        hold_timeout_from(&configuration()),
+        Duration::from_millis(i32::MAX as u64)
+    );
+}
+
+#[test]
 fn kitty_state_mutations_stay_held() {
     let _guard = TEST_LOCK.lock();
-    let (mut tx, pane, parser) = start_parser();
+    let (mut tx, pane, parser) = start_parser(60_000);
 
     tx.write_all(BSU).unwrap();
     // A held switch to the alternate screen; the keyboard stacks are
@@ -92,7 +226,7 @@ fn kitty_state_mutations_stay_held() {
 #[test]
 fn decrqm_stays_held() {
     let _guard = TEST_LOCK.lock();
-    let (mut tx, pane, parser) = start_parser();
+    let (mut tx, pane, parser) = start_parser(60_000);
 
     let is_decrqm = |action: &Action| {
         matches!(
@@ -132,7 +266,7 @@ fn decrqm_stays_held() {
 #[test]
 fn cursor_position_reports_stay_held() {
     let _guard = TEST_LOCK.lock();
-    let (mut tx, pane, parser) = start_parser();
+    let (mut tx, pane, parser) = start_parser(60_000);
 
     tx.write_all(BSU).unwrap();
     tx.write_all(b"\x1b[6n").unwrap();


### PR DESCRIPTION
Fixes #7918.

This implements the two changes discussed in the issue:

1. **Capability queries are answered while a synchronized update is open.** In `parse_buffered_data`, queries whose answers reflect terminal capabilities rather than screen state (DA1/DA2/DA3, XTVERSION, DSR `CSI 5n`, and the kitty keyboard query `CSI ?u`) are forwarded to the terminal as their own batch instead of being parked in the hold buffer. Everything whose meaning depends on the held actions stays held: CPR (the answer is the cursor position), DECRQM (the answer is mode state a held action may change; the issue originally proposed passing it through, but the terminal-side handler for querying mode 2026 itself relies on the hold intercepting it, so blocking on DECRQM now resolves via the timeout below instead), and the kitty state mutations (the keyboard stacks live on the screens themselves, so a held screen switch could route an eagerly-applied mutation to the wrong screen's stack).

2. **The hold now has a deadline.** A synchronized update that stays open longer than the new `synchronized_output_timeout_ms` option (default 1000ms) is released: the buffered output is applied and the eventual `CSI ?2026l` becomes a no-op. This is the same protection kitty (2s) and alacritty (150ms) have, and it means a client that crashes or stalls mid-update can no longer freeze its pane forever. The deadline is anchored to each update's opening sequence and cleared when it closes, so back-to-back updates can't inherit a stale deadline; re-sending BSU while an update is open is idempotent (it previously flushed the partially-held frame). While waiting out the deadline, an interrupted poll is retried and other poll errors fail open by releasing the hold. The timeout only kicks in while a hold is actually open, so it costs nothing on the normal path.

I went with a config option rather than a hardcoded value since the terminals that bound this disagree by an order of magnitude on what the bound should be; 1000ms sits in the middle and is generous enough that a legitimate frame should never hit it.

To make this testable I added a small test suite around `parse_buffered_data` (the first one, as far as I can tell): a new `mux/src/test/` module mirroring the layout of `term/src/test/`, with a recording `Pane` impl fed through a socketpair in `mod.rs` and the tests in `sync_update.rs`. It covers: queries passing through an open update as their own single-action batch while `Print` output stays held; CPR, DECRQM, and kitty mutations staying held until the update closes; repeated BSU not leaking the held frame; a back-to-back update not inheriting the previous update's deadline (using a passed-through DA1 as a synchronization barrier so the test can't race the parser); the timeout expiring a stalled update; a late ESU after expiry being a harmless no-op; and the timeout clamp against extreme configured values.

Verified end to end by running an iocraft 0.8.3 binary against a build of this branch, with the pty relay from the issue in between. That version of iocraft probes kitty keyboard support inside its first synchronized update, which is the pathological case from the issue. Before, the probe's answers were deferred until the update closed and the app ate crossterm's full 2 second query timeout before its first frame. Now the probe is answered while the update is still open and the first frame goes out a few ms after spawn:

```
0.0235 APP>TERM b'\x1b[?25l\x1b[?1049h\x1b[?2026h'
0.0378 APP>TERM b'\x1b[?u\x1b[c'
0.0482 TERM>APP b'\x1b[?65;4;6;18;22;52c'
0.0483 APP>TERM ... (first frame follows immediately)
```

(That run was against wezterm-mux-server, which shares the code path under change; the `?u` query itself gets no reply because `enable_kitty_keyboard` defaults to off, which is why crossterm pairs it with DA1 as the terminator.)
