### PR TITLE
wayland: honor compositor size for tiled windows (eg: sway)

### DIFF
--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -109,19 +109,23 @@ bitflags! {
         /// Maximized along either or both of horizontal or vertical dimensions;
         /// cannot be resized while in this state.
         const MAXIMIZED = 1<<2;
+        /// Tiled by the window manager on all edges (eg: a tiling Wayland
+        /// compositor such as sway). The compositor owns the window size,
+        /// so the application must not resize itself.
+        const TILED = 1<<3;
         /// Minimized or in some kind of off-screen state. Cannot be repainted
         /// while in this state.
-        const HIDDEN = 1<<3;
+        const HIDDEN = 1<<4;
         /// Always on top (floating) window
-        const ALWAYS_ON_TOP = 1<<4;
+        const ALWAYS_ON_TOP = 1<<5;
         /// Always on bottom (docked) window
-        const ALWAYS_ON_BOTTOM = 1<<5;
+        const ALWAYS_ON_BOTTOM = 1<<6;
     }
 }
 
 impl WindowState {
     pub fn can_resize(self) -> bool {
-        !self.intersects(Self::FULL_SCREEN | Self::MAXIMIZED)
+        !self.intersects(Self::FULL_SCREEN | Self::MAXIMIZED | Self::TILED)
     }
 
     pub fn can_paint(self) -> bool {

--- a/window/src/os/wayland/window.rs
+++ b/window/src/os/wayland/window.rs
@@ -1417,6 +1417,15 @@ impl WaylandState {
                 if configure.state.contains(SCTKWindowState::MAXIMIZED) {
                     state |= WindowState::MAXIMIZED;
                 }
+                // A tiling compositor (eg: sway) owns the window size; record
+                // the tiled state so that we don't fight the compositor by
+                // speculatively resizing ourselves to preserve rows/cols.
+                // SCTKWindowState::TILED is the alias for all four tiled edges,
+                // so this only matches when every edge is pinned by the
+                // compositor.
+                if configure.state.contains(SCTKWindowState::TILED) {
+                    state |= WindowState::TILED;
+                }
 
                 log::debug!(
                     "Config: self.window_state={:?}, states: {:?} {:?}",


### PR DESCRIPTION
## Problem

On a tiling Wayland compositor such as sway, wezterm launches but only
renders into a narrow region instead of filling the tile it was assigned.
Manually resizing the window (or re-tiling) fixes it, and
`enable_wayland = false` avoids it.

## Root cause

The compositor sends the correct tiled size in its configure event
(e.g. 1276x1007) and we apply it. But because a Wayland surface only
learns its scale factor after creation, a scaling change fires on
startup and `apply_dimensions()` runs a speculative resize (via
`set_inner_size`) to preserve the current rows/cols. On Wayland
`set_inner_size` synthesizes a configure event, which overwrites the
compositor-provided tiled size with our own smaller default
(1276x1007 -> 964x609), leaving the window rendering in a small corner.

`apply_dimensions()` already guards this speculative resize behind
`WindowState::can_resize()`, but that only accounted for fullscreen and
maximized; the tiled state from the compositor was discarded entirely.

## Fix

Track the compositor's tiled state as a new `WindowState::TILED` flag and
treat it as non-resizable, so the existing guard skips the speculative
resize and we honor the compositor-assigned size. No-op on floating
desktops (GNOME/KDE), X11, macOS and Windows, where TILED is never set.

## Testing

- sway: wezterm now fills its tile on launch without a manual resize.
