### PR TITLE
Add win32_system_backdrop_keep_inactive: keep the active backdrop material on unfocused windows

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -585,6 +585,15 @@ pub struct Config {
     #[dynamic(default)]
     pub win32_system_backdrop: SystemBackdrop,
 
+    /// Only works on Windows: when a `win32_system_backdrop` material is
+    /// active, keep rendering the *active* material while the window is
+    /// unfocused. By default DWM swaps the backdrop for a desaturated /
+    /// solid fallback on inactive windows (a power-saving behavior); this
+    /// option suppresses that by reporting the window as visually active.
+    /// See <https://github.com/wezterm/wezterm/issues/5895>.
+    #[dynamic(default)]
+    pub win32_system_backdrop_keep_inactive: bool,
+
     #[dynamic(default = "default_win32_acrylic_accent_color")]
     pub win32_acrylic_accent_color: RgbaColor,
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,7 @@ usually the best available version.
 As features stabilize some brief notes about them will accumulate here.
 
 #### Changed
+
 * DECRQCRA is now disabled by default to prevent silent screen scraping.
   Set `enable_checksum_rectangular_area = true` to re-enable it.
   Thanks to @jquast! #7701
@@ -75,6 +76,11 @@ As features stabilize some brief notes about them will accumulate here.
   easier to spot the remaining candidates. Thanks to @mr-felixoid and @bew! #7752
 
 #### New
+
+* [win32_system_backdrop_keep_inactive](config/lua/config/win32_system_backdrop_keep_inactive.md)
+  option to keep the vivid *active* backdrop material (Acrylic/Mica/Tabbed)
+  rendering while the window is unfocused, instead of DWM's desaturated
+  inactive fallback. #5895
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345
@@ -147,6 +153,7 @@ As features stabilize some brief notes about them will accumulate here.
   See dedicated section in [CONTRIBUTING.md](https://github.com/wezterm/wezterm/blob/main/CONTRIBUTING.md)
 
 #### Fixed
+
 * Race condition when very quickly adjusting font scale, and other improvements
   around resizing. Thanks to @jknockel! #4876 #5032 #5033
 * macOS: wacky initial window size with external monitors or certain font
@@ -281,6 +288,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Fix render loop freeze when closing workspaces. Thanks to @JafarAbdi! #7444
 
 #### Updated
+
 * Bundled conpty.dll and OpenConsole.exe to build 1.22.250204002.nupkg
 * Bundled harfbuzz to 11.2.1
 * Bundled libssh to 0.11.1
@@ -330,6 +338,7 @@ As features stabilize some brief notes about them will accumulate here.
 ### 20240203-110809-5046fc22
 
 #### Changed
+
 * The default for
   [freetype_load_flags](config/lua/config/freetype_load_flags.md) is now
   `NO_HINTING` when the dpi is >= 100, otherwise `DEFAULT`. #4902
@@ -337,13 +346,17 @@ As features stabilize some brief notes about them will accumulate here.
   it will itself terminate. Thanks to @vimpostor! #4535 #4523
 * Reverted the text cursor cell dimension change due to overwhelming and
   sometimes toxic feedback. #2882
+
 #### New
+
 * We now show the Lua version in the debug overlay. Thanks to @bbkane! #4943
 * `wezterm start --new-tab` and `wezterm connect --new-tab` to request a new
   tab rather than a new window when spawning via an existing GUI instance.
   The new [prefer_to_spawn_tabs](config/lua/config/prefer_to_spawn_tabs.md)
   option allows you to make this happen by default. ?4854 ?4946
+
 #### Fixed
+
 * It was not possible to specify `freetype_load_flags = 'DEFAULT'`. #4902
 * macOS: fallback fonts could select thin or otherwise unspecified font
   attributes. #4808
@@ -367,6 +380,7 @@ As features stabilize some brief notes about them will accumulate here.
 ### 20240128-202157-1e552d76
 
 #### Changed
+
 * The default for [front_end](config/lua/config/front_end.md) is again
   `OpenGL`.
 * The default for
@@ -374,6 +388,7 @@ As features stabilize some brief notes about them will accumulate here.
   `NO_HINTING`. #4874
 
 #### Fixed
+
 * macOS: System LastResort font would be taken in preference to other fonts
   in some cases when trying to find the fallback for bold fonts. #4877
 * The fancy tab bar could take a few moments to update after closing a tab. #4880
@@ -383,6 +398,7 @@ As features stabilize some brief notes about them will accumulate here.
 ### 20240127-113634-bbcac864
 
 #### Changed
+
 * The default for [front_end](config/lua/config/front_end.md) is now `WebGpu`.
 * The return type of
   [pane.get_current_working_dir](config/lua/pane/get_current_working_dir.md)
@@ -405,6 +421,7 @@ As features stabilize some brief notes about them will accumulate here.
   which enables transparent fancy tab bar backgrounds. ?4816 #3580 ?4311
 
 #### New
+
 * [wezterm imgcat](cli/imgcat.md) now has `--position`, `--no-move-cursor` and
   `--hold` options. #3716
 * [wezterm set-working-directory](cli/set-working-directory.md) will now wrap
@@ -503,6 +520,7 @@ As features stabilize some brief notes about them will accumulate here.
   retrieve text + style/formatting. #4780
 
 #### Fixed
+
 * Command Palette was using now-invalid Nerd Font 2.0 symbols for macOS
   keyboard shortcuts. #3988
 * Windows: couldn't use shifted keys like `(` in the Debug Overlay. #3999
@@ -562,6 +580,7 @@ As features stabilize some brief notes about them will accumulate here.
   Thanks to @crides for investigating! #4788
 
 #### Updated
+
 * Bundled harfbuzz to 8.3.0
 * Bundled freetype to 2.13.1
 * Bundled Noto Color Emoji font to 2.038
@@ -683,6 +702,7 @@ As features stabilize some brief notes about them will accumulate here.
   registered with the mux server. #3907
 
 #### Updated
+
 * Bundled harfbuzz to 8.0.1
 * Bundled freetype to 2.13.0
 * Bundled Nerd Font Symbols font to v3.0.1. Note that there are several
@@ -852,6 +872,7 @@ As features stabilize some brief notes about them will accumulate here.
 ### 20230408-112425-69ae8472
 
 #### Changed
+
 * macOS: Japanese IME users: CTRL-modified keys are no long routed to the IME
   by default, as it introduced problems with CTRL-key combinations for other users.
   A new [macos_forward_to_ime_modifier_mask](config/lua/config/macos_forward_to_ime_modifier_mask.md)
@@ -873,6 +894,7 @@ As features stabilize some brief notes about them will accumulate here.
 * [wezterm replay](cli/replay.md) new options `--explain-only`, `--cat`. #3446
 
 #### New
+
 * [PromptInputLine](config/lua/keyassignment/PromptInputLine.md) action for
   prompting the user for a line of text and then doing something with it.
   Can be used to prompt for (re)naming new or existing tabs, workspaces and so on.
@@ -925,6 +947,7 @@ As features stabilize some brief notes about them will accumulate here.
   [Modus-Vivendi](colorschemes/m/index.md#modus-vivendi)
 
 #### Fixed
+
 * mux: Stale remote window mapping could prevent spawning new tabs in remote domain. #2759
 * mux: Splitting then killing a pane could result in incorrect pane sizes. #3386
 * Windows: "error converting Lua string to &str" on systems with an ACP that
@@ -971,6 +994,7 @@ As features stabilize some brief notes about them will accumulate here.
 ### 20230326-111934-3666303c
 
 #### New
+
 * [mouse_wheel_scrolls_tabs](config/lua/config/mouse_wheel_scrolls_tabs.md) option
   to control whether the mouse wheel can be used to activate tabs when hovering
   over the tab bar. Thanks to @eaglgenes101! #3227
@@ -986,6 +1010,7 @@ As features stabilize some brief notes about them will accumulate here.
   [pane:move_to_new_tab()](config/lua/pane/move_to_new_tab.md). #3374
 
 #### Fixed
+
 * ssh ProxyCommand didn't parse command lines containing `=` correctly. #3307
 * `wezterm.GLOBALS.foo` now supports `__len` and `__pairs` metamethods, as well
   as being passed to `wezterm.json_encode`
@@ -1036,11 +1061,13 @@ As features stabilize some brief notes about them will accumulate here.
   the actual mux server was not updated. #3374
 
 #### Updated
+
 * Bundled JetBrainsMono to 2.304. #3362
 
 ### 20230320-124340-559cb7b0
 
 #### New
+
 * Copy Mode now supports using `CTRL-u` and `CTRL-d` to move by half a page at
   a time. Thanks to [@pengux](https://github.com/pengux)!
   [#2662](https://github.com/wezterm/wezterm/pull/2662)
@@ -1112,6 +1139,7 @@ As features stabilize some brief notes about them will accumulate here.
   function makes it easier to extend the default set of hyperlink rules.
 
 #### Fixed
+
 * X11: hanging or killing the IME could hang wezterm
   [#2819](https://github.com/wezterm/wezterm/issues/2819)
 * `wezterm ssh` now respects the `AddressFamily` option when connecting
@@ -1182,6 +1210,7 @@ As features stabilize some brief notes about them will accumulate here.
   [#3113](https://github.com/wezterm/wezterm/issues/3113)
 
 #### Changed
+
 * `CTRL-SHIFT-P` now activates the new [command
   palette](config/lua/keyassignment/ActivateCommandPalette.md), instead of
   `PaneSelect` [#1485](https://github.com/wezterm/wezterm/issues/1485)
@@ -1236,16 +1265,19 @@ As features stabilize some brief notes about them will accumulate here.
   [#3287](https://github.com/wezterm/wezterm/issues/3287)
 
 #### Updated
+
 * Bundled harfbuzz updated to version 6.0.0
 * Bundled Nerd Font Symbols font to v2.3.3
 
 ### 20221119-145034-49b9839f
 
 #### Improved
+
 * Reduced CPU and RAM utilization, reduced overhead of parsing output and
   rendering to the GPU.
 
 #### New
+
 * [wezterm.gui.default_key_tables](config/lua/wezterm.gui/default_key_tables.md)
   and [wezterm.gui.default_keys](config/lua/wezterm.gui/default_keys.md) for
   more conveniently copying and extending the default configuration.
@@ -1283,6 +1315,7 @@ As features stabilize some brief notes about them will accumulate here.
 * [front_end = "WebGpu"](config/lua/config/front_end.md) enables Metal, Vulkan and DX 12 drivers.
 
 #### Fixed
+
 * Wayland: key repeat gets stuck after pressing two keys in quick succession.
   Thanks to [@valpackett](https://github.com/valpackett)!
   [#2492](https://github.com/wezterm/wezterm/pull/2492)
@@ -1365,6 +1398,7 @@ As features stabilize some brief notes about them will accumulate here.
   [#2569](https://github.com/wezterm/wezterm/issues/2569)
 
 #### Changed
+
 * Removed Last Resort fallback font
 * X11: use `_NET_WM_MOVERESIZE` to drag by tab bar, when supported by the WM
   [#2530](https://github.com/wezterm/wezterm/issues/2530)
@@ -1392,16 +1426,20 @@ As features stabilize some brief notes about them will accumulate here.
   [#2667](https://github.com/wezterm/wezterm/issues/2667)
 
 #### Updated
+
 * Bundled Nerd Font Symbols font to v2.2.2
 * Bundled harfbuzz to 5.3.1
 
 ### 20220905-102802-7d4b8249
 
 #### New
+
 * [switch_to_last_active_tab_when_closing_tab](config/lua/config/switch_to_last_active_tab_when_closing_tab.md)
   option to control behavior when closing the active tab.
   [#2487](https://github.com/wezterm/wezterm/issues/2487)
+
 #### Changed
+
 * fontconfig: when locating a fallback font for a given codepoint, allow
   matching non-monospace fonts if we can't find any matching monospace fonts.
   [#2468](https://github.com/wezterm/wezterm/discussions/2468)
@@ -1411,6 +1449,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Searching is now incremental and shows progress. [#1209](https://github.com/wezterm/wezterm/issues/1209)
 
 #### Fixed
+
 * Hangul in NFD incorrectly shaped [#2482](https://github.com/wezterm/wezterm/issues/2482)
 * Visual artifacts when resizing splits [#2483](https://github.com/wezterm/wezterm/issues/2483)
 
@@ -1460,6 +1499,7 @@ As features stabilize some brief notes about them will accumulate here.
 ### 20220807-113146-c2fee766
 
 #### New
+
 * [ActivateKeyTable](config/lua/keyassignment/ActivateKeyTable.md) now supports `until_unknown=true` to implicitly pop the table when a key not defined by that table is pressed. [#2178](https://github.com/wezterm/wezterm/issues/2178)
 * [window:copy_to_clipboard](config/lua/window/copy_to_clipboard.md) method for putting arbitrary text into the clipboard/selection.
 * [window:set_inner_size](config/lua/window/set_inner_size.md) method for controlling window size.
@@ -1487,6 +1527,7 @@ As features stabilize some brief notes about them will accumulate here.
 * [window:set_left_status](config/lua/window/set_left_status.md) for setting status to the left of the tabs in the tab bar [#1561](https://github.com/wezterm/wezterm/issues/1561)
 
 #### Changed
+
 * If `timeout_milliseconds` is specified in
   [ActivateKeyTable](config/lua/keyassignment/ActivateKeyTable.md), then the
   timeout duration is now reset each time a key press matches that key table
@@ -1505,6 +1546,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Copy Mode: new default vim-style `y` "yank" key assignment will copy the selection and close copy mode
 
 #### Fixed
+
 * [ActivateKeyTable](config/lua/keyassignment/ActivateKeyTable.md)'s `replace_current` field was not actually optional. Made it optional. [#2179](https://github.com/wezterm/wezterm/issues/2179)
 * `winget` causes toast notification spam [#2185](https://github.com/wezterm/wezterm/issues/2185)
 * `wezterm connect sshdomain` could hang on startup if password authentication was required [#2194](https://github.com/wezterm/wezterm/issues/2194)
@@ -1533,11 +1575,13 @@ As features stabilize some brief notes about them will accumulate here.
 * Visual Bell now fills out to the adjacent window edges rather than being constrained by the padding. [#2364](https://github.com/wezterm/wezterm/issues/2364)
 
 #### Updated
+
 * Bundled harfbuzz to 5.1.0
 
 ### 20220624-141144-bd1b7c5d
 
 #### New
+
 * [background](config/lua/config/background.md) option for rich background compositing and parallax scrolling effects.
 * Added [docs for the cli](cli/general.md)
 * Support for the [Kitty Keyboard Protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol). Use [enable_kitty_keyboard](config/lua/config/enable_kitty_keyboard.md)`=true` to enable it.
@@ -1579,9 +1623,11 @@ As features stabilize some brief notes about them will accumulate here.
 * `wezterm show-keys` command to show key and mouse binding assignments [#2134](https://github.com/wezterm/wezterm/issues/2134)
 
 #### Updated
+
 * Bundled harfbuzz to 4.3.0
 
 #### Changed
+
 * Debian packages now register wezterm as an alternative for `x-terminal-emulator`. Thanks to [@xpufx](https://github.com/xpufx)! [#1883](https://github.com/wezterm/wezterm/pull/1883)
 * Windows: wezterm will now read the default environment variables from the `HKLM\System\CurrentControlSet\Control\Session Manager\Environment` and `HKCU\Environment` and apply those to the base environment prior to applying `set_environment_variables`. [#1848](https://github.com/wezterm/wezterm/issues/1848)
 * [Key Table](config/key-tables.md) lookups will now keep searching the activation stack until a matching assignment is found, allowing for layered key tables. [#993](https://github.com/wezterm/wezterm/issues/993)
@@ -1595,6 +1641,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Improved [wezterm.action](config/lua/wezterm/action.md) syntax for slightly more ergnomic and understandable key assignments. [#1150](https://github.com/wezterm/wezterm/issues/1150)
 
 #### Fixed
+
 * Flush after replying to `XTGETTCAP`, `DECRQM`, `XTVERSION`, `DA2`, `DA3` [#2060](https://github.com/wezterm/wezterm/issues/2060) [#1850](https://github.com/wezterm/wezterm/issues/1850) [#1950](https://github.com/wezterm/wezterm/issues/1950)
 * macOS: `CMD-.` was treated as `CTRL-ESC` [#1867](https://github.com/wezterm/wezterm/issues/1867)
 * macOS: `CTRL-Backslash` on German layouts was incorrect [#1891](https://github.com/wezterm/wezterm/issues/1891)
@@ -1626,13 +1673,18 @@ As features stabilize some brief notes about them will accumulate here.
 ### 20220408-101518-b908e2dd
 
 #### New
+
 * [Key Tables](config/key-tables.md) feature for powerful modal key assignments
 * `wezterm start --position x,y`, `wezterm start --position displayname:30%,30%` option to control starting window position on all systems except for Wayland. See `wezterm start --help` for more info. [#1794](https://github.com/wezterm/wezterm/issues/1794)
+
 #### Changed
+
 * Default key assignments are `mapped:` again. A new [key_map_preference](config/lua/config/key_map_preference.md) option allows the defaults to use `"Mapped"` or `"Physical"`.
 * Disabled ligatures for `"Monaco"` and `"Menlo"` fonts, as those have `"fi"` ligatures that match even for words such as `find`. [#1786](https://github.com/wezterm/wezterm/issues/1786) [#1736](https://github.com/wezterm/wezterm/issues/1736)
 * Removed the `send_composed_key_when_alt_is_pressed` option. When processing generic `ALT` (eg: that has neither left nor right), if either `send_composed_key_when_left_alt_is_pressed` or `send_composed_key_when_right_alt_is_pressed` is true, then the composed form of the key event will be generated.
+
 #### Updated and Improved
+
 * Bundled harfbuzz to 4.2.0
 * On macOS, non-native fullscreen mode now attempts to avoid the notch on systems that have one. [#1737](https://github.com/wezterm/wezterm/issues/1737)
 * Sixel parsing performance has been improved
@@ -1643,6 +1695,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Secondary DA response bumped up to persuade vim to set `ttymouse=sgr` by default. [#1825](https://github.com/wezterm/wezterm/issues/1825)
 
 #### Fixed
+
 * Incorrect csi-u encoding with non-ascii characters. [#1746](https://github.com/wezterm/wezterm/issues/1746)
 * X11 `_NET_WM_ICON` had red/blue channels swapped [#1754](https://github.com/wezterm/wezterm/issues/1754)
 * ls-fonts output didn't quote the `style` field [#1762](https://github.com/wezterm/wezterm/issues/1762)
@@ -2425,7 +2478,6 @@ As features stabilize some brief notes about them will accumulate here.
 * We now grey out the UI for lagging multiplexer connections
 * Set an upper bound on the memory usage for multiplexer connections
 
-
 ### 20200202-181957-765184e5
 
 * Improved font shaping performance 2-3x by adding a shaper cache
@@ -2462,7 +2514,6 @@ As features stabilize some brief notes about them will accumulate here.
 * Windows: removed support for WinPty, which was too difficult to obtain, configure and use.
 * Configuration errors now show in a separate window on startup, or when the configuration is reloaded
 * Improved reliability and performance of MUX sessions, although they still have room for further improvement
-
 
 ### 20200113-214446-bb6251f
 
@@ -2534,5 +2585,3 @@ font_hinting = "Full" # None, Vertical, VerticalSubpixel, Full
 * `wezterm imgcat /some/image.png` to display images inline in the terminal using the iTerm2 image protocol
 * IME support on macOS and Windows systems
 * Automatic fallback to software rendering if no GPU is available (eg: certain types of remote desktop sessions)
-
-

--- a/docs/config/lua/config/win32_system_backdrop_keep_inactive.md
+++ b/docs/config/lua/config/win32_system_backdrop_keep_inactive.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - appearance
+---
+
+# `win32_system_backdrop_keep_inactive = false`
+
+{{since('nightly')}}
+
+When a [win32_system_backdrop](win32_system_backdrop.md) material is in use,
+DWM swaps the backdrop for a desaturated/solid *inactive* fallback whenever
+the window is deactivated — a power-saving behavior that cannot be disabled
+system-wide.
+
+Setting this option to `true` keeps the vivid *active* material rendering
+while the window is unfocused, by reporting the window's non-client visual
+state as active. Real focus handling is unaffected.
+
+```lua
+config.window_background_opacity = 0.75
+config.win32_system_backdrop = "Acrylic"
+config.win32_system_backdrop_keep_inactive = true
+```
+
+Defaults to `false`, matching the OS behavior.
+
+Has no effect when `win32_system_backdrop = "Disable"`.
+
+See [#5895](https://github.com/wezterm/wezterm/issues/5895) for the
+motivating issue.

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2922,6 +2922,34 @@ unsafe fn drop_files(hwnd: HWND, _msg: UINT, wparam: WPARAM, _lparam: LPARAM) ->
     Some(0)
 }
 
+/// DWM keys the system-backdrop material (Acrylic/Mica/Tabbed) off the
+/// window's non-client activation state: when `DefWindowProc` processes
+/// `WM_NCACTIVATE` with `wParam == FALSE`, the material is swapped for a
+/// desaturated/solid "inactive" fallback (a power-saving behavior that
+/// cannot be disabled from outside the window). When the user has opted
+/// in via `win32_system_backdrop_keep_inactive`, lie to `DefWindowProc`
+/// so the active material keeps rendering while unfocused.
+/// `lParam = -1` suppresses the frame repaint (long-standing Win32 idiom).
+/// Real focus handling (WM_SETFOCUS/WM_KILLFOCUS) is unaffected.
+unsafe fn wm_ncactivate(
+    hwnd: HWND,
+    _msg: UINT,
+    wparam: WPARAM,
+    _lparam: LPARAM,
+) -> Option<LRESULT> {
+    if wparam == 0 {
+        if let Some(inner) = rc_from_hwnd(hwnd) {
+            let inner = inner.borrow();
+            if inner.config.win32_system_backdrop_keep_inactive
+                && inner.config.win32_system_backdrop != SystemBackdrop::Disable
+            {
+                return Some(DefWindowProcW(hwnd, WM_NCACTIVATE, 1, -1));
+            }
+        }
+    }
+    None
+}
+
 unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> Option<LRESULT> {
     match msg {
         WM_NCCREATE => wm_nccreate(hwnd, msg, wparam, lparam),
@@ -2933,6 +2961,7 @@ unsafe fn do_wnd_proc(hwnd: HWND, msg: UINT, wparam: WPARAM, lparam: LPARAM) -> 
         WM_WINDOWPOSCHANGED => wm_windowposchanged(hwnd, msg, wparam, lparam),
         WM_SETFOCUS => wm_set_focus(hwnd, msg, wparam, lparam),
         WM_KILLFOCUS => wm_kill_focus(hwnd, msg, wparam, lparam),
+        WM_NCACTIVATE => wm_ncactivate(hwnd, msg, wparam, lparam),
         WM_DEADCHAR | WM_KEYDOWN | WM_KEYUP | WM_SYSCHAR | WM_CHAR | WM_IME_CHAR | WM_SYSKEYUP
         | WM_SYSKEYDOWN => key(hwnd, msg, wparam, lparam),
         WM_SIZING => {


### PR DESCRIPTION
## Summary

DWM swaps a window's system-backdrop material (Acrylic/Mica/Tabbed) for a desaturated/solid fallback whenever the window is deactivated — a power-saving behavior keyed off the non-client activation state that `DefWindowProc` records while processing `WM_NCACTIVATE`. There is no system-wide way to disable it, and windows using `win32_system_backdrop` lose their transparency/material whenever they lose focus.

This PR adds an opt-in config option:

```lua
config.window_background_opacity = 0.75
config.win32_system_backdrop = "Acrylic"
config.win32_system_backdrop_keep_inactive = true
```

When enabled (and a system backdrop is in use), WezTerm handles `WM_NCACTIVATE` by passing `wParam=TRUE` to `DefWindowProc` (with `lParam=-1` to suppress the frame repaint), so DWM keeps rendering the vivid active material while the window is unfocused. Real focus handling (`WM_SETFOCUS`/`WM_KILLFOCUS`) is untouched, and deactivation (`wParam == 0`) is the only case intercepted.

Fixes #5895 (also reported as #6979).

## Notes

- Off by default — default behavior is unchanged.
- No effect when `win32_system_backdrop = "Disable"`.
- This is the same approach Win32 apps use in their own wndprocs to keep active-state visuals; Windows Terminal achieves the equivalent by composing its own in-app acrylic brush (microsoft/terminal#593).
- Tested on Windows 11 25H2 with Acrylic: unfocused windows keep the vivid material; without the option they gray out as before.

## Docs

- New page: `docs/config/lua/config/win32_system_backdrop_keep_inactive.md`
- Changelog entry under Nightly → New