### PR TITLE
wayland: DPI calculation fixes for different desktop scale factors

### DIFF
--- a/window/src/os/wayland/connection.rs
+++ b/window/src/os/wayland/connection.rs
@@ -162,6 +162,19 @@ impl ConnectionOps for WaylandConnection {
         "Wayland".to_string()
     }
 
+    fn default_dpi(&self) -> f64 {
+        // Use the effective dpi of the screen that new windows are most
+        // likely to appear on, so that the initial window size can be
+        // computed with a realistic dpi. Getting this right avoids
+        // visibly re-resizing the window once the compositor reports
+        // the true scale factor of the output; if we guessed the wrong
+        // output, the configure/scale events will correct it later.
+        match self.screens() {
+            Ok(screens) => screens.active.effective_dpi.unwrap_or(crate::DEFAULT_DPI),
+            Err(_) => crate::DEFAULT_DPI,
+        }
+    }
+
     fn terminate_message_loop(&self) {
         log::trace!("Terminating Message Loop");
         *self.should_terminate.borrow_mut() = true;

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -236,7 +236,7 @@ impl WaylandWindow {
         let dimensions = Dimensions {
             pixel_width: width,
             pixel_height: height,
-            dpi: config.dpi.unwrap_or(crate::DEFAULT_DPI) as usize,
+            dpi: config.dpi.unwrap_or_else(|| conn.default_dpi()) as usize,
         };
 
         let window = {

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -1449,10 +1449,22 @@ impl CompositorHandler for WaylandState {
         &mut self,
         _conn: &WConnection,
         _qh: &wayland_client::QueueHandle<Self>,
-        _surface: &wayland_client::protocol::wl_surface::WlSurface,
-        _new_factor: i32,
+        surface: &wayland_client::protocol::wl_surface::WlSurface,
+        new_factor: i32,
     ) {
-        // We do nothing, we get the scale_factor from surface_data
+        // The actual scale factor is read from surface_data when the
+        // configure is processed; here we only nudge the window to
+        // re-evaluate its dpi.
+        let Some(surface_data) = SurfaceUserData::try_from_wl(surface) else {
+            // Not one of our window surfaces (eg: a CSD subsurface)
+            return;
+        };
+        let window_id = surface_data.window_id;
+        WaylandConnection::with_window_inner(window_id, move |inner| {
+            inner.pending_event.lock().unwrap().dpi.replace(new_factor);
+            inner.dispatch_pending_event();
+            Ok(())
+        });
     }
 
     fn frame(


### PR DESCRIPTION
There are size and dragging issues with initially created windows (reproduced on COSMIC desktop) that are related to wrong initial DPI calculations. They are gone after manual window resize, because that triggers DPI recalculation. Here are fixes for relevant initial calculations.