### PR TITLE
Fix window_frame border color missing at rounded macOS corners

### DIFF
--- a/wezterm-gui/src/termwindow/render/borders.rs
+++ b/wezterm-gui/src/termwindow/render/borders.rs
@@ -1,6 +1,10 @@
 use crate::quad::TripleLayerQuadAllocator;
+use crate::termwindow::render::corners::{
+    BOTTOM_LEFT_ROUNDED_CORNER, BOTTOM_RIGHT_ROUNDED_CORNER, TOP_LEFT_ROUNDED_CORNER,
+    TOP_RIGHT_ROUNDED_CORNER,
+};
 use crate::utilsprites::RenderMetrics;
-use ::window::ULength;
+use ::window::{PointF, SizeF, ULength};
 use config::{ConfigHandle, DimensionContext};
 
 impl crate::TermWindow {
@@ -71,6 +75,149 @@ impl crate::TermWindow {
                         .border_right_color
                         .map(|c| c.to_linear())
                         .unwrap_or(border_dimensions.color),
+                )?;
+            }
+
+            // On macOS, the WindowServer rounds the outer silhouette of the
+            // window, but the border rectangles above paint square corners:
+            // the corner overlap is only `border_width` pixels across, and
+            // since the OS corner radius is bigger than that, the whole
+            // colored overlap sits inside the region the OS clips away and
+            // the corner comes out bare.
+            //
+            // Rebuild each corner as: a solid square of border color, with
+            // a background-colored quarter-disc painted on top to carve the
+            // window interior back out. The disc is inset by the border
+            // widths and its arc is centered on the same point as the OS's
+            // corner arc, so the visible ring between the OS clip and the
+            // disc reads as a constant-thickness border that follows the
+            // rounded corner. The OS radius isn't queryable from here; we
+            // use an estimate, and because the disc meets the straight
+            // border edges exactly at the configured width, an estimation
+            // error only slightly fattens/thins the ring at the diagonal.
+            #[cfg(target_os = "macos")]
+            {
+                let top_color = self
+                    .config
+                    .window_frame
+                    .border_top_color
+                    .map(|c| c.to_linear())
+                    .unwrap_or(border_dimensions.color);
+                let bottom_color = self
+                    .config
+                    .window_frame
+                    .border_bottom_color
+                    .map(|c| c.to_linear())
+                    .unwrap_or(border_dimensions.color);
+                let left_color = self
+                    .config
+                    .window_frame
+                    .border_left_color
+                    .map(|c| c.to_linear())
+                    .unwrap_or(border_dimensions.color);
+                let right_color = self
+                    .config
+                    .window_frame
+                    .border_right_color
+                    .map(|c| c.to_linear())
+                    .unwrap_or(border_dimensions.color);
+
+                let bg_color = self
+                    .palette()
+                    .background
+                    .to_linear()
+                    .mul_alpha(self.config.window_background_opacity);
+
+                // Estimated OS corner radius: ~10pt on modern macOS.
+                // dpi is 72 * scale on macOS, so pt -> px is dpi / 72.
+                let radius = (10.0 * self.dimensions.dpi as f32 / 72.0)
+                    .max(border_top.max(border_bottom))
+                    .max(border_left.max(border_right))
+                    + 1.0;
+
+                let mut corner = |x: f32,
+                                  y: f32,
+                                  b_x: f32,
+                                  b_y: f32,
+                                  poly: &'static [crate::customglyph::Poly],
+                                  color|
+                 -> anyhow::Result<()> {
+                    if b_x <= 0.0 && b_y <= 0.0 {
+                        return Ok(());
+                    }
+                    self.filled_rectangle(
+                        layers,
+                        1,
+                        euclid::rect(x, y, radius, radius),
+                        color,
+                    )?;
+                    let inset_w = radius - b_x;
+                    let inset_h = radius - b_y;
+                    if inset_w > 0.0 && inset_h > 0.0 {
+                        // The disc hugs the inner corner of its cell, so
+                        // inset the cell origin only on the outer sides.
+                        let inset_x = if x == 0.0 { x + b_x } else { x };
+                        let inset_y = if y == 0.0 { y + b_y } else { y };
+                        self.poly_quad(
+                            layers,
+                            1,
+                            PointF::new(inset_x, inset_y),
+                            poly,
+                            0,
+                            SizeF::new(inset_w, inset_h),
+                            bg_color,
+                        )?;
+                    }
+                    Ok(())
+                };
+
+                corner(
+                    0.0,
+                    0.0,
+                    border_left,
+                    border_top,
+                    TOP_LEFT_ROUNDED_CORNER,
+                    if border_top >= border_left {
+                        top_color
+                    } else {
+                        left_color
+                    },
+                )?;
+                corner(
+                    width - radius,
+                    0.0,
+                    border_right,
+                    border_top,
+                    TOP_RIGHT_ROUNDED_CORNER,
+                    if border_top >= border_right {
+                        top_color
+                    } else {
+                        right_color
+                    },
+                )?;
+                corner(
+                    0.0,
+                    height - radius,
+                    border_left,
+                    border_bottom,
+                    BOTTOM_LEFT_ROUNDED_CORNER,
+                    if border_bottom >= border_left {
+                        bottom_color
+                    } else {
+                        left_color
+                    },
+                )?;
+                corner(
+                    width - radius,
+                    height - radius,
+                    border_right,
+                    border_bottom,
+                    BOTTOM_RIGHT_ROUNDED_CORNER,
+                    if border_bottom >= border_right {
+                        bottom_color
+                    } else {
+                        right_color
+                    },
                 )?;
             }
         }

--- a/wezterm-gui/src/termwindow/render/borders.rs
+++ b/wezterm-gui/src/termwindow/render/borders.rs
@@ -95,7 +95,18 @@ impl crate::TermWindow {
             // use an estimate, and because the disc meets the straight
             // border edges exactly at the configured width, an estimation
             // error only slightly fattens/thins the ring at the diagonal.
+            //
+            // In native fullscreen (and when the user forces square corners),
+            // the OS doesn't round the window at all - the straight
+            // rectangles above already produce a correct, solid square
+            // corner - so skip the carve entirely; doing it anyway would cut
+            // a rounded notch into a corner that's supposed to be square.
             #[cfg(target_os = "macos")]
+            if !self.window_state.contains(window::WindowState::FULL_SCREEN)
+                && !self
+                    .config
+                    .window_decorations
+                    .contains(window::WindowDecorations::MACOS_FORCE_SQUARE_CORNERS)
             {
                 let top_color = self
                     .config


### PR DESCRIPTION
On macOS, the WindowServer rounds a titleless window's outer silhouette, but the border rectangles drawn for window_frame only overlap in border_width-sized squares at each corner. Since the OS's real corner radius is bigger than that, the whole colored overlap sits inside the region the OS clips away, leaving the corner bare.

Rebuild each corner as a solid square of border color with a background-colored quarter-disc carved out of it, inset by the configured border width and centered on the same point as the OS's own corner arc. The visible ring between the OS clip and the disc then reads as a constant-thickness border that follows the rounded corner, without needing to know the OS's exact radius.