### PR TITLE
nix: fix flake headless package eval error

### DIFF
--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -200,7 +200,9 @@
                   version
                   src
                   postPatch
-                  cargoLock
+                  # inherit `cargoDeps` here because `buildRustPackage` strips `cargoLock`
+                  # from `finalAttrs` via `excludeDrvArgNames`
+                  cargoDeps
                   meta
                   ;
 


### PR DESCRIPTION
## Problem

Trying to build the `wezterm-headless` package in the nix flake currently results in an evaluation error.

To reproduce, run the below command while in the root of the repo:

```bash
nix build './nix#default.headless'
```

Results in the following:

```
error:
       … while calling the 'derivationStrict' builtin
         at «nix-internal»/derivation-internal.nix:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'wezterm-headless-20260713-192414-b3255666'
         whose name attribute is located at «github:NixOS/nixpkgs/3b32825de172d0bc85664f495edb096b10862524?narHash=sha256-2aZisVTVGSFEk3MYcOiWQp3zvwyzbqpktB69Rcfp150%3D»/pkgs/stdenv/generic/make-derivation.nix:651:11

       … while evaluating attribute 'cargoDeps' of derivation 'wezterm-headless-20260713-192414-b3255666'
         at «github:NixOS/nixpkgs/3b32825de172d0bc85664f495edb096b10862524?narHash=sha256-2aZisVTVGSFEk3MYcOiWQp3zvwyzbqpktB69Rcfp150%3D»/pkgs/build-support/rust/build-rust-package/default.nix:104:7:
          103|
          104|       cargoDeps =
             |       ^
          105|         if cargoVendorDir != null then

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: attribute 'cargoLock' missing
       at /home/eldyl/dev/open_source/wezterm/nix/flake.nix:203:19:
          202|                   postPatch
          203|                   cargoLock
             |                   ^
          204|                   meta
```

## Root Cause

`buildRustPackage` needs `cargoDeps`, which it cannot get access to through `cargoLock` because `cargoLock` is not available in `finalAttrs`. `buildRustPackage` lists `cargoLock` in `excludeDrvArgNames`, so `cargoLock` is stripped before `mkDerivation`:

https://github.com/NixOS/nixpkgs/blob/3b32825de172d0bc85664f495edb096b10862524/pkgs/build-support/rust/build-rust-package/default.nix#L34-L37

## Solution

Inherit `cargoDeps` instead, which is available through `finalAttrs`. `nix build './nix#default.headless'` evaluates and builds with the change.

Additionally, CI isn't building headless, so it didn't get caught.