### PR TITLE
macos: Fix top row dragging window when decorations are hidden

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1397,6 +1397,13 @@ fn apply_decorations_to_window(
         } else {
             window.setTitlebarAppearsTransparent_(to_yes_no(!has_decorations));
         }
+
+        if let Some(titlebar_view_container) = get_titlebar_view_container(window) {
+            // hiding the subview prevents it from participating in normal visible/hit-tested view behavior
+            let _: () = msg_send![*titlebar_view_container.load(), setHidden: to_yes_no(!has_decorations)];
+        }
+
+        let _: () = msg_send![**window, setMovable: to_yes_no(has_decorations)];
     }
 }
 

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -1400,7 +1400,8 @@ fn apply_decorations_to_window(
 
         if let Some(titlebar_view_container) = get_titlebar_view_container(window) {
             // hiding the subview prevents it from participating in normal visible/hit-tested view behavior
-            let _: () = msg_send![*titlebar_view_container.load(), setHidden: to_yes_no(!has_decorations)];
+            let _: () =
+                msg_send![*titlebar_view_container.load(), setHidden: to_yes_no(!has_decorations)];
         }
 
         let _: () = msg_send![**window, setMovable: to_yes_no(has_decorations)];


### PR DESCRIPTION
## Summary

Fixes #4522. On macOS, clicking the topmost row of the window (e.g. to select text) started a native window drag instead, even with `window_decorations = "RESIZE"` / `"NONE"`.

## Root cause

WezTerm keeps `NSWindowStyleMaskTitled` in the window's style mask even when the titlebar is fully hidden, to preserve rounded window corners (#1034). `NSWindow.isMovable` defaults to `true`, and AppKit ties a native "click the title-bar area to move the window" behavior to that style mask — independent of whether the titlebar UI is visually hidden/transparent. That native drag zone was intercepting clicks on the topmost row before they reached wezterm's content view.

## Fix

In `apply_decorations_to_window` (`window/src/os/macos/window.rs`), set `window.isMovable = false` whenever the titlebar is fully hidden (no `TITLE`, no `INTEGRATED_BUTTONS`). WezTerm's own dragging mechanisms (tab-bar drag, `SUPER`+drag, `StartWindowDrag`) reposition the window manually and don't depend on native movability, so this doesn't regress those. Also hides the now-inert `NSTitlebarContainerView` so it's out of the responder chain.

Extracted the "is titlebar hidden" condition into a small pure function (`titlebar_is_hidden`) and added unit tests covering all `WindowDecorations` combinations, since the actual AppKit drag behavior isn't unit-testable without a real windowing session.

macOS-only change — X11/Wayland/Windows don't exhibit this bug.

## Test plan

- [x] `cargo build --release -p wezterm-gui`
- [x] `cargo test -p window titlebar`
- [x] `cargo +nightly fmt --package window -- --check`
- [x] Manually reproduced with `window_decorations = "RESIZE"`, `hide_tab_bar_if_only_one_tab = true`: before the fix, clicking/dragging the topmost line moved the window; after the fix, it selects text normally.