### PR TITLE
Guard shell integration against unset ZSH_NAME

### DIFF
--- a/assets/shell-integration/wezterm.sh
+++ b/assets/shell-integration/wezterm.sh
@@ -468,7 +468,7 @@ __wezterm_semantic_precmd() {
     __wezterm_save_ps2="$PS2"
     # Markup the left and right prompts so that the terminal
     # knows that they are semantically prompt output.
-    if [[ -n "$ZSH_NAME" ]] ; then
+    if [[ -n "${ZSH_NAME-}" ]] ; then
       PS1=$'%{\e]133;P;k=i\a%}'$PS1$'%{\e]133;B\a%}'
       PS2=$'%{\e]133;P;k=s\a%}'$PS2$'%{\e]133;B\a%}'
     else


### PR DESCRIPTION
## What changed

Guard the remaining `ZSH_NAME` check in the shell-integration prompt hook with a default expansion.

## Why

When a Bash user enables `set -u`, `__wezterm_semantic_precmd` previously expanded an unset `ZSH_NAME` directly and aborted before rendering the prompt's semantic markers.

## User impact

Bash users who enable nounset can load WezTerm shell integration without an unset `ZSH_NAME` breaking their prompt hook.

Fixes #7920.

## Validation

- Reproduced before the change with interactive Bash and `set -u`: `ZSH_NAME: unbound variable`.
- Re-ran the same source-and-prompt-hook command after the change; it exits 0.
- `git diff --check`

ShellCheck is not installed in the local environment.
