### PR TITLE
fix: macOS crash (SIGABRT) from RefCell re-entrancy panic in WindowView::draw_rect

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -154,6 +154,7 @@ As features stabilize some brief notes about them will accumulate here.
 * macOS: wacky initial window size with external monitors or certain font
   sizes. #4966 #4250
 * macOS: dragging non-filename data over wezterm could cause it to crash. #4771
+* macOS: repainting a window could cause wezterm to crash. #7427
 * New tabs spawned by the gui could spawn into the wrong domain when using
   multiplexing together `default_domain`. Thanks to @bogdan2412! #4994
 * Linux: the `divine_process_list` fallback function used the *vmwisze*

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -3063,12 +3063,17 @@ impl WindowView {
             if inner.paint_throttled {
                 inner.invalidated = true;
             } else {
-                inner.events.dispatch(WindowEvent::NeedRepaint);
                 inner.invalidated = false;
                 inner.paint_throttled = true;
 
                 let window_id = inner.window_id;
                 let max_fps = inner.config.max_fps;
+                let mut events =
+                    std::mem::replace(&mut inner.events, WindowEventSender::new(|_, _| {}));
+                drop(inner);
+                events.dispatch(WindowEvent::NeedRepaint);
+                this.inner.borrow_mut().events = events;
+
                 promise::spawn::spawn(async move {
                     async_io::Timer::after(std::time::Duration::from_millis(1000 / max_fps as u64))
                         .await;


### PR DESCRIPTION
`draw_rect` in `window/src/os/macos/window.rs` (around line 3047) holds a live. `this.inner.borrow_mut()` guard while calling. Reporter Porkepix sees wezterm-gui abort/segfault on macOS with no reliable. repro ("one-time crash", recurring roughly weekly).

Happy path: resizing/repainting a wezterm window on macOS repeatedly; (including rapid successive repaints, e.g. resizing while content is.

Fixes #7427
