### PR TITLE
Add a Windows GDI text front_end for Remote Desktop (RDP) - By Vibe Coding for POC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,6 +987,7 @@ dependencies = [
  "wezterm-ssh",
  "wezterm-term",
  "winapi",
+ "winreg",
 ]
 
 [[package]]

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -47,4 +47,5 @@ wezterm-term = { workspace = true, features=["use_serde"] }
 nix = {workspace=true, features=["resource"]}
 
 [target."cfg(windows)".dependencies]
-winapi = { workspace=true, features = ["winuser"]}
+winapi = { workspace=true, features = ["winuser", "processthreadsapi"]}
+winreg = { workspace=true }

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -9,7 +9,7 @@ use crate::font::{
     AllowSquareGlyphOverflow, DisplayPixelGeometry, FontLocatorSelection, FontRasterizerSelection,
     FontShaperSelection, FreeTypeLoadFlags, FreeTypeLoadTarget, StyleRule, TextStyle,
 };
-use crate::frontend::FrontEndSelection;
+use crate::frontend::{default_front_end, FrontEndSelection};
 use crate::keyassignment::{
     KeyAssignment, KeyTable, KeyTableEntry, KeyTables, MouseEventTrigger, SpawnCommand,
 };
@@ -340,7 +340,7 @@ pub struct Config {
     #[dynamic(default = "default_harfbuzz_features")]
     pub harfbuzz_features: Vec<String>,
 
-    #[dynamic(default)]
+    #[dynamic(default = "default_front_end")]
     pub front_end: FrontEndSelection,
 
     /// Whether to select the higher powered discrete GPU when
@@ -1327,6 +1327,11 @@ impl Config {
     /// on those provided by the user.  This is where we do that.
     pub fn compute_extra_defaults(&self, config_path: Option<&Path>) -> Self {
         let mut cfg = self.clone();
+
+        // Resolve the front_end for the current platform. The GDI text renderer
+        // is Windows-only; on other platforms an explicit `Gdi` selection falls
+        // back to OpenGL (with a warning emitted by `resolve()`).
+        cfg.front_end = cfg.front_end.resolve();
 
         // Convert any relative font dirs to their config file relative locations
         if let Some(config_dir) = config_path.as_ref().and_then(|p| p.parent()) {

--- a/config/src/frontend.rs
+++ b/config/src/frontend.rs
@@ -7,6 +7,89 @@ pub enum FrontEndSelection {
     OpenGL,
     WebGpu,
     Software,
+    /// Windows-only GDI text renderer (ExtTextOutW direct-to-HDC).
+    /// On non-Windows platforms this falls back to OpenGL with a warning.
+    Gdi,
+}
+
+impl FrontEndSelection {
+    /// Returns true for the GDI text renderer, which is only meaningful on Windows.
+    pub fn is_gdi(&self) -> bool {
+        matches!(self, FrontEndSelection::Gdi)
+    }
+
+    /// Resolve the selection for the current platform. The GDI renderer is
+    /// Windows-only; if it is somehow selected on another platform we fall back
+    /// to OpenGL with a logged warning.
+    pub fn resolve(self) -> FrontEndSelection {
+        #[cfg(not(windows))]
+        {
+            if matches!(self, FrontEndSelection::Gdi) {
+                log::warn!(
+                    "front_end=\"Gdi\" is only supported on Windows; falling back to OpenGL"
+                );
+                return FrontEndSelection::OpenGL;
+            }
+        }
+        self
+    }
+}
+
+/// Returns true if we are running in an RDP session.
+/// Mirrors `window::os::windows::is_running_in_rdp_session`, duplicated here
+/// because the `config` crate cannot depend on the `window` crate.
+/// See <https://docs.microsoft.com/en-us/windows/win32/termserv/detecting-the-terminal-services-environment>
+#[cfg(windows)]
+fn is_running_in_rdp_session() -> bool {
+    use winapi::shared::minwindef::DWORD;
+    use winapi::um::processthreadsapi::{GetCurrentProcessId, ProcessIdToSessionId};
+    use winapi::um::winuser::{GetSystemMetrics, SM_REMOTESESSION};
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+    use winreg::RegKey;
+
+    if unsafe { GetSystemMetrics(SM_REMOTESESSION) } != 0 {
+        return true;
+    }
+
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    let terminal_server =
+        match hklm.open_subkey("SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\") {
+            Ok(k) => k,
+            Err(_) => return false,
+        };
+
+    let glass_session_id: DWORD = match terminal_server.get_value("GlassSessionId") {
+        Ok(sess) => sess,
+        Err(_) => return false,
+    };
+
+    unsafe {
+        let mut current_session = 0;
+        if ProcessIdToSessionId(GetCurrentProcessId(), &mut current_session) != 0 {
+            current_session != glass_session_id
+        } else {
+            false
+        }
+    }
+}
+
+/// Default value for `front_end` when the user has not set it explicitly.
+///
+/// On Windows, when running inside an RDP session we default to `Software`
+/// rendering (a mature, full-feature path), matching the historical behavior.
+/// The GDI text renderer (`Gdi`) remotes output as text and is much lighter over
+/// RDP, but is an MVP that does not yet render overlay/modal UI, so it is
+/// opt-in rather than auto-selected. An explicit `front_end` always wins because
+/// this function is only consulted when the field is unset.
+pub fn default_front_end() -> FrontEndSelection {
+    #[cfg(windows)]
+    {
+        if is_running_in_rdp_session() {
+            log::trace!("Running in an RDP session, defaulting front_end to Software");
+            return FrontEndSelection::Software;
+        }
+    }
+    FrontEndSelection::OpenGL
 }
 
 /// Corresponds to <https://docs.rs/wgpu/latest/wgpu/struct.AdapterInfo.html>

--- a/docs/config/lua/config/front_end.md
+++ b/docs/config/lua/config/front_end.md
@@ -5,12 +5,15 @@ tags:
 # `front_end = "OpenGL"`
 
 Specifies which render front-end to use.  This option used to have
-more scope in earlier versions of wezterm, but today it allows three
+more scope in earlier versions of wezterm, but today it allows these
 possible values:
 
 * `OpenGL` - use GPU accelerated rasterization
 * `Software` - use CPU-based rasterization.
 * `WebGpu` - use GPU accelerated rasterization {{since('20221119-145034-49b9839f', inline=True)}}
+* `Gdi` - Windows-only text renderer that draws directly to the window with
+  GDI (`ExtTextOutW`). Intended for Remote Desktop (RDP) sessions. See
+  [the Gdi section](#gdi) below.
 
 {{since('20240127-113634-bbcac864', outline=true)}}
     The default is `"WebGpu"`. In earlier versions it was `"OpenGL"`
@@ -21,8 +24,66 @@ possible values:
 You may wish (or need!) to select `Software` if there are issues with your
 GPU/OpenGL drivers.
 
-WezTerm will automatically select `Software` if it detects that it is
-being started in a Remote Desktop environment on Windows.
+On Windows, when `front_end` is left unset and WezTerm detects that it is
+running inside a Remote Desktop (RDP) session, it defaults to `"Software"`
+(as in prior releases). The new `"Gdi"` renderer is much lighter over RDP but is
+currently opt-in (see below). An explicit `front_end` in your config always
+wins.
+
+!!! note "Behavior change"
+    In an RDP session, an explicit `front_end = "OpenGL"` is now honored
+    (previously it was silently forced to software rendering). OpenGL over RDP
+    can behave poorly on disconnect; prefer `"Software"` or `"Gdi"` there.
+
+## Gdi
+
+The `Gdi` front end is a Windows-only text renderer that paints terminal
+output directly to the window device context using GDI (`ExtTextOutW`),
+without creating any OpenGL/WebGpu context.
+
+Its purpose is Remote Desktop: RDP remotes GDI text/glyph drawing operations
+as text, whereas the GPU front ends (and `Software`) present an opaque
+framebuffer that RDP must screen-scrape and video-encode every frame. In a
+typical RDP/Hyper-V session that exposes no 3D GPU this makes `Gdi`
+substantially more responsive and much lighter on network bandwidth, similar
+to how Windows Terminal behaves over RDP.
+
+It is Windows-only and currently opt-in; request it explicitly:
+
+```lua
+config.front_end = "Gdi"
+```
+
+Fonts and cell metrics in `Gdi` mode come from GDI (`GetTextMetrics`) for the
+configured primary font family and `font_size`, so glyph positioning may differ
+slightly from the GPU front ends; this is intentional to guarantee that glyphs
+fit the grid.
+
+To reduce RDP traffic, `Gdi` only repaints lines that changed since the last
+frame (tracked via per-line sequence numbers), plus the cursor's previous/next
+cell and rows whose selection changed. Scrolling, resizing, focus changes and
+config reloads trigger a full repaint.
+
+### Supported in `Gdi` mode
+
+* Truecolor foreground/background, reverse video
+* Bold / italic / underline / strikethrough
+* Wide (CJK) cells
+* Block / bar / underline cursor (hollow block when unfocused)
+* Selection highlight
+* A minimal tab strip built from `format-tab-title`
+
+### Not supported in `Gdi` mode (MVP limitations)
+
+* Ligatures / HarfBuzz shaping (drawing is per-cell)
+* Images (sixel / iTerm / kitty), custom shaders, background images,
+  blur/retro effects, and animated cursor/visual bell
+* IME/composition rendering is best-effort
+* Overlay/modal UI that is drawn via the GPU box-model — the command palette and
+  the character/pane selectors — is not yet rendered in `Gdi` mode (it depends on
+  the GPU glyph atlas). Note that *overlay panes* (launcher, copy-mode, the
+  fuzzy selector, prompts) render normally, and tab-bar mouse clicks work.
+* On non-Windows platforms, `Gdi` falls back to `OpenGL` with a warning.
 
 ## WebGpu
 

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -111,6 +111,7 @@ window.workspace = true
 shared_library.workspace = true
 winapi = { workspace=true, features = [
     "winuser",
+    "wingdi",
     "consoleapi",
     "handleapi",
     "fileapi",

--- a/wezterm-gui/src/termwindow/gdi/draw.rs
+++ b/wezterm-gui/src/termwindow/gdi/draw.rs
@@ -1,0 +1,653 @@
+//! Cell/run drawing for the GDI text front_end.
+//!
+//! Walks the visible lines of each pane and produces GDI draw commands: an
+//! `ExtTextOutW` with `ETO_OPAQUE` per cell run (which paints the background and
+//! the glyph in a single call, so RDP remotes it as text), plus manually drawn
+//! underline/strikethrough and the cursor.
+//!
+//! Phase 1 is a full-redraw baseline: every visible cell is emitted each paint.
+//! Phase 2 will restrict this to dirty lines.
+
+use super::font::FontStyleKey;
+use super::{colorref, GdiState};
+use crate::termwindow::TermWindow;
+use config::DimensionContext;
+use termwiz::cell::{CellAttributes, Intensity, Underline};
+use termwiz::surface::{CursorShape, CursorVisibility};
+use wezterm_term::color::{ColorAttribute, ColorPalette};
+use wezterm_term::StableRowIndex;
+use winapi::shared::windef::{HDC, RECT};
+use winapi::um::wingdi::{
+    CreateSolidBrush, DeleteObject, ExtTextOutW, SelectObject, SetBkColor, SetTextColor,
+    ETO_CLIPPED, ETO_OPAQUE,
+};
+use winapi::um::winuser::FillRect;
+
+/// Resolve a cell's foreground/background to GDI `COLORREF`s, applying the
+/// default-color fast path and reverse-video swap. Selection override (if any)
+/// is layered on by the caller.
+fn resolve_fg_bg(
+    palette: &ColorPalette,
+    attrs: &CellAttributes,
+    default_fg: u32,
+    default_bg: u32,
+) -> (u32, u32) {
+    let fg_attr = attrs.foreground();
+    let bg_attr = attrs.background();
+    let mut fg = if fg_attr == ColorAttribute::Default {
+        default_fg
+    } else {
+        colorref(palette.resolve_fg(fg_attr))
+    };
+    let mut bg = if bg_attr == ColorAttribute::Default {
+        default_bg
+    } else {
+        colorref(palette.resolve_bg(bg_attr))
+    };
+    if attrs.reverse() {
+        std::mem::swap(&mut fg, &mut bg);
+    }
+    (fg, bg)
+}
+
+/// A single drawable cell run. For Phase 1 each cell is emitted individually so
+/// that combining characters and wide glyphs stay correct without a per-glyph
+/// `dx` array; run batching is a Phase 2 optimization.
+pub(crate) struct GdiCell {
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    text: Vec<u16>,
+    fg: u32,
+    bg: u32,
+    style: FontStyleKey,
+    underline: bool,
+    strike: bool,
+}
+
+/// A cursor to overlay after the cells are drawn.
+pub(crate) struct GdiCursor {
+    x: i32,
+    y: i32,
+    w: i32,
+    h: i32,
+    shape: CursorShape,
+    bg: u32,
+    fg: u32,
+    focused: bool,
+    text: Vec<u16>,
+    text_style: FontStyleKey,
+}
+
+#[derive(Default)]
+pub(crate) struct GdiFrameData {
+    pub cells: Vec<GdiCell>,
+    pub cursors: Vec<GdiCursor>,
+    /// When true, the caller should clear the whole client area before drawing
+    /// (full redraw). When false, only changed cells are present and the
+    /// previous frame's pixels are left in place (incremental).
+    pub full_clear: bool,
+}
+
+impl TermWindow {
+    /// Collect the GDI draw commands for the current frame. Uses GDI cell
+    /// metrics (`cw`/`ch`) for pixel positioning.
+    pub(crate) fn gdi_collect_frame(&mut self, cw: i32, ch: i32) -> GdiFrameData {
+        let mut data = GdiFrameData::default();
+
+        // Rebuild mouse hit-test regions from scratch each frame, mirroring the
+        // GPU paint_pass which clears `ui_items` at the start of every paint.
+        self.ui_items.clear();
+
+        let panes = self.get_panes_to_render();
+        if panes.is_empty() {
+            // Nothing to render (e.g. window tearing down); clear so we don't
+            // leave the previous frame's pixels on screen.
+            data.full_clear = true;
+            if let Some(g) = self.gdi.as_mut() {
+                g.pane_states.clear();
+                g.last_layout.clear();
+                g.needs_full_paint = false;
+            }
+            return data;
+        }
+
+        // Phase 2 damage tracking: pull the per-pane paint state out of GdiState
+        // so we can borrow `self` for pane/selection access, then write it back.
+        let needs_full = self
+            .gdi
+            .as_ref()
+            .map(|g| g.needs_full_paint)
+            .unwrap_or(true);
+        let mut pane_states = self
+            .gdi
+            .as_mut()
+            .map(|g| std::mem::take(&mut g.pane_states))
+            .unwrap_or_default();
+
+        // Layout signature: a change (split/close/move/zoom) can relocate
+        // unchanged lines, so force a full redraw when it differs.
+        let layout: Vec<(mux::pane::PaneId, usize, usize, usize, usize, bool)> = panes
+            .iter()
+            .map(|p| {
+                (
+                    p.pane.pane_id(),
+                    p.left,
+                    p.top,
+                    p.width,
+                    p.height,
+                    p.is_active,
+                )
+            })
+            .collect();
+        let layout_changed = self
+            .gdi
+            .as_ref()
+            .map(|g| g.last_layout != layout)
+            .unwrap_or(true);
+
+        // Pre-pass: a viewport-top change means the pane scrolled, which seqno
+        // tracking can't express (moved lines keep their old seqno). Any scroll,
+        // newly-seen pane, or layout change forces a full-frame clear+redraw so
+        // we never leave stale pixels or mix a clear with per-pane incremental
+        // draws.
+        let mut full = needs_full || layout_changed;
+        for pos in &panes {
+            let pane_id = pos.pane.pane_id();
+            let dims = pos.pane.get_dimensions();
+            let stable_top = self.get_viewport(pane_id).unwrap_or(dims.physical_top);
+            match pane_states.get(&pane_id) {
+                Some(s) if s.top == stable_top => {}
+                _ => full = true,
+            }
+        }
+        data.full_clear = full;
+
+        // Ensure the palette is initialized, then borrow it (avoid cloning the
+        // whole 256-entry palette every frame).
+        self.palette();
+        let palette = self.palette.as_ref().unwrap();
+        let focused = self.focused.is_some();
+
+        // Window padding (in the GDI metric space) and tab bar reservation.
+        let dpi = self.dimensions.dpi as f32;
+        let ctx_h = DimensionContext {
+            dpi,
+            pixel_max: self.dimensions.pixel_width as f32,
+            pixel_cell: cw as f32,
+        };
+        let ctx_v = DimensionContext {
+            dpi,
+            pixel_max: self.dimensions.pixel_height as f32,
+            pixel_cell: ch as f32,
+        };
+        let pad_left = self.config.window_padding.left.evaluate_as_pixels(ctx_h) as i32;
+        let pad_top = self.config.window_padding.top.evaluate_as_pixels(ctx_v) as i32;
+        let tab_at_bottom = self.config.tab_bar_at_bottom;
+        let tab_bar_h = if self.show_tab_bar && !tab_at_bottom {
+            ch
+        } else {
+            0
+        };
+
+        let default_fg = colorref(palette.foreground);
+        let default_bg = colorref(palette.background);
+        let sel_fg = colorref(palette.selection_fg);
+        let sel_bg = colorref(palette.selection_bg);
+        let cursor_bg = colorref(palette.cursor_bg);
+        let cursor_fg = colorref(palette.cursor_fg);
+
+        for pos in &panes {
+            let pane = &pos.pane;
+            let pane_id = pane.pane_id();
+
+            let dims = pane.get_dimensions();
+            let viewport = self.get_viewport(pane_id);
+            let stable_top = viewport.unwrap_or(dims.physical_top);
+            let stable_range = stable_top..stable_top + pos.height as isize;
+
+            let (first_row, lines) = pane.get_lines(stable_range);
+
+            // Selection for this pane.
+            let (sel_range, sel_rect) = {
+                let sel = self.selection(pane_id);
+                (sel.range, sel.rectangular)
+            };
+
+            // Cursor (only for the active pane, when visible).
+            let cursor = pane.get_cursor_position();
+            let cursor_visible = pos.is_active && cursor.visibility == CursorVisibility::Visible;
+
+            // Damage tracking: which stable rows must be redrawn this frame.
+            let cur_seqno = pane.get_current_seqno();
+            let prev_state = pane_states.get(&pane_id).cloned().unwrap_or_default();
+            let changed = if full {
+                None
+            } else {
+                Some(pane.get_changed_since(
+                    first_row..first_row + lines.len() as isize,
+                    prev_state.last_seqno,
+                ))
+            };
+
+            // Current selection (range + rectangular) and whether it changed.
+            let cur_sel = sel_range.map(|r| (r, sel_rect));
+            let sel_changed = cur_sel != prev_state.selection;
+            let cur_sel_rows = sel_range.map(|r| r.rows());
+            let prev_sel_rows = prev_state.selection.as_ref().map(|(r, _)| r.rows());
+
+            // A row is dirty if: content changed since last paint, the cursor is
+            // on it now or was last frame, or its selection state changed
+            // (including horizontal changes on an already-selected row).
+            let row_is_dirty = |stable_row: StableRowIndex| -> bool {
+                if full {
+                    return true;
+                }
+                if let Some(changed) = &changed {
+                    if changed.contains(stable_row) {
+                        return true;
+                    }
+                }
+                if cursor_visible && cursor.y == stable_row {
+                    return true;
+                }
+                if let Some((_, prev_row)) = prev_state.cursor {
+                    if prev_row == stable_row {
+                        return true;
+                    }
+                }
+                if sel_changed {
+                    let in_now = cur_sel_rows
+                        .as_ref()
+                        .map(|r| r.contains(&stable_row))
+                        .unwrap_or(false);
+                    let in_prev = prev_sel_rows
+                        .as_ref()
+                        .map(|r| r.contains(&stable_row))
+                        .unwrap_or(false);
+                    if in_now || in_prev {
+                        return true;
+                    }
+                }
+                false
+            };
+
+            let origin_x = pad_left + pos.left as i32 * cw;
+            let origin_y = pad_top + tab_bar_h + pos.top as i32 * ch;
+
+            for (line_idx, line) in lines.iter().enumerate() {
+                let stable_row = first_row + line_idx as isize;
+                if !row_is_dirty(stable_row) {
+                    continue;
+                }
+                let y = origin_y + line_idx as i32 * ch;
+
+                let sel_cols = sel_range.and_then(|r| {
+                    if r.rows().contains(&stable_row) {
+                        Some(r.cols_for_row(stable_row, sel_rect))
+                    } else {
+                        None
+                    }
+                });
+
+                let mut next_col = 0usize;
+                for cell in line.visible_cells() {
+                    let idx = cell.cell_index();
+                    let width = cell.width().max(1);
+                    next_col = idx + width;
+                    let x = origin_x + idx as i32 * cw;
+                    let w = width as i32 * cw;
+
+                    let attrs = cell.attrs();
+
+                    let (mut fg_ref, mut bg_ref) =
+                        resolve_fg_bg(&palette, attrs, default_fg, default_bg);
+
+                    // Selection overrides colors.
+                    let selected = sel_cols
+                        .as_ref()
+                        .map(|cols| cols.contains(&idx))
+                        .unwrap_or(false);
+                    if selected {
+                        fg_ref = sel_fg;
+                        bg_ref = sel_bg;
+                    }
+
+                    let bold = attrs.intensity() == Intensity::Bold;
+                    let italic = attrs.italic();
+                    let style = super::font::GdiFonts::style_for(bold, italic);
+
+                    let text: Vec<u16> = if attrs.invisible() {
+                        Vec::new()
+                    } else {
+                        cell.str().encode_utf16().collect()
+                    };
+
+                    data.cells.push(GdiCell {
+                        x,
+                        y,
+                        w,
+                        h: ch,
+                        text,
+                        fg: fg_ref,
+                        bg: bg_ref,
+                        style,
+                        underline: attrs.underline() != Underline::None,
+                        strike: attrs.strikethrough(),
+                    });
+                }
+
+                // Cover trailing columns past the end of the line content. A
+                // `Line` may omit trailing default blanks, so on an incremental
+                // frame stale glyphs/backgrounds could remain; emit one opaque
+                // blank span (default background) across the remaining width.
+                if next_col < pos.width {
+                    let x = origin_x + next_col as i32 * cw;
+                    let w = (pos.width - next_col) as i32 * cw;
+                    data.cells.push(GdiCell {
+                        x,
+                        y,
+                        w,
+                        h: ch,
+                        text: Vec::new(),
+                        fg: default_fg,
+                        bg: default_bg,
+                        style: super::font::FontStyleKey::Regular,
+                        underline: false,
+                        strike: false,
+                    });
+                }
+            }
+
+            if cursor_visible {
+                // Locate the cursor cell relative to the rendered viewport.
+                // Use `first_row` (the range actually returned by get_lines,
+                // which may be clamped at the scrollback top) so the cursor row
+                // and glyph lookup match the cell loop's `first_row + line_idx`.
+                let screen_row = cursor.y - first_row;
+                if screen_row >= 0 && (screen_row as usize) < lines.len() {
+                    let x = origin_x + cursor.x as i32 * cw;
+                    let y = origin_y + screen_row as i32 * ch;
+
+                    // Recover the glyph under the cursor for block redraw.
+                    let (glyph, glyph_style) = lines
+                        .get(screen_row as usize)
+                        .and_then(|line| {
+                            line.visible_cells()
+                                .find(|c| c.cell_index() == cursor.x)
+                                .map(|c| {
+                                    let a = c.attrs();
+                                    (
+                                        c.str().encode_utf16().collect::<Vec<u16>>(),
+                                        super::font::GdiFonts::style_for(
+                                            a.intensity() == Intensity::Bold,
+                                            a.italic(),
+                                        ),
+                                    )
+                                })
+                        })
+                        .unwrap_or_else(|| (Vec::new(), FontStyleKey::Regular));
+
+                    data.cursors.push(GdiCursor {
+                        x,
+                        y,
+                        w: cw,
+                        h: ch,
+                        shape: self
+                            .config
+                            .default_cursor_style
+                            .effective_shape(cursor.shape),
+                        bg: cursor_bg,
+                        fg: cursor_fg,
+                        focused,
+                        text: glyph,
+                        text_style: glyph_style,
+                    });
+                }
+            }
+
+            // Record this pane's paint state for the next frame's damage calc.
+            pane_states.insert(
+                pane_id,
+                super::PanePaintState {
+                    last_seqno: cur_seqno,
+                    top: stable_top,
+                    cursor: if cursor_visible {
+                        Some((cursor.x, cursor.y))
+                    } else {
+                        None
+                    },
+                    selection: cur_sel,
+                },
+            );
+        }
+
+        // Tab strip: render the formatted tab-bar Line (which already carries
+        // the format-tab-title colors) as a single row at the top or bottom.
+        if self.show_tab_bar {
+            let y = if tab_at_bottom {
+                (self.dimensions.pixel_height as i32 - ch).max(0)
+            } else {
+                0
+            };
+
+            // Register tab-bar mouse hit regions every frame (ui_items were
+            // cleared above and are consumed by mouse hit-testing), regardless
+            // of whether the strip pixels need redrawing this frame.
+            let mut items = self.tab_bar.compute_ui_items(
+                y.max(0) as usize,
+                ch.max(1) as usize,
+                cw.max(1) as usize,
+            );
+            self.ui_items.append(&mut items);
+
+            // Compare by reference (no clone) to decide whether to redraw pixels.
+            let tab_changed = full
+                || self
+                    .gdi
+                    .as_ref()
+                    .map(|g| g.last_tab_bar.as_ref() != Some(self.tab_bar.line()))
+                    .unwrap_or(true);
+            if tab_changed {
+                let mut next_col = 0usize;
+                for cell in self.tab_bar.line().visible_cells() {
+                    let idx = cell.cell_index();
+                    let width = cell.width().max(1);
+                    next_col = idx + width;
+                    let x = idx as i32 * cw;
+                    let w = width as i32 * cw;
+                    let attrs = cell.attrs();
+
+                    let (fg_ref, bg_ref) = resolve_fg_bg(&palette, attrs, default_fg, default_bg);
+
+                    data.cells.push(GdiCell {
+                        x,
+                        y,
+                        w,
+                        h: ch,
+                        text: cell.str().encode_utf16().collect(),
+                        fg: fg_ref,
+                        bg: bg_ref,
+                        style: super::font::GdiFonts::style_for(
+                            attrs.intensity() == Intensity::Bold,
+                            attrs.italic(),
+                        ),
+                        underline: attrs.underline() != Underline::None,
+                        strike: attrs.strikethrough(),
+                    });
+                }
+
+                // Cover trailing columns past the end of the tab line so a
+                // shorter tab bar on an incremental frame doesn't leave stale
+                // pixels to the right.
+                let total_cols = (self.dimensions.pixel_width / cw.max(1) as usize).max(0);
+                if next_col < total_cols {
+                    let x = next_col as i32 * cw;
+                    let w = (total_cols - next_col) as i32 * cw;
+                    data.cells.push(GdiCell {
+                        x,
+                        y,
+                        w,
+                        h: ch,
+                        text: Vec::new(),
+                        fg: default_fg,
+                        bg: default_bg,
+                        style: super::font::FontStyleKey::Regular,
+                        underline: false,
+                        strike: false,
+                    });
+                }
+
+                if let Some(g) = self.gdi.as_mut() {
+                    g.last_tab_bar = Some(self.tab_bar.line().clone());
+                }
+            }
+        }
+
+        // Write back the damage-tracking state and clear the full-paint flag.
+        // Drop paint state for panes that are no longer present.
+        let live_ids: std::collections::HashSet<mux::pane::PaneId> =
+            layout.iter().map(|l| l.0).collect();
+        pane_states.retain(|id, _| live_ids.contains(id));
+        if let Some(g) = self.gdi.as_mut() {
+            g.pane_states = pane_states;
+            g.last_layout = layout;
+            g.needs_full_paint = false;
+        }
+
+        data
+    }
+}
+
+impl GdiState {
+    /// Render the collected frame data to `hdc`. Assumes the background has
+    /// already been cleared and text alignment/bk mode are set.
+    pub(crate) unsafe fn render_frame(&self, hdc: HDC, data: &GdiFrameData) {
+        for cell in &data.cells {
+            self.draw_cell(hdc, cell);
+        }
+        for cursor in &data.cursors {
+            self.draw_cursor(hdc, cursor);
+        }
+    }
+
+    unsafe fn draw_cell(&self, hdc: HDC, cell: &GdiCell) {
+        let fonts = match &self.fonts {
+            Some(f) => f,
+            None => return,
+        };
+
+        let rect = RECT {
+            left: cell.x,
+            top: cell.y,
+            right: cell.x + cell.w,
+            bottom: cell.y + cell.h,
+        };
+
+        SetTextColor(hdc, cell.fg);
+        SetBkColor(hdc, cell.bg);
+        let prev = fonts.select(hdc, cell.style);
+
+        ExtTextOutW(
+            hdc,
+            cell.x,
+            cell.y,
+            ETO_OPAQUE | ETO_CLIPPED,
+            &rect,
+            cell.text.as_ptr(),
+            cell.text.len() as u32,
+            std::ptr::null(),
+        );
+
+        SelectObject(hdc, prev);
+
+        if cell.underline {
+            self.fill_line(hdc, cell.x, cell.y + cell.h - 2, cell.w, 1, cell.fg);
+        }
+        if cell.strike {
+            self.fill_line(hdc, cell.x, cell.y + cell.h / 2, cell.w, 1, cell.fg);
+        }
+    }
+
+    unsafe fn draw_cursor(&self, hdc: HDC, cursor: &GdiCursor) {
+        // When the window is not focused, every cursor shape renders as a hollow
+        // block outline (matching the GPU renderer and the docs).
+        if !cursor.focused {
+            self.fill_line(hdc, cursor.x, cursor.y, cursor.w, 1, cursor.bg);
+            self.fill_line(
+                hdc,
+                cursor.x,
+                cursor.y + cursor.h - 1,
+                cursor.w,
+                1,
+                cursor.bg,
+            );
+            self.fill_line(hdc, cursor.x, cursor.y, 1, cursor.h, cursor.bg);
+            self.fill_line(
+                hdc,
+                cursor.x + cursor.w - 1,
+                cursor.y,
+                1,
+                cursor.h,
+                cursor.bg,
+            );
+            return;
+        }
+        match cursor.shape {
+            CursorShape::BlinkingBar | CursorShape::SteadyBar => {
+                self.fill_line(hdc, cursor.x, cursor.y, 2, cursor.h, cursor.bg);
+            }
+            CursorShape::BlinkingUnderline | CursorShape::SteadyUnderline => {
+                self.fill_line(
+                    hdc,
+                    cursor.x,
+                    cursor.y + cursor.h - 2,
+                    cursor.w,
+                    2,
+                    cursor.bg,
+                );
+            }
+            // Default and block shapes (focused): filled block with inverted
+            // glyph.
+            _ => {
+                let rect = RECT {
+                    left: cursor.x,
+                    top: cursor.y,
+                    right: cursor.x + cursor.w,
+                    bottom: cursor.y + cursor.h,
+                };
+                SetTextColor(hdc, cursor.fg);
+                SetBkColor(hdc, cursor.bg);
+                if let Some(fonts) = &self.fonts {
+                    let prev = fonts.select(hdc, cursor.text_style);
+                    ExtTextOutW(
+                        hdc,
+                        cursor.x,
+                        cursor.y,
+                        ETO_OPAQUE | ETO_CLIPPED,
+                        &rect,
+                        cursor.text.as_ptr(),
+                        cursor.text.len() as u32,
+                        std::ptr::null(),
+                    );
+                    SelectObject(hdc, prev);
+                }
+            }
+        }
+    }
+
+    unsafe fn fill_line(&self, hdc: HDC, x: i32, y: i32, w: i32, h: i32, color: u32) {
+        let rect = RECT {
+            left: x,
+            top: y,
+            right: x + w,
+            bottom: y + h,
+        };
+        let brush = CreateSolidBrush(color);
+        if !brush.is_null() {
+            FillRect(hdc, &rect, brush);
+            DeleteObject(brush as _);
+        }
+    }
+}

--- a/wezterm-gui/src/termwindow/gdi/draw.rs
+++ b/wezterm-gui/src/termwindow/gdi/draw.rs
@@ -18,8 +18,7 @@ use wezterm_term::color::{ColorAttribute, ColorPalette};
 use wezterm_term::StableRowIndex;
 use winapi::shared::windef::{HDC, RECT};
 use winapi::um::wingdi::{
-    CreateSolidBrush, DeleteObject, ExtTextOutW, SelectObject, SetBkColor, SetTextColor,
-    ETO_CLIPPED, ETO_OPAQUE,
+    CreateSolidBrush, DeleteObject, ExtTextOutW, SelectObject, SetBkColor, SetTextColor, ETO_OPAQUE,
 };
 use winapi::um::winuser::FillRect;
 
@@ -553,7 +552,7 @@ impl GdiState {
             hdc,
             cell.x,
             cell.y,
-            ETO_OPAQUE | ETO_CLIPPED,
+            ETO_OPAQUE,
             &rect,
             cell.text.as_ptr(),
             cell.text.len() as u32,
@@ -625,7 +624,7 @@ impl GdiState {
                         hdc,
                         cursor.x,
                         cursor.y,
-                        ETO_OPAQUE | ETO_CLIPPED,
+                        ETO_OPAQUE,
                         &rect,
                         cursor.text.as_ptr(),
                         cursor.text.len() as u32,

--- a/wezterm-gui/src/termwindow/gdi/font.rs
+++ b/wezterm-gui/src/termwindow/gdi/font.rs
@@ -1,0 +1,177 @@
+//! GDI font management for the GDI text front_end.
+//!
+//! Creates the four `HFONT` style variants (regular / bold / italic /
+//! bold-italic) from the configured primary font family and size, and derives
+//! fixed cell metrics from GDI `GetTextMetrics`. In GDI mode we deliberately use
+//! GDI's own metrics for cell sizing so that `ExtTextOutW` glyph placement is
+//! guaranteed to fit the grid, at the cost of small differences from the GPU
+//! path's freetype/harfbuzz metrics.
+
+use std::ptr::null_mut;
+use winapi::shared::windef::{HDC, HFONT};
+use winapi::um::wingdi::{
+    CreateFontW, DeleteObject, GetTextMetricsW, SelectObject, CLIP_DEFAULT_PRECIS, DEFAULT_CHARSET,
+    FF_MODERN, FIXED_PITCH, FW_BOLD, FW_NORMAL, OUT_TT_PRECIS, PROOF_QUALITY, TEXTMETRICW,
+};
+use winapi::um::winuser::{GetDC, ReleaseDC};
+
+/// Convert a `&str` to a NUL-terminated UTF-16 buffer for the Win32 W APIs.
+fn wide(s: &str) -> Vec<u16> {
+    s.encode_utf16().chain(std::iter::once(0)).collect()
+}
+
+/// The four style variants used when drawing cells.
+#[derive(Copy, Clone, Debug)]
+pub enum FontStyleKey {
+    Regular,
+    Bold,
+    Italic,
+    BoldItalic,
+}
+
+/// Owns the GDI `HFONT`s and the derived cell metrics.
+pub struct GdiFonts {
+    regular: HFONT,
+    bold: HFONT,
+    italic: HFONT,
+    bold_italic: HFONT,
+
+    /// Fixed advance width of a cell, in device pixels.
+    pub cell_width: i32,
+    /// Full line height of a cell, in device pixels.
+    pub cell_height: i32,
+
+    /// Remember how we were built so we can detect when a rebuild is required.
+    family: String,
+    point_size: f64,
+    dpi: usize,
+}
+
+unsafe fn create_font(family_w: &[u16], height: i32, weight: i32, italic: u32) -> HFONT {
+    CreateFontW(
+        height,
+        0, // width: 0 = choose based on aspect ratio
+        0, // escapement
+        0, // orientation
+        weight,
+        italic,
+        0, // underline (drawn manually)
+        0, // strikeout (drawn manually)
+        DEFAULT_CHARSET,
+        OUT_TT_PRECIS,
+        CLIP_DEFAULT_PRECIS,
+        PROOF_QUALITY,
+        FIXED_PITCH | FF_MODERN,
+        family_w.as_ptr(),
+    )
+}
+
+impl GdiFonts {
+    /// Build the font set for `family` at `point_size` points and the given
+    /// `dpi`. Returns an error only if the base regular font cannot be created.
+    pub fn new(family: &str, point_size: f64, dpi: usize) -> anyhow::Result<Self> {
+        // GDI logical height: negate to request a cell (character) height that
+        // maps the requested point size at this DPI.
+        let height = -((point_size * dpi as f64 / 72.0).round() as i32);
+        let family_w = wide(family);
+
+        let (regular, bold, italic, bold_italic);
+        unsafe {
+            regular = create_font(&family_w, height, FW_NORMAL, 0);
+            if regular.is_null() {
+                anyhow::bail!("CreateFontW failed for family {family:?}");
+            }
+            bold = create_font(&family_w, height, FW_BOLD, 0);
+            italic = create_font(&family_w, height, FW_NORMAL, 1);
+            bold_italic = create_font(&family_w, height, FW_BOLD, 1);
+        }
+        // Fall back to the regular face for any variant GDI could not create, so
+        // SelectObject is never handed a null handle.
+        let bold = if bold.is_null() { regular } else { bold };
+        let italic = if italic.is_null() { regular } else { italic };
+        let bold_italic = if bold_italic.is_null() {
+            regular
+        } else {
+            bold_italic
+        };
+
+        // Measure cell metrics using a screen DC.
+        let (cell_width, cell_height) = unsafe {
+            let hdc = GetDC(null_mut());
+            let prev = SelectObject(hdc, regular as _);
+            let mut tm: TEXTMETRICW = std::mem::zeroed();
+            GetTextMetricsW(hdc, &mut tm);
+            SelectObject(hdc, prev);
+            ReleaseDC(null_mut(), hdc);
+            (
+                tm.tmAveCharWidth.max(1),
+                (tm.tmHeight + tm.tmExternalLeading).max(1),
+            )
+        };
+
+        log::debug!(
+            "GdiFonts: family={family:?} point_size={point_size} dpi={dpi} \
+             cell={cell_width}x{cell_height}"
+        );
+
+        Ok(Self {
+            regular,
+            bold,
+            italic,
+            bold_italic,
+            cell_width,
+            cell_height,
+            family: family.to_string(),
+            point_size,
+            dpi,
+        })
+    }
+
+    /// Return the `HFONT` for the given style variant.
+    pub fn hfont(&self, style: FontStyleKey) -> HFONT {
+        match style {
+            FontStyleKey::Regular => self.regular,
+            FontStyleKey::Bold => self.bold,
+            FontStyleKey::Italic => self.italic,
+            FontStyleKey::BoldItalic => self.bold_italic,
+        }
+    }
+
+    /// Map bold/italic attribute flags to the appropriate style variant.
+    pub fn style_for(bold: bool, italic: bool) -> FontStyleKey {
+        match (bold, italic) {
+            (false, false) => FontStyleKey::Regular,
+            (true, false) => FontStyleKey::Bold,
+            (false, true) => FontStyleKey::Italic,
+            (true, true) => FontStyleKey::BoldItalic,
+        }
+    }
+
+    /// Select the requested style's `HFONT` into `hdc`, returning the previously
+    /// selected object so the caller can restore it.
+    pub unsafe fn select(&self, hdc: HDC, style: FontStyleKey) -> *mut winapi::ctypes::c_void {
+        SelectObject(hdc, self.hfont(style) as _)
+    }
+
+    /// True if this font set was built for different parameters and should be
+    /// recreated.
+    pub fn needs_rebuild(&self, family: &str, point_size: f64, dpi: usize) -> bool {
+        self.family != family || self.point_size != point_size || self.dpi != dpi
+    }
+}
+
+impl Drop for GdiFonts {
+    fn drop(&mut self) {
+        unsafe {
+            // Delete each distinct handle once; variants may alias `regular`
+            // when GDI failed to create a bold/italic face.
+            let mut seen: Vec<HFONT> = Vec::new();
+            for f in [self.regular, self.bold, self.italic, self.bold_italic] {
+                if !f.is_null() && !seen.contains(&f) {
+                    DeleteObject(f as _);
+                    seen.push(f);
+                }
+            }
+        }
+    }
+}

--- a/wezterm-gui/src/termwindow/gdi/font.rs
+++ b/wezterm-gui/src/termwindow/gdi/font.rs
@@ -10,8 +10,9 @@
 use std::ptr::null_mut;
 use winapi::shared::windef::{HDC, HFONT};
 use winapi::um::wingdi::{
-    CreateFontW, DeleteObject, GetTextMetricsW, SelectObject, CLIP_DEFAULT_PRECIS, DEFAULT_CHARSET,
-    FF_MODERN, FIXED_PITCH, FW_BOLD, FW_NORMAL, OUT_TT_PRECIS, PROOF_QUALITY, TEXTMETRICW,
+    CreateFontW, DeleteObject, GetTextMetricsW, SelectObject, CLEARTYPE_QUALITY,
+    CLIP_DEFAULT_PRECIS, DEFAULT_CHARSET, FF_MODERN, FIXED_PITCH, FW_BOLD, FW_NORMAL,
+    OUT_TT_PRECIS, TEXTMETRICW,
 };
 use winapi::um::winuser::{GetDC, ReleaseDC};
 
@@ -60,7 +61,7 @@ unsafe fn create_font(family_w: &[u16], height: i32, weight: i32, italic: u32) -
         DEFAULT_CHARSET,
         OUT_TT_PRECIS,
         CLIP_DEFAULT_PRECIS,
-        PROOF_QUALITY,
+        CLEARTYPE_QUALITY,
         FIXED_PITCH | FF_MODERN,
         family_w.as_ptr(),
     )

--- a/wezterm-gui/src/termwindow/gdi/mod.rs
+++ b/wezterm-gui/src/termwindow/gdi/mod.rs
@@ -1,0 +1,246 @@
+//! Windows-only GDI text rendering front_end.
+//!
+//! This backend paints terminal output directly to the window HDC using GDI
+//! (`ExtTextOutW`), so that Remote Desktop (RDP) remotes the output as text /
+//! glyph operations instead of screen-scraping and video-encoding an opaque
+//! GPU swapchain. See `.kilo/plans/1784175286267-gdi-front-end-rdp.md`.
+//!
+//! Phase 1 (this module) establishes the GPU-free paint path. The current
+//! implementation clears the client area to the palette background color; font
+//! and cell/run drawing are layered on top in subsequent tasks.
+
+use crate::termwindow::TermWindow;
+use ::window::Window;
+use mux::pane::PaneId;
+use std::collections::HashMap;
+use termwiz::surface::SequenceNo;
+use wezterm_term::StableRowIndex;
+use winapi::shared::windef::{HDC, RECT};
+use winapi::um::wingdi::{
+    CreateSolidBrush, DeleteObject, SetBkMode, SetTextAlign, OPAQUE, TA_LEFT, TA_TOP,
+};
+use winapi::um::winuser::FillRect;
+
+pub mod draw;
+pub mod font;
+
+use font::GdiFonts;
+/// Convert an `SrgbaTuple` to a GDI `COLORREF` (0x00BBGGRR).
+pub(crate) fn colorref(color: wezterm_term::color::SrgbaTuple) -> u32 {
+    let (r, g, b, _a) = color.as_rgba_u8();
+    (r as u32) | ((g as u32) << 8) | ((b as u32) << 16)
+}
+
+/// The primary font family name from config, falling back to Consolas.
+pub(crate) fn primary_family(config: &config::ConfigHandle) -> String {
+    config
+        .font
+        .font
+        .first()
+        .map(|f| f.family.clone())
+        .filter(|f| !f.is_empty())
+        .unwrap_or_else(|| "Consolas".to_string())
+}
+
+/// GDI cell (width, height) in device pixels for the configured font at `dpi`
+/// and effective point size `point_size` (i.e. `config.font_size * font_scale`),
+/// or `None` when the GDI front_end is not active or measurement failed. Used to
+/// make GDI metrics authoritative for terminal/window layout in GDI mode.
+///
+/// Measuring requires constructing GDI fonts, which is comparatively expensive
+/// and is called on the resize path, so results are memoized by
+/// (family, point_size, dpi) in a small single-entry cache.
+pub(crate) fn gdi_cell_metrics(
+    config: &config::ConfigHandle,
+    point_size: f64,
+    dpi: usize,
+) -> Option<(usize, usize)> {
+    if config.front_end != config::FrontEndSelection::Gdi {
+        return None;
+    }
+    let family = primary_family(config);
+    let size_bits = point_size.to_bits();
+
+    thread_local! {
+        static CACHE: std::cell::RefCell<Option<(String, u64, usize, (usize, usize))>> =
+            std::cell::RefCell::new(None);
+    }
+
+    CACHE.with(|cache| {
+        if let Some((f, s, d, wh)) = cache.borrow().as_ref() {
+            if *f == family && *s == size_bits && *d == dpi {
+                return Some(*wh);
+            }
+        }
+        let wh = match GdiFonts::new(&family, point_size, dpi) {
+            Ok(f) => (f.cell_width.max(1) as usize, f.cell_height.max(1) as usize),
+            Err(err) => {
+                log::error!("gdi_cell_metrics: {err:#}");
+                return None;
+            }
+        };
+        *cache.borrow_mut() = Some((family, size_bits, dpi, wh));
+        Some(wh)
+    })
+}
+
+/// Per-pane damage-tracking state used by the Phase 2 dirty-line optimization.
+#[derive(Default, Clone)]
+pub(crate) struct PanePaintState {
+    /// The sequence number at the last successful paint of this pane.
+    pub last_seqno: SequenceNo,
+    /// The viewport top (stable row) at the last paint. If this changes the
+    /// pane scrolled and must be fully repainted (seqno tracking alone can't
+    /// detect lines that merely moved position).
+    pub top: StableRowIndex,
+    /// Cursor position (col, stable row) at the last paint, so we can repaint
+    /// the cell the cursor left behind.
+    pub cursor: Option<(usize, StableRowIndex)>,
+    /// The selection range + rectangular flag at the last paint, so we can
+    /// repaint rows whose selection changed (including horizontal changes on an
+    /// already-selected row).
+    pub selection: Option<(crate::selection::SelectionRange, bool)>,
+}
+
+/// State owned by a `TermWindow` when the GDI front_end is active.
+///
+/// Holds the GDI font set (created lazily on first paint / rebuilt when the
+/// configured font or DPI changes) and per-pane damage-tracking state.
+pub struct GdiState {
+    fonts: Option<GdiFonts>,
+    /// When true, the next paint clears and redraws the whole client area. Set
+    /// on first paint, resize, focus change, and config reload.
+    pub(crate) needs_full_paint: bool,
+    pub(crate) pane_states: HashMap<PaneId, PanePaintState>,
+    /// The tab-bar line at the last paint, so we only redraw the strip when it
+    /// actually changes.
+    pub(crate) last_tab_bar: Option<termwiz::surface::Line>,
+    /// Signature of the pane layout at the last paint: (pane_id, left, top,
+    /// width, height, is_active). A change means panes were split/closed/moved/
+    /// zoomed, which can relocate unchanged lines, so we force a full redraw.
+    pub(crate) last_layout: Vec<(PaneId, usize, usize, usize, usize, bool)>,
+}
+
+impl GdiState {
+    pub fn new() -> Self {
+        Self {
+            fonts: None,
+            needs_full_paint: true,
+            pane_states: HashMap::new(),
+            last_tab_bar: None,
+            last_layout: Vec::new(),
+        }
+    }
+
+    /// Force a full clear+redraw on the next paint (e.g. after a resize).
+    pub(crate) fn invalidate_all(&mut self) {
+        self.needs_full_paint = true;
+    }
+
+    /// Ensure the font set matches `family`/`point_size`/`dpi`, rebuilding it if
+    /// necessary. Returns a reference to the current font set.
+    fn ensure_fonts(
+        &mut self,
+        family: &str,
+        point_size: f64,
+        dpi: usize,
+    ) -> anyhow::Result<&GdiFonts> {
+        let rebuild = match &self.fonts {
+            Some(fonts) => fonts.needs_rebuild(family, point_size, dpi),
+            None => true,
+        };
+        if rebuild {
+            self.fonts = Some(GdiFonts::new(family, point_size, dpi)?);
+        }
+        Ok(self.fonts.as_ref().unwrap())
+    }
+}
+
+impl TermWindow {
+    /// Force the next GDI paint to be a full clear+redraw. No-op unless the GDI
+    /// front_end is active. Call on resize / focus change / config reload.
+    pub(crate) fn gdi_invalidate_all(&mut self) {
+        if let Some(gdi) = self.gdi.as_mut() {
+            gdi.invalidate_all();
+        }
+    }
+
+    /// Paint the window using GDI. Returns true if a frame was produced.
+    ///
+    /// Runs on the GUI thread. Obtains the client DC via `Window::with_gdi_dc`,
+    /// which handles the `GetDC`/`ReleaseDC`/`ValidateRect` lifecycle for us.
+    pub(crate) fn do_paint_gdi(&mut self, window: &Window) -> bool {
+        // If the OS asked for a repaint (expose/resize) since the last paint,
+        // force a full clear+redraw so we never leave stale/blank regions.
+        if window.take_gdi_full_repaint() {
+            self.gdi_invalidate_all();
+        }
+
+        // Resolve the background color up-front to avoid borrowing `self`
+        // across the paint closure.
+        let bg = self.palette().background;
+
+        // Font parameters from the current config / window DPI. Use the
+        // effective point size (config font size scaled by the runtime font
+        // zoom) so GDI drawing matches the layout metrics.
+        let family = primary_family(&self.config);
+        let point_size = self.config.font_size * self.fonts.get_font_scale();
+        let dpi = self.dimensions.dpi;
+
+        // Ensure the GDI font set is built/current and copy out the cell metrics.
+        let metrics = match self.gdi.as_mut() {
+            Some(gdi) => match gdi.ensure_fonts(&family, point_size, dpi) {
+                Ok(fonts) => Some((fonts.cell_width, fonts.cell_height)),
+                Err(err) => {
+                    log::error!("GDI font creation failed: {:#}", err);
+                    None
+                }
+            },
+            None => None,
+        };
+        let (cw, ch) = match metrics {
+            Some(m) => m,
+            None => return false,
+        };
+
+        // Collect draw commands (borrows &mut self for pane/selection/cursor
+        // state), then render them under the client DC.
+        let data = self.gdi_collect_frame(cw, ch);
+        let gdi = self.gdi.as_ref().unwrap();
+
+        let result = window.with_gdi_dc(|hdc: HDC, rect: RECT| {
+            unsafe {
+                // Neutral text rendering defaults for cell drawing.
+                SetBkMode(hdc, OPAQUE as i32);
+                SetTextAlign(hdc, TA_LEFT | TA_TOP);
+
+                // Clear the whole client area to the terminal background only on
+                // a full paint; incremental frames leave prior pixels in place
+                // and let ETO_OPAQUE overwrite just the changed cells (so RDP
+                // only remotes the changed text).
+                if data.full_clear {
+                    let brush = CreateSolidBrush(colorref(bg));
+                    if !brush.is_null() {
+                        FillRect(hdc, &rect, brush);
+                        DeleteObject(brush as _);
+                    }
+                }
+
+                gdi.render_frame(hdc, &data);
+            }
+            Ok(())
+        });
+
+        match result {
+            Ok(()) => true,
+            Err(err) => {
+                log::error!("do_paint_gdi failed: {:#}", err);
+                // The damage state was already advanced during collection; since
+                // drawing failed, force a full redraw next frame so we recover
+                // rather than leaving the failed content marked as painted.
+                self.gdi_invalidate_all();
+                false
+            }
+        }
+    }
+}

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -72,6 +72,8 @@ pub mod background;
 pub mod box_model;
 pub mod charselect;
 pub mod clipboard;
+#[cfg(windows)]
+pub mod gdi;
 pub mod keyevent;
 pub mod modal;
 mod mouseevent;
@@ -465,6 +467,8 @@ pub struct TermWindow {
 
     gl: Option<Rc<glium::backend::Context>>,
     webgpu: Option<Rc<WebGpuState>>,
+    #[cfg(windows)]
+    gdi: Option<gdi::GdiState>,
     config_subscription: Option<config::ConfigSubscription>,
 }
 
@@ -545,6 +549,11 @@ impl TermWindow {
         // Reset the cursor blink phase
         self.prev_cursor.bump();
 
+        // Focus toggles cursor rendering (solid vs hollow); force a full GDI
+        // repaint so the change is visible.
+        #[cfg(windows)]
+        self.gdi_invalidate_all();
+
         // force cursor to be repainted
         window.invalidate();
 
@@ -602,6 +611,16 @@ impl TermWindow {
         let physical_cols = size.cols as usize;
 
         let render_metrics = RenderMetrics::new(&fontconfig)?;
+        #[cfg(windows)]
+        let render_metrics = {
+            let mut rm = render_metrics;
+            if let Some((w, h)) =
+                gdi::gdi_cell_metrics(&config, config.font_size * fontconfig.get_font_scale(), dpi)
+            {
+                rm.override_cell_size(w, h);
+            }
+            rm
+        };
         log::trace!("using render_metrics {:#?}", render_metrics);
 
         // Initially we have only a single tab, so take that into account
@@ -691,6 +710,8 @@ impl TermWindow {
             os_parameters: None,
             gl: None,
             webgpu: None,
+            #[cfg(windows)]
+            gdi: None,
             window: None,
             window_background,
             config: config.clone(),
@@ -849,7 +870,7 @@ impl TermWindow {
         });
 
         let gl = match config.front_end {
-            FrontEndSelection::WebGpu => None,
+            FrontEndSelection::WebGpu | FrontEndSelection::Gdi => None,
             _ => Some(window.enable_opengl().await?),
         };
 
@@ -885,6 +906,12 @@ impl TermWindow {
             if let Some(webgpu) = webgpu {
                 myself.webgpu.replace(Rc::clone(&webgpu));
                 myself.created(RenderContext::WebGpu(Rc::clone(&webgpu)))?;
+            }
+            #[cfg(windows)]
+            {
+                if config.front_end == FrontEndSelection::Gdi {
+                    myself.gdi.replace(gdi::GdiState::new());
+                }
             }
             myself.load_os_parameters();
             window.show();
@@ -960,12 +987,21 @@ impl TermWindow {
                 live_resizing,
             } => {
                 self.resize(dimensions, window_state, window, live_resizing);
+                #[cfg(windows)]
+                self.gdi_invalidate_all();
                 Ok(true)
             }
             WindowEvent::SetInnerSizeCompleted => {
                 self.resizes_pending -= 1;
                 if self.is_repaint_pending {
                     self.is_repaint_pending = false;
+                    #[cfg(windows)]
+                    if self.gdi.is_some() {
+                        self.gdi_invalidate_all();
+                        self.do_paint_gdi(window);
+                        self.apply_pending_scale_changes();
+                        return Ok(true);
+                    }
                     if self.webgpu.is_some() {
                         self.do_paint_webgpu()?;
                     } else {
@@ -1006,10 +1042,18 @@ impl TermWindow {
                 if self.resizes_pending > 0 {
                     self.is_repaint_pending = true;
                     Ok(true)
-                } else if self.webgpu.is_some() {
-                    self.do_paint_webgpu()
                 } else {
-                    Ok(self.do_paint(window))
+                    #[cfg(windows)]
+                    {
+                        if self.gdi.is_some() {
+                            return Ok(self.do_paint_gdi(window));
+                        }
+                    }
+                    if self.webgpu.is_some() {
+                        self.do_paint_webgpu()
+                    } else {
+                        Ok(self.do_paint(window))
+                    }
                 }
             }
             WindowEvent::Notification(item) => {
@@ -1730,6 +1774,10 @@ impl TermWindow {
         );
         self.key_table_state.clear_stack();
         self.connection_name = Connection::get().unwrap().name();
+        // Colors/fonts may have changed; force a full GDI repaint (and font
+        // rebuild happens automatically via needs_rebuild).
+        #[cfg(windows)]
+        self.gdi_invalidate_all();
         let config = match config::overridden_config(&self.config_overrides) {
             Ok(config) => config,
             Err(err) => {

--- a/wezterm-gui/src/termwindow/render/tab_bar.rs
+++ b/wezterm-gui/src/termwindow/render/tab_bar.rs
@@ -111,7 +111,12 @@ impl crate::TermWindow {
         fontconfig: &wezterm_font::FontConfiguration,
         render_metrics: &RenderMetrics,
     ) -> anyhow::Result<f32> {
-        if config.use_fancy_tab_bar {
+        // The GDI front_end renders the retro (single cell-row) tab bar and does
+        // not draw the fancy box-model tab bar, so reserve exactly one cell row
+        // regardless of use_fancy_tab_bar to keep layout and rendering aligned.
+        let use_fancy =
+            config.use_fancy_tab_bar && config.front_end != config::FrontEndSelection::Gdi;
+        if use_fancy {
             let font = fontconfig.title_font()?;
             Ok((font.metrics().cell_height.get() as f32 * 1.75).ceil())
         } else {

--- a/wezterm-gui/src/termwindow/resize.rs
+++ b/wezterm-gui/src/termwindow/resize.rs
@@ -108,6 +108,14 @@ impl super::TermWindow {
         match RenderMetrics::new(&self.fonts) {
             Ok(metrics) => {
                 self.render_metrics = metrics;
+                #[cfg(windows)]
+                if let Some((w, h)) = crate::termwindow::gdi::gdi_cell_metrics(
+                    &self.config,
+                    self.config.font_size * self.fonts.get_font_scale(),
+                    dimensions.dpi as usize,
+                ) {
+                    self.render_metrics.override_cell_size(w, h);
+                }
             }
             Err(err) => {
                 log::error!(
@@ -479,6 +487,18 @@ impl super::TermWindow {
             self.dimensions.dpi,
         )?);
         let render_metrics = RenderMetrics::new(&fontconfig)?;
+        #[cfg(windows)]
+        let render_metrics = {
+            let mut rm = render_metrics;
+            if let Some((w, h)) = crate::termwindow::gdi::gdi_cell_metrics(
+                &config,
+                config.font_size * self.fonts.get_font_scale(),
+                self.dimensions.dpi,
+            ) {
+                rm.override_cell_size(w, h);
+            }
+            rm
+        };
 
         let terminal_size = TerminalSize {
             rows: size.rows,

--- a/wezterm-gui/src/utilsprites.rs
+++ b/wezterm-gui/src/utilsprites.rs
@@ -133,6 +133,14 @@ impl RenderMetrics {
             underline_height,
         })
     }
+
+    /// Override the cell size (used in GDI front_end mode where GDI's own
+    /// `GetTextMetrics` are authoritative for layout so drawing and geometry
+    /// agree).
+    #[cfg(windows)]
+    pub fn override_cell_size(&mut self, width: usize, height: usize) {
+        self.cell_size = Size::new(width as isize, height as isize);
+    }
 }
 
 pub struct UtilSprites {

--- a/window/src/configuration.rs
+++ b/window/src/configuration.rs
@@ -1,12 +1,27 @@
 pub(crate) fn prefer_swrast() -> bool {
+    let config = config::configuration();
+
+    // When the GDI text front_end is active we don't use the OpenGL path at
+    // all, so software selection is irrelevant here.
+    if config.front_end == config::FrontEndSelection::Gdi {
+        return false;
+    }
+
     #[cfg(windows)]
     {
-        if crate::os::windows::is_running_in_rdp_session() {
-            // Using OpenGL in RDP has problematic behavior upon
-            // disconnect, so we force the use of software rendering.
-            log::trace!("Running in an RDP session, use SWRAST");
-            return true;
+        if config.front_end == config::FrontEndSelection::OpenGL
+            && crate::os::windows::is_running_in_rdp_session()
+        {
+            // Historically we forced software rendering in RDP because OpenGL
+            // has problematic behavior upon disconnect. Now that an unset
+            // front_end auto-selects the GDI renderer in RDP, an OpenGL
+            // selection here is necessarily explicit, and an explicit choice
+            // must win. Warn but honor it.
+            log::warn!(
+                "front_end=\"OpenGL\" in an RDP session may behave poorly on \
+                 disconnect; consider front_end=\"Gdi\" or \"Software\""
+            );
         }
     }
-    config::configuration().front_end == config::FrontEndSelection::Software
+    config.front_end == config::FrontEndSelection::Software
 }

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -127,6 +127,10 @@ pub(crate) struct WindowInner {
     config: ConfigHandle,
     paint_throttled: bool,
     invalidated: bool,
+    /// GDI front_end: set when a real WM_PAINT (OS expose/resize) occurred so
+    /// the GDI renderer knows to perform a full clear+redraw of the client area
+    /// rather than an incremental (dirty-line) paint.
+    gdi_full_repaint: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -221,6 +225,34 @@ impl HasWindowHandle for WindowInner {
 }
 
 impl WindowInner {
+    /// Drive an incremental GDI repaint without invalidating the OS paint
+    /// region. Model-driven changes use this so that a genuine `WM_PAINT` (OS
+    /// expose/resize) remains distinguishable and can force a full redraw.
+    /// Preserves the same `max_fps` coalescing that `wm_paint` uses.
+    fn request_gdi_repaint(&mut self) {
+        if self.paint_throttled {
+            self.invalidated = true;
+            return;
+        }
+        self.invalidated = false;
+        self.events.dispatch(WindowEvent::NeedRepaint);
+
+        self.paint_throttled = true;
+        let window_id = self.hwnd;
+        let max_fps = self.config.max_fps;
+        promise::spawn::spawn(async move {
+            async_io::Timer::after(std::time::Duration::from_millis(1000 / max_fps as u64)).await;
+            Connection::with_window_inner(window_id, move |inner| {
+                inner.paint_throttled = false;
+                if inner.invalidated {
+                    inner.request_gdi_repaint();
+                }
+                Ok(())
+            });
+        })
+        .detach();
+    }
+
     fn enable_opengl(&mut self) -> anyhow::Result<Rc<glium::backend::Context>> {
         let conn = Connection::get().unwrap();
 
@@ -547,6 +579,7 @@ impl Window {
             config: config.clone(),
             paint_throttled: false,
             invalidated: true,
+            gdi_full_repaint: true,
         }));
 
         // Careful: `raw` owns a ref to inner, but there is no Drop impl
@@ -744,6 +777,55 @@ impl HasDisplayHandle for Window {
     }
 }
 
+impl Window {
+    /// GDI front_end: read and clear the "OS requested a full repaint" flag.
+    /// Returns true if a real `WM_PAINT` (expose/resize) occurred since the last
+    /// call, meaning the next GDI paint must be a full clear+redraw.
+    pub fn take_gdi_full_repaint(&self) -> bool {
+        let conn = match Connection::get() {
+            Some(c) => c,
+            None => return true,
+        };
+        match conn.get_window(self.0) {
+            Some(handle) => {
+                let mut inner = handle.borrow_mut();
+                let v = inner.gdi_full_repaint;
+                inner.gdi_full_repaint = false;
+                v
+            }
+            None => true,
+        }
+    }
+
+    /// Windows-only: run a GDI paint closure against the window's client DC.
+    ///
+    /// Used by the GDI text `front_end`. Obtains the client HDC via `GetDC`,
+    /// invokes `f` with the HDC and the current client `RECT`, then releases the
+    /// DC and validates the whole client area (so the pending `WM_PAINT` update
+    /// region is cleared). Must be called on the GUI thread.
+    pub fn with_gdi_dc<F, R>(&self, f: F) -> anyhow::Result<R>
+    where
+        F: FnOnce(HDC, RECT) -> anyhow::Result<R>,
+    {
+        let hwnd = self.0 .0;
+        if hwnd.is_null() {
+            anyhow::bail!("with_gdi_dc: window has no hwnd");
+        }
+        unsafe {
+            let hdc = GetDC(hwnd);
+            if hdc.is_null() {
+                anyhow::bail!("with_gdi_dc: GetDC returned null");
+            }
+            let mut rect: RECT = std::mem::zeroed();
+            GetClientRect(hwnd, &mut rect);
+            let result = f(hdc, rect);
+            ReleaseDC(hwnd, hdc);
+            ValidateRect(hwnd, null());
+            result
+        }
+    }
+}
+
 impl HasWindowHandle for Window {
     fn window_handle(&self) -> Result<WindowHandle, HandleError> {
         let conn = Connection::get().expect("raw_window_handle only callable on main thread");
@@ -862,6 +944,17 @@ impl WindowOps for Window {
     }
 
     fn invalidate(&self) {
+        // In GDI mode, model-driven repaints must not invalidate the OS paint
+        // region (that would make every repaint indistinguishable from an OS
+        // expose and force a full redraw). Instead drive an incremental repaint
+        // directly through the throttle.
+        if config::configuration().front_end == config::FrontEndSelection::Gdi {
+            Connection::with_window_inner(self.0, |inner| {
+                inner.request_gdi_repaint();
+                Ok(())
+            });
+            return;
+        }
         let hwnd = self.0 .0;
         log::trace!("WindowOps::invalidate calling InvalidateRect");
         unsafe {
@@ -1611,6 +1704,10 @@ unsafe fn wm_kill_focus(
 unsafe fn wm_paint(hwnd: HWND, _msg: UINT, _wparam: WPARAM, _lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let mut inner = inner.borrow_mut();
+
+    // A real WM_PAINT means the OS needs (part of) the client reconstructed;
+    // for the GDI front_end this must be a full clear+redraw.
+    inner.gdi_full_repaint = true;
 
     if inner.paint_throttled {
         inner.invalidated = true;

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -127,10 +127,6 @@ pub(crate) struct WindowInner {
     config: ConfigHandle,
     paint_throttled: bool,
     invalidated: bool,
-    /// GDI front_end: set when a real WM_PAINT (OS expose/resize) occurred so
-    /// the GDI renderer knows to perform a full clear+redraw of the client area
-    /// rather than an incremental (dirty-line) paint.
-    gdi_full_repaint: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -579,7 +575,6 @@ impl Window {
             config: config.clone(),
             paint_throttled: false,
             invalidated: true,
-            gdi_full_repaint: true,
         }));
 
         // Careful: `raw` owns a ref to inner, but there is no Drop impl
@@ -781,20 +776,15 @@ impl Window {
     /// GDI front_end: read and clear the "OS requested a full repaint" flag.
     /// Returns true if a real `WM_PAINT` (expose/resize) occurred since the last
     /// call, meaning the next GDI paint must be a full clear+redraw.
+    ///
+    /// The flag lives in a thread-local keyed by HWND rather than in
+    /// `WindowInner`, because `do_paint_gdi` frequently runs re-entrantly while
+    /// `WindowInner` is already mutably borrowed (e.g. `wm_paint` dispatches
+    /// `NeedRepaint` synchronously while holding the borrow, and
+    /// `SetInnerSizeCompleted` is dispatched from inside `with_window_inner`).
+    /// Borrowing `WindowInner` again there would panic.
     pub fn take_gdi_full_repaint(&self) -> bool {
-        let conn = match Connection::get() {
-            Some(c) => c,
-            None => return true,
-        };
-        match conn.get_window(self.0) {
-            Some(handle) => {
-                let mut inner = handle.borrow_mut();
-                let v = inner.gdi_full_repaint;
-                inner.gdi_full_repaint = false;
-                v
-            }
-            None => true,
-        }
+        gdi_take_full_repaint(self.0 .0 as isize)
     }
 
     /// Windows-only: run a GDI paint closure against the window's client DC.
@@ -1701,13 +1691,36 @@ unsafe fn wm_kill_focus(
     None
 }
 
+thread_local! {
+    /// GDI front_end: per-HWND "OS requested a full repaint" flag. Kept out of
+    /// `WindowInner` so it can be read during a re-entrant GDI paint without
+    /// re-borrowing `WindowInner`. GUI runs single-threaded, so a thread-local
+    /// is sufficient.
+    static GDI_FULL_REPAINT: std::cell::RefCell<std::collections::HashMap<isize, bool>> =
+        std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+/// Mark that the given window needs a full GDI repaint on its next paint.
+fn gdi_set_full_repaint(hwnd: isize) {
+    GDI_FULL_REPAINT.with(|m| {
+        m.borrow_mut().insert(hwnd, true);
+    });
+}
+
+/// Read and clear the full-repaint flag for the given window.
+fn gdi_take_full_repaint(hwnd: isize) -> bool {
+    GDI_FULL_REPAINT.with(|m| m.borrow_mut().insert(hwnd, false).unwrap_or(false))
+}
+
 unsafe fn wm_paint(hwnd: HWND, _msg: UINT, _wparam: WPARAM, _lparam: LPARAM) -> Option<LRESULT> {
     let inner = rc_from_hwnd(hwnd)?;
     let mut inner = inner.borrow_mut();
 
     // A real WM_PAINT means the OS needs (part of) the client reconstructed;
-    // for the GDI front_end this must be a full clear+redraw.
-    inner.gdi_full_repaint = true;
+    // for the GDI front_end this must be a full clear+redraw. Stored outside
+    // WindowInner (see `Window::take_gdi_full_repaint`) so the re-entrant GDI
+    // paint can read it without re-borrowing WindowInner.
+    gdi_set_full_repaint(hwnd as isize);
 
     if inner.paint_throttled {
         inner.invalidated = true;


### PR DESCRIPTION
# Summary
Adds a new Windows-only front_end = "Gdi" that paints terminal output directly to the window HDC with GDI ExtTextOutW, instead of rendering through OpenGL/WebGpu/Software.
Motivation: In an RDP (or Hyper-V) session there is no hardware GPU — every adapter is WARP/llvmpipe (CPU). The GPU and Software front ends rasterize the whole surface on the CPU and stream it to the RDP client every frame, which RDP must screen-scrape and video-encode. That is the main cause of the responsiveness gap vs. Windows Terminal over RDP. The GDI front end instead emits text/glyph drawing operations, which RDP remotes as text — far more responsive and much lighter on bandwidth.
# What it does
- Opt-in via front_end = "Gdi". On non-Windows it falls back to OpenGL with a warning. In an RDP session with an unset front_end, the default remains Software (GDI is not auto-selected, since it's an MVP — see limitations).
- GPU-free window paint path (Window::with_gdi_dc): no GL/WebGpu context is created; painting happens via GetDC/ExtTextOutW.
- GDI font manager: creates regular/bold/italic/bold-italic HFONTs and derives cell metrics from GetTextMetrics; these metrics are made authoritative for layout (terminal sizing, resize, mouse coords), including runtime font zoom, so drawing and geometry always agree.
- Cell/run drawing: truecolor fg/bg, reverse video, bold/italic/underline/strikethrough, wide (CJK) cells, block/bar/underline cursor (hollow when unfocused), selection highlight, and a clickable retro tab strip.
- Damage tracking: per-line sequence-number dirty tracking so only changed lines are repainted (keeping RDP traffic minimal), with full-frame safety for scroll, pane topology changes, resize, focus, and OS expose/WM_PAINT.
- ClearType text for crisp rendering.
# Not included (documented limitations)
- Box-model overlay/modal UI (command palette, char/pane selectors) isn't rendered in GDI mode — it depends on the GPU glyph atlas. Overlay panes (launcher, copy-mode, fuzzy selector, prompts) do render normally, and tab clicks work.
- No ligatures/shaping (per-cell drawing), images (sixel/iTerm/kitty), custom shaders, or background images.

Perf test within Windows RDP session:

https://github.com/user-attachments/assets/8d12f9ef-fe3f-43af-b153-9aac5a32c28a
