### PR TITLE
Fix: Kitty keyboard protocol drops single-char Composed key events

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -149,6 +149,15 @@ As features stabilize some brief notes about them will accumulate here.
   OSC 9 escapes set the progress state to "Indeterminate".
 
 #### Fixed
+* Kitty keyboard protocol: a single-character `Composed` key event (delivered
+  by an IME, or e.g. the Windows emoji picker) with no backing raw hardware
+  key event was silently dropped -- `encode_kitty` had no match arm for
+  `Composed` and fell through to the catch-all branch, which requires a raw
+  event to resolve a kitty function code and produced an empty string
+  otherwise. Most visible when using a multiplexer that negotiates
+  `REPORT_ALL_KEYS_AS_ESCAPE_CODES` (e.g. tmux, herdr): plain single-codepoint
+  text arriving this way (multi-codepoint sequences, e.g. ZWJ emoji, were
+  unaffected -- they ride WezTerm's raw text path instead of Kitty encoding).
 * Race condition when very quickly adjusting font scale, and other improvements
   around resizing. Thanks to @jknockel! #4876 #5032 #5033
 * macOS: wacky initial window size with external monitors or certain font

--- a/wezterm-input-types/src/lib.rs
+++ b/wezterm-input-types/src/lib.rs
@@ -1711,6 +1711,29 @@ impl KeyEvent {
     pub fn encode_kitty(&self, flags: KittyKeyboardFlags) -> String {
         use KeyCode::*;
 
+        // A `Composed` string containing exactly one char is functionally a
+        // plain character keypress (delivered by an IME, or e.g. the Windows
+        // emoji picker). It never carries a `raw` hardware key event, and
+        // unlike every other key it has no dedicated arm below, so it falls
+        // through to the final `_` catch-all, which requires `raw` to resolve
+        // a kitty function code. With no raw event that's always `None`, so
+        // the whole function silently returns an empty string and the
+        // keypress is dropped outright under Kitty protocols with
+        // REPORT_ALL_KEYS_AS_ESCAPE_CODES set. Normalize it to `Char` up
+        // front so the rest of this function treats it like any other
+        // single character; a genuinely multi-char Composed string (e.g. a
+        // ZWJ emoji sequence) is unaffected and keeps falling through as
+        // before, exactly as-is, since it never reaches encode_kitty via the
+        // Composed match arm in keyevent.rs anyway.
+        if let Composed(s) = &self.key {
+            let mut chars = s.chars();
+            if let (Some(c), None) = (chars.next(), chars.next()) {
+                let mut normalized = self.clone();
+                normalized.key = Char(c);
+                return normalized.encode_kitty(flags);
+            }
+        }
+
         if !flags.contains(KittyKeyboardFlags::REPORT_EVENT_TYPES) && !self.key_is_down {
             return String::new();
         }
@@ -2340,6 +2363,73 @@ mod test {
             .encode_kitty(flags),
             "\x1b[111;1:3u".to_string()
         );
+    }
+
+    #[test]
+    fn encode_kitty_single_char_composed_matches_char() {
+        // A `Composed` string containing exactly one char happens whenever
+        // the OS delivers synthetic/IME-style text input with no backing
+        // hardware key event (`raw: None`) -- for example the Windows emoji
+        // picker (Win+.). Prior to this fix, `encode_kitty` had no match arm
+        // for `Composed` at all, so it fell through to the catch-all `_` arm,
+        // which requires `raw` to resolve a kitty function code; with `raw`
+        // always `None` for this kind of input, the function silently
+        // returned an empty string and the keystroke was dropped outright
+        // under any protocol with REPORT_ALL_KEYS_AS_ESCAPE_CODES set.
+        let flags = KittyKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES;
+
+        let composed = KeyEvent {
+            key: KeyCode::Composed("\u{2615}".to_string()), // \u{2615} == HOT BEVERAGE
+            modifiers: Modifiers::NONE,
+            leds: KeyboardLedStatus::empty(),
+            repeat_count: 1,
+            key_is_down: true,
+            raw: None,
+            #[cfg(windows)]
+            win32_uni_char: None,
+        };
+        let equivalent_char = KeyEvent {
+            key: KeyCode::Char('\u{2615}'),
+            ..composed.clone()
+        };
+
+        assert_eq!(composed.encode_kitty(flags), "\x1b[9749;1u".to_string());
+        assert_eq!(
+            composed.encode_kitty(flags),
+            equivalent_char.encode_kitty(flags),
+            "a single-char Composed key must encode identically to the equivalent Char key"
+        );
+
+        // With REPORT_ASSOCIATED_TEXT also negotiated, the associated-text
+        // field should be present, matching the real CSI-u sequence WezTerm's
+        // kitty keyboard protocol emits for this input in practice.
+        let flags_with_text =
+            flags | KittyKeyboardFlags::REPORT_ASSOCIATED_TEXT;
+        assert_eq!(
+            composed.encode_kitty(flags_with_text),
+            "\x1b[9749;1;9749u".to_string()
+        );
+    }
+
+    #[test]
+    fn encode_kitty_multi_char_composed_is_unaffected() {
+        // A genuinely multi-char Composed string (e.g. a ZWJ emoji sequence)
+        // never reaches this function via WezTerm's normal routing -- it's
+        // written directly to the pane as raw text in keyevent.rs, bypassing
+        // Kitty encoding entirely. This test locks in that encode_kitty's own
+        // behavior for that case is untouched by the single-char fix above.
+        let flags = KittyKeyboardFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES;
+        let multi = KeyEvent {
+            key: KeyCode::Composed("ab".to_string()),
+            modifiers: Modifiers::NONE,
+            leds: KeyboardLedStatus::empty(),
+            repeat_count: 1,
+            key_is_down: true,
+            raw: None,
+            #[cfg(windows)]
+            win32_uni_char: None,
+        };
+        assert_eq!(multi.encode_kitty(flags), String::new());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

A single-character `Composed` key event — delivered by an IME, or e.g. the Windows emoji picker (Win+.) — is functionally a plain character keypress, but it never carries a backing raw hardware key event (`raw: None`).

`encode_kitty()` had no match arm for `Composed` at all. It fell through to the final catch-all `_` arm, which requires `self.raw` to resolve a kitty function code. With `raw` always `None` for this kind of input, the whole function silently returned an empty string, and the keystroke was written to the pane as zero bytes — dropped outright, with no error surfaced anywhere in the pipeline.

Most visible when the inner application negotiates `REPORT_ALL_KEYS_AS_ESCAPE_CODES` (tmux, [herdr](https://github.com/ogulcancelik/herdr), and similar multiplexers): plain single-codepoint text delivered this way (e.g. picking a single emoji like ☕ or 😀 from the Windows emoji picker) vanishes completely, while multi-codepoint `Composed` strings (VS16 pairs, ZWJ emoji sequences) are unaffected, because `key_event_impl` in `wezterm-gui` routes those through the raw-text path and never calls `encode_kitty` for them at all.

## Root cause, confirmed live

Reproduced with `debug_key_events = true`. The log shows the exact failure:

```
key_event KeyEvent { key: Composed("☕"), modifiers: NONE, ..., raw: None, win32_uni_char: None }
kitty: Encoded input as ""
```

`encode_kitty_input()` in `wezterm-gui/src/termwindow/keyevent.rs` calls `.encode_kitty()` directly on the original, still-`Composed`-wrapped `KeyEvent`. The separate `win_key_code_to_termwiz_key_code()` helper *does* correctly recognize a single-char `Composed` string as "really just a char" — but only for routing purposes (deciding between the Kitty-encode path and the raw-`Composed`-text path); that unwrapped value is discarded and never reaches the actual encoder.

## Fix

Normalize a single-char `Composed` key to `Char` at the top of `encode_kitty()`, so the rest of the function treats it exactly like any other character key. Minimal, surgical — no other match arm touched.

## Tests

- `encode_kitty_single_char_composed_matches_char`: asserts a single-char `Composed` key encodes byte-identically to the equivalent `Char` key, both with and without `REPORT_ASSOCIATED_TEXT`. Verified this test fails cleanly under the prior (pre-fix) behavior by temporarily disabling the new normalization and re-running, then restored the fix and confirmed green again.
- `encode_kitty_multi_char_composed_is_unaffected`: locks in that a genuinely multi-char `Composed` string's behavior in this function is untouched by the fix (it never reaches here via WezTerm's normal routing anyway).

Full existing `wezterm-input-types` suite (15 tests) passes.

## Related

Downstream, this was chased for weeks as a suspected [herdr](https://github.com/ogulcancelik/herdr) bug — herdr shipped a real, correct fix to their own CSI-u parser ([#1404](https://github.com/ogulcancelik/herdr/issues/1404)) that turned out to be unrelated, because WezTerm was never emitting the CSI-u sequence at all for this input. Filing here once the actual root cause was found.