### PR TITLE
macOS: compute non-native fullscreen notch inset from the window's own screen, not mainScreen

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -885,9 +885,22 @@ impl WindowOps for Window {
             && !native_full_screen
             && !config.macos_fullscreen_extend_behind_notch
         {
-            let main_screen = unsafe { NSScreen::mainScreen(nil) };
+            // Compute notch avoidance from the window's OWN screen, not
+            // NSScreen::mainScreen. mainScreen is documented as "the screen
+            // containing the window with keyboard focus", so it is
+            // focus-dependent: a non-native fullscreen window on a notchless
+            // external display would otherwise inherit the built-in notched
+            // screen's safeAreaInsets whenever focus moved to that display,
+            // producing a spurious black top border. Fall back to mainScreen
+            // when the window reports no screen (e.g. it is offscreen).
+            let window_screen: id = unsafe { msg_send![self.ns_window, screen] };
+            let screen = if window_screen == nil {
+                unsafe { NSScreen::mainScreen(nil) }
+            } else {
+                window_screen
+            };
             let has_safe_area_insets: BOOL =
-                unsafe { msg_send![main_screen, respondsToSelector: sel!(safeAreaInsets)] };
+                unsafe { msg_send![screen, respondsToSelector: sel!(safeAreaInsets)] };
             if has_safe_area_insets == YES {
                 #[derive(Debug)]
                 struct NSEdgeInsets {
@@ -896,12 +909,12 @@ impl WindowOps for Window {
                     bottom: CGFloat,
                     right: CGFloat,
                 }
-                let insets: NSEdgeInsets = unsafe { msg_send![main_screen, safeAreaInsets] };
+                let insets: NSEdgeInsets = unsafe { msg_send![screen, safeAreaInsets] };
                 log::trace!("{:?}", insets);
 
                 let scale = unsafe {
-                    let frame = NSScreen::frame(main_screen);
-                    let backing_frame = NSScreen::convertRectToBacking_(main_screen, frame);
+                    let frame = NSScreen::frame(screen);
+                    let backing_frame = NSScreen::convertRectToBacking_(screen, frame);
                     backing_frame.size.height / frame.size.height
                 };
 


### PR DESCRIPTION
## Problem
In non-native (borderless) fullscreen with `macos_fullscreen_extend_behind_notch = false`, `WindowInner::get_os_parameters` (`window/src/os/macos/window.rs`) computes the notch/`border_dimensions` inset from `NSScreen::mainScreen().safeAreaInsets`. Per Apple's docs `mainScreen` is the screen with keyboard focus — it is focus-dependent, not the screen the window is on.

## Repro
MacBook with a notch (lid open) + an external display without a notch: put a wezterm window in non-native fullscreen on the external notchless display, then click a window on the built-in notched display to move keyboard focus there. The fullscreen window on the external display gains a black top border equal to the built-in notch height; moving focus back removes it.

## Fix
Derive `safeAreaInsets` and the backing scale from the window's own screen (`[ns_window screen]`) instead of `NSScreen::mainScreen`, with a `mainScreen` fallback when the window reports no screen (e.g. transiently offscreen during a display change). On a notchless display `safeAreaInsets.top` is 0, so no spurious border appears regardless of focus; it also makes the inset correct on the notched display by the window's actual screen. The change is confined to the existing `FULL_SCREEN && !native_full_screen && !macos_fullscreen_extend_behind_notch` branch.

## Testing
Builds cleanly (`cargo build -p window`).
