### PR TITLE
macos: bounce dock icon on bell to request user attention

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1243,6 +1243,12 @@ impl TermWindow {
                         AudibleBell::Disabled => {}
                     }
 
+                    // Bounce the dock/taskbar icon to attract the user's
+                    // attention when this window is not in the foreground.
+                    Connection::get()
+                        .expect("on main thread")
+                        .request_attention();
+
                     log::trace!("Ding! (this is the bell) in pane {}", pane_id);
                     self.emit_window_event("bell", Some(pane_id));
 

--- a/window/src/connection.rs
+++ b/window/src/connection.rs
@@ -76,6 +76,12 @@ pub trait ConnectionOps {
     /// Perform the system beep/notification sound
     fn beep(&self) {}
 
+    /// Request user attention via the OS (e.g. macOS dock bounce).
+    /// Implementations should arrange for the application's dock/taskbar
+    /// icon to attract the user's attention. No-ops on platforms without
+    /// such a mechanism.
+    fn request_attention(&self) {}
+
     /// Returns information about the screens
     fn screens(&self) -> anyhow::Result<Screens> {
         anyhow::bail!("Unable to query screen information");

--- a/window/src/os/macos/connection.rs
+++ b/window/src/os/macos/connection.rs
@@ -172,6 +172,17 @@ impl ConnectionOps for Connection {
         }
     }
 
+    fn request_attention(&self) {
+        // NSCriticalRequest: the dock icon bounces continuously until the
+        // user brings the application to the foreground. macOS automatically
+        // suppresses the bounce while this application is already active,
+        // so no explicit focus check is needed here.
+        const NS_CRITICAL_REQUEST: u64 = 1;
+        unsafe {
+            let () = msg_send![NSApp(), requestUserAttention: NS_CRITICAL_REQUEST];
+        }
+    }
+
     fn screens(&self) -> anyhow::Result<Screens> {
         let mut by_name = HashMap::new();
         let mut virtual_rect = euclid::rect(0, 0, 0, 0);


### PR DESCRIPTION
Add a request_attention() method to the ConnectionOps trait (no-op by default) and implement it for macOS via [NSApp requestUserAttention: NSCriticalRequest]. The dock icon bounces continuously until the user brings WezTerm to the foreground; macOS automatically suppresses the bounce while WezTerm is already active, so no explicit focus check is needed.

Trigger it from the Alert::Bell handler so a BEL (`\x07`) received in any pane