### PR TITLE
Fix selection landing in the middle of wide characters (#6733)

### DIFF
--- a/wezterm-gui/src/termwindow/mouseevent.rs
+++ b/wezterm-gui/src/termwindow/mouseevent.rs
@@ -773,6 +773,42 @@ impl super::TermWindow {
             .unwrap_or(dims.physical_top)
             + row as StableRowIndex;
 
+        // When the click lands inside a wide (multi-column) character, the
+        // rounded column can point at the character's second (hidden) column,
+        // which would start/extend a selection in the middle of the glyph.
+        // Snap the column to the nearer edge of the wide character based on
+        // which half of it was clicked. We only do this when the mouse isn't
+        // grabbed, matching the coordinate rounding in `mouse_event_impl`.
+        if column > 0 && !pane.is_mouse_grabbed() {
+            let (_, lines) = pane.get_lines(stable_row..stable_row + 1);
+            if let Some(line) = lines.first() {
+                if let Some(covered) = line.wide_cell_covering(column) {
+                    // Reconstruct the sub-cell click position (in columns) so
+                    // that we can compare against the wide character's midpoint.
+                    let cell_width = self.render_metrics.cell_size.width as f32;
+                    let frac = if cell_width > 0. {
+                        x_pixel_offset as f32 / cell_width
+                    } else {
+                        0.
+                    };
+                    // `column` is `round(floor_val + frac)`, so a fraction of
+                    // 0.5 or more means the value was rounded up.
+                    let floor_val = if frac >= 0.5 {
+                        column.saturating_sub(1)
+                    } else {
+                        column
+                    };
+                    let x_in_cells = floor_val as f32 + frac;
+                    let mid = covered.start as f32 + (covered.end - covered.start) as f32 / 2.;
+                    column = if x_in_cells < mid {
+                        covered.start
+                    } else {
+                        covered.end
+                    };
+                }
+            }
+        }
+
         self.pane_state(pane.pane_id())
             .mouse_terminal_coords
             .replace((

--- a/wezterm-surface/src/line/line.rs
+++ b/wezterm-surface/src/line/line.rs
@@ -672,17 +672,23 @@ impl Line {
         let mut lower = click_col;
         let mut upper = click_col;
 
-        // TODO: look back and look ahead for cells that are hidden by
-        // a preceding multi-wide cell
         let cells = self.visible_cells().collect::<Vec<_>>();
         for cell in &cells {
-            if cell.cell_index() < click_col {
+            // Skip cells that end at or before the click. Comparing against the
+            // end of the cell (rather than its start) means that clicking on the
+            // hidden second column of a wide character still starts the scan at
+            // the wide character that covers the click.
+            if cell.cell_index() + cell.width().max(1) <= click_col {
                 continue;
             }
             if !is_word(cell.str()) {
                 break;
             }
-            upper = cell.cell_index() + 1;
+            // Advance past the full width of the cell so that the second
+            // (and subsequent) columns occupied by a wide character are
+            // included in the range; otherwise a trailing wide character
+            // would be left half-selected.
+            upper = cell.cell_index() + cell.width().max(1);
         }
         for cell in cells.iter().rev() {
             if cell.cell_index() > click_col {
@@ -1038,6 +1044,29 @@ impl Line {
     pub fn get_cell(&self, cell_index: usize) -> Option<CellRef<'_>> {
         self.visible_cells()
             .find(|cell| cell.cell_index() == cell_index)
+    }
+
+    /// If `column` falls within a multi-column (wide) character, returns the
+    /// `[start, start + width)` range of the columns that character occupies.
+    /// Returns `None` for single-width cells and for columns at or beyond the
+    /// end of the line. This is used to snap mouse/selection coordinates so
+    /// they never land in the middle of a wide character.
+    pub fn wide_cell_covering(&self, column: usize) -> Option<Range<usize>> {
+        for cell in self.visible_cells() {
+            let start = cell.cell_index();
+            if start > column {
+                break;
+            }
+            let width = cell.width().max(1);
+            if column < start + width {
+                return if width > 1 {
+                    Some(start..start + width)
+                } else {
+                    None
+                };
+            }
+        }
+        None
     }
 
     pub fn cluster(&self, bidi_hint: Option<ParagraphDirectionHint>) -> Vec<CellCluster> {

--- a/wezterm-surface/src/line/test.rs
+++ b/wezterm-surface/src/line/test.rs
@@ -106,6 +106,34 @@ fn double_click_range_bounds() {
     assert_eq!(r, DoubleClickRange::Range(200..200));
 }
 
+/// Double-clicking a run of wide (2-cell) characters must include the full
+/// width of the trailing character, otherwise the last glyph is left
+/// half-selected. <https://github.com/wezterm/wezterm/issues/6733>
+#[test]
+fn double_click_range_wide() {
+    // "日本語" occupies 6 columns (each character is 2 cells wide).
+    let line: Line = "日本語".into();
+    assert_eq!(line.len(), 6);
+    // Clicking on any of its columns should select all 6 columns, so that the
+    // final wide character's second column (index 5) is included.
+    for click_col in 0..6 {
+        let r = line.compute_double_click_range(click_col, |_| true);
+        assert_eq!(r, DoubleClickRange::Range(0..6));
+    }
+}
+
+#[test]
+fn wide_cell_covering() {
+    // "a日b": a=col0 (w1), 日=col1..3 (w2), b=col3 (w1)
+    let line: Line = "a日b".into();
+    assert_eq!(line.len(), 4);
+    assert_eq!(line.wide_cell_covering(0), None); // single-width 'a'
+    assert_eq!(line.wide_cell_covering(1), Some(1..3)); // start of wide '日'
+    assert_eq!(line.wide_cell_covering(2), Some(1..3)); // hidden 2nd col of '日'
+    assert_eq!(line.wide_cell_covering(3), None); // single-width 'b'
+    assert_eq!(line.wide_cell_covering(4), None); // past end of line
+}
+
 #[test]
 fn cluster_representation_basic() {
     let line: Line = "hello".into();


### PR DESCRIPTION
## Problem

When selecting CJK / double-width text, the selection could start or end in the *middle* of a wide character, and double-clicking a word left the trailing wide character half-selected.

Fixes #6733

## Root cause

There were two independent causes:

1. **Double-click / word selection** — `Line::compute_double_click_range` advanced the word end by a fixed `+1` per cell, ignoring the cell width, so a trailing wide character's second column was excluded from the range. Its forward scan also skipped the cell that covers the click when the click landed on the hidden second column of a wide character (the pre-existing `TODO` in that function).

2. **Click / drag selection** — the mouse pixel→column mapping rounds to single-cell boundaries and has no notion of glyph width, so a click on a wide character could resolve to its hidden second column, starting/extending the selection in the middle of the glyph.

## Fix

1. In `compute_double_click_range`, advance by `cell.width()` and compare the skip condition against the *end* of the cell instead of its start.
2. Add `Line::wide_cell_covering` and, in `mouse_event_terminal`, snap the resolved column to the nearer edge of the wide character based on which half was clicked (reconstructing the sub-cell position from `x_pixel_offset`). This preserves the existing "toggle selection at the cell midpoint" model while making it wide-aware, and leaves single-width behavior unchanged. Snapping is skipped while the mouse is grabbed, matching the existing coordinate rounding in `mouse_event_impl`.

## Tests

Adds regression tests in `wezterm-surface/src/line/test.rs`:
- `double_click_range_wide` — double-clicking anywhere in `日本語` selects all 6 columns.
- `wide_cell_covering` — boundary behavior for `a日b`.

All `wezterm-surface` `line::test` tests pass; `wezterm-gui` builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
