### PR TITLE
Add pane_padding: a configurable gutter between split panes

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -17,7 +17,7 @@ use crate::keys::{Key, LeaderKey, Mouse};
 use crate::lua::make_lua_context;
 use crate::ssh::{SshBackend, SshDomain};
 use crate::tls::{TlsDomainClient, TlsDomainServer};
-use crate::units::Dimension;
+use crate::units::{Dimension, DimensionContext};
 use crate::unix::UnixDomain;
 use crate::wsl::WslDomain;
 use crate::{
@@ -543,6 +543,13 @@ pub struct Config {
     /// Controls the amount of padding to use around the terminal cell area
     #[dynamic(default)]
     pub window_padding: WindowPadding,
+
+    /// Controls the amount of padding reserved as a gutter around each pane
+    /// on the side(s) where it borders a sibling pane in a split. Has no
+    /// effect on a tab with a single, unsplit pane - see window_padding for
+    /// that. Defaults to zero (no gutter, matching prior behavior).
+    #[dynamic(default)]
+    pub pane_padding: PanePadding,
 
     #[dynamic(default)]
     pub window_content_alignment: WindowContentAlignment,
@@ -1940,6 +1947,10 @@ const fn default_half_cell() -> Dimension {
     Dimension::Cells(0.5)
 }
 
+const fn default_zero_dimension() -> Dimension {
+    Dimension::Pixels(0.)
+}
+
 const fn default_reverse_video_cursor_min_contrast() -> f32 {
     2.5
 }
@@ -1964,6 +1975,88 @@ impl Default for WindowPadding {
             top: default_half_cell(),
             bottom: default_half_cell(),
         }
+    }
+}
+
+/// Padding reserved as a gutter around a pane on the side(s) where it
+/// borders a sibling pane in a split. Unlike WindowPadding, this defaults
+/// to zero on every edge: a configured pane_padding is opt-in, so existing
+/// configs see no change in split layout until they set it.
+#[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, Default)]
+pub struct PanePadding {
+    #[dynamic(
+        try_from = "crate::units::PixelUnit",
+        default = "default_zero_dimension"
+    )]
+    pub left: Dimension,
+    #[dynamic(
+        try_from = "crate::units::PixelUnit",
+        default = "default_zero_dimension"
+    )]
+    pub top: Dimension,
+    #[dynamic(
+        try_from = "crate::units::PixelUnit",
+        default = "default_zero_dimension"
+    )]
+    pub right: Dimension,
+    #[dynamic(
+        try_from = "crate::units::PixelUnit",
+        default = "default_zero_dimension"
+    )]
+    pub bottom: Dimension,
+}
+
+impl PanePadding {
+    /// Resolve this padding to whole cells reserved on each side of a split
+    /// divider, given the pixel size of a single cell. The divider itself
+    /// always keeps its pre-existing 1-cell width; the padding adds
+    /// `leading`/`trailing` cells on either side of it.
+    /// Pass `horizontal = true` for a left/right (Horizontal) split, whose
+    /// gutter is measured in columns using `cell_pixel_width`; pass `false`
+    /// for a top/bottom (Vertical) split, measured in rows using
+    /// `cell_pixel_height`. (Named after mux::tab::SplitDirection, which
+    /// this crate can't reference directly since mux depends on config.)
+    /// Returns (leading_cells, total_gap_cells). `trailing_cells` isn't
+    /// returned since it's trivially `total_gap_cells - leading_cells - 1`
+    /// and no caller has needed it separately.
+    pub fn split_gap_cells(
+        &self,
+        horizontal: bool,
+        cell_pixel_width: f32,
+        cell_pixel_height: f32,
+        dpi: f32,
+    ) -> (usize, usize) {
+        fn cells_for(pad: Dimension, pixel_cell: f32, dpi: f32) -> usize {
+            if pixel_cell <= 0.0 {
+                return 0;
+            }
+            let ctx = DimensionContext {
+                dpi,
+                pixel_max: pixel_cell,
+                pixel_cell,
+            };
+            let px = pad.evaluate_as_pixels(ctx).max(0.0);
+            (px / pixel_cell).ceil() as usize
+        }
+
+        // Horizontal split: first pane is on the left, second on the right.
+        // The gutter on the divider's left edge is the first pane's `right`
+        // padding; on its right edge, the second pane's `left` padding.
+        // Vertical split: first pane on top, second on bottom, using
+        // `bottom`/`top` the same way.
+        let (leading, trailing) = if horizontal {
+            (
+                cells_for(self.right, cell_pixel_width, dpi),
+                cells_for(self.left, cell_pixel_width, dpi),
+            )
+        } else {
+            (
+                cells_for(self.bottom, cell_pixel_height, dpi),
+                cells_for(self.top, cell_pixel_height, dpi),
+            )
+        };
+
+        (leading, 1 + leading + trailing)
     }
 }
 
@@ -2205,4 +2298,61 @@ fn default_macos_forward_mods() -> Modifiers {
 
 fn default_colr_rasterizer() -> FontRasterizerSelection {
     FontRasterizerSelection::Harfbuzz
+}
+
+#[cfg(test)]
+mod pane_padding_test {
+    use super::*;
+    use crate::units::Dimension;
+
+    #[test]
+    fn zero_padding_is_bare_divider() {
+        let padding = PanePadding::default();
+        let (leading, total) = padding.split_gap_cells(true, 10.0, 20.0, 96.0);
+        assert_eq!((leading, total), (0, 1));
+    }
+
+    #[test]
+    fn symmetric_padding_centers_the_divider() {
+        let padding = PanePadding {
+            left: Dimension::Cells(2.0),
+            right: Dimension::Cells(2.0),
+            top: Dimension::Cells(1.0),
+            bottom: Dimension::Cells(1.0),
+        };
+        // Horizontal split: gutter is the left pane's `right` padding plus
+        // the right pane's `left` padding, plus the 1-cell divider itself.
+        let (leading, total) = padding.split_gap_cells(true, 10.0, 20.0, 96.0);
+        assert_eq!((leading, total), (2, 5));
+
+        // Vertical split uses `bottom`/`top` the same way.
+        let (leading, total) = padding.split_gap_cells(false, 10.0, 20.0, 96.0);
+        assert_eq!((leading, total), (1, 3));
+    }
+
+    #[test]
+    fn asymmetric_padding_is_not_centered() {
+        let padding = PanePadding {
+            left: Dimension::Cells(1.0),
+            right: Dimension::Cells(3.0),
+            top: Dimension::default(),
+            bottom: Dimension::default(),
+        };
+        // For a horizontal split, `leading` is this pane's `right` padding
+        // (it sits on the first/left side of the split).
+        let (leading, total) = padding.split_gap_cells(true, 10.0, 20.0, 96.0);
+        assert_eq!((leading, total), (3, 5));
+    }
+
+    #[test]
+    fn zero_cell_pixel_size_is_handled_gracefully() {
+        let padding = PanePadding {
+            left: Dimension::Cells(2.0),
+            right: Dimension::Cells(2.0),
+            top: Dimension::Cells(2.0),
+            bottom: Dimension::Cells(2.0),
+        };
+        let (leading, total) = padding.split_gap_cells(true, 0.0, 0.0, 96.0);
+        assert_eq!((leading, total), (0, 1));
+    }
 }

--- a/docs/config/appearance.md
+++ b/docs/config/appearance.md
@@ -408,6 +408,12 @@ You may add padding around the edges of the terminal area.
 
 [See the window_padding docs for more info](lua/config/window_padding.md)
 
+### Pane Padding
+
+You may add padding as a gutter between panes in a split.
+
+[See the pane_padding docs for more info](lua/config/pane_padding.md)
+
 ## Styling Inactive Panes
 
 {{since('20201031-154415-9614e117')}}

--- a/docs/config/lua/config/pane_padding.md
+++ b/docs/config/lua/config/pane_padding.md
@@ -1,0 +1,35 @@
+---
+tags:
+  - appearance
+---
+# `pane_padding`
+
+Controls the amount of padding reserved as a gutter around a pane, on
+whichever side(s) it borders a sibling pane in a split.
+
+Unlike [window_padding](window_padding.md), which pads between the window
+border and the terminal cells, `pane_padding` widens the gap *between*
+panes. The divider line that wezterm draws between split panes keeps its
+usual width and is centered within the gutter.
+
+Padding is measured using the same units as `window_padding`: `"1px"`,
+`"1pt"`, `"1cell"` or `"1%"`, or a plain number of pixels.
+
+```lua
+config.pane_padding = {
+  left = 0,
+  right = 0,
+  top = 0,
+  bottom = 0,
+}
+```
+
+The default is `0` on every edge, so existing configs see no change in
+split layout until `pane_padding` is explicitly set.
+
+Only the side(s) of a pane that actually border a sibling are affected;
+`left`/`top`/`right`/`bottom` describe the edge of the *pane*, not the
+direction of the split, so a pane's `pane_padding` only ever has a visual
+effect on the edge(s) where it touches another pane.
+
+{{since('nightly')}}

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -142,23 +142,27 @@ impl Default for SplitRequest {
 }
 
 impl SplitDirectionAndSize {
+    fn gap_cells(&self) -> usize {
+        split_gap_cells(self.direction, &cell_dimensions(&self.first))
+    }
+
     fn top_of_second(&self) -> usize {
         match self.direction {
             SplitDirection::Horizontal => 0,
-            SplitDirection::Vertical => self.first.rows as usize + 1,
+            SplitDirection::Vertical => self.first.rows as usize + self.gap_cells(),
         }
     }
 
     fn left_of_second(&self) -> usize {
         match self.direction {
-            SplitDirection::Horizontal => self.first.cols as usize + 1,
+            SplitDirection::Horizontal => self.first.cols as usize + self.gap_cells(),
             SplitDirection::Vertical => 0,
         }
     }
 
     pub fn width(&self) -> usize {
         if self.direction == SplitDirection::Horizontal {
-            self.first.cols + self.second.cols + 1
+            self.first.cols + self.second.cols + self.gap_cells()
         } else {
             self.first.cols
         }
@@ -166,7 +170,7 @@ impl SplitDirectionAndSize {
 
     pub fn height(&self) -> usize {
         if self.direction == SplitDirection::Vertical {
-            self.first.rows + self.second.rows + 1
+            self.first.rows + self.second.rows + self.gap_cells()
         } else {
             self.first.rows
         }
@@ -326,9 +330,10 @@ fn compute_min_size(tree: &mut Tree) -> (usize, usize) {
         } => {
             let (left_x, left_y) = compute_min_size(&mut *left);
             let (right_x, right_y) = compute_min_size(&mut *right);
+            let gap = data.gap_cells();
             match data.direction {
-                SplitDirection::Vertical => (left_x.max(right_x), left_y + right_y + 1),
-                SplitDirection::Horizontal => (left_x + right_x + 1, left_y.max(right_y)),
+                SplitDirection::Vertical => (left_x.max(right_x), left_y + right_y + gap),
+                SplitDirection::Horizontal => (left_x + right_x + gap, left_y.max(right_y)),
             }
         }
         Tree::Leaf(_) => (1, 1),
@@ -504,6 +509,21 @@ fn cell_dimensions(size: &TerminalSize) -> TerminalSize {
         pixel_height: size.pixel_height / size.rows,
         dpi: size.dpi,
     }
+}
+
+/// How many cells wide the gap between two sibling panes should be along
+/// `direction`, given `cell_dims` (as returned by `cell_dimensions`, i.e. a
+/// 1x1-cell-sized TerminalSize). This is 1 (just the divider line) unless
+/// `config.pane_padding` is set, in which case it grows to reserve a gutter
+/// on either side of the divider too. See `PanePadding::split_gap_cells`.
+fn split_gap_cells(direction: SplitDirection, cell_dims: &TerminalSize) -> usize {
+    let (_leading, total) = configuration().pane_padding.split_gap_cells(
+        direction == SplitDirection::Horizontal,
+        cell_dims.pixel_width as f32,
+        cell_dims.pixel_height as f32,
+        cell_dims.dpi as f32,
+    );
+    total
 }
 
 impl Tab {
@@ -1196,16 +1216,17 @@ impl TabInner {
             // child and adjust the second, so if we are split down the middle
             // and the window is made wider, the right column will grow in
             // size, leaving the left at its current width.
+            let gap = node.gap_cells();
             if node.direction == SplitDirection::Horizontal {
                 node.first.rows = pane_size.rows;
                 node.second.rows = pane_size.rows;
 
-                node.second.cols = pane_size.cols.saturating_sub(1 + node.first.cols);
+                node.second.cols = pane_size.cols.saturating_sub(gap + node.first.cols);
             } else {
                 node.first.cols = pane_size.cols;
                 node.second.cols = pane_size.cols;
 
-                node.second.rows = pane_size.rows.saturating_sub(1 + node.first.rows);
+                node.second.rows = pane_size.rows.saturating_sub(gap + node.first.rows);
             }
             node.first.pixel_width = node.first.cols * cell_width;
             node.first.pixel_height = node.first.rows * cell_height;
@@ -1294,6 +1315,7 @@ impl TabInner {
     fn adjust_node_at_cursor(&mut self, cursor: &mut Cursor, delta: isize) {
         let cell_dimensions = self.cell_dimensions();
         if let Ok(Some(node)) = cursor.node_mut() {
+            let gap = node.gap_cells();
             match node.direction {
                 SplitDirection::Horizontal => {
                     let width = node.width();
@@ -1302,12 +1324,12 @@ impl TabInner {
                     cols = cols
                         .saturating_add(delta)
                         .max(1)
-                        .min((width as isize).saturating_sub(2));
+                        .min((width as isize).saturating_sub(gap as isize + 1));
                     node.first.cols = cols as usize;
                     node.first.pixel_width =
                         node.first.cols.saturating_mul(cell_dimensions.pixel_width);
 
-                    node.second.cols = width.saturating_sub(node.first.cols.saturating_add(1));
+                    node.second.cols = width.saturating_sub(node.first.cols.saturating_add(gap));
                     node.second.pixel_width =
                         node.second.cols.saturating_mul(cell_dimensions.pixel_width);
                 }
@@ -1318,12 +1340,12 @@ impl TabInner {
                     rows = rows
                         .saturating_add(delta)
                         .max(1)
-                        .min((height as isize).saturating_sub(2));
+                        .min((height as isize).saturating_sub(gap as isize + 1));
                     node.first.rows = rows as usize;
                     node.first.pixel_height =
                         node.first.rows.saturating_mul(cell_dimensions.pixel_height);
 
-                    node.second.rows = height.saturating_sub(node.first.rows.saturating_add(1));
+                    node.second.rows = height.saturating_sub(node.first.rows.saturating_add(gap));
                     node.second.pixel_height = node
                         .second
                         .rows
@@ -1488,6 +1510,9 @@ impl TabInner {
         let mut best = None;
 
         let recency = &self.recency;
+        let cell_dims = self.cell_dimensions();
+        let gap_x = split_gap_cells(SplitDirection::Horizontal, &cell_dims);
+        let gap_y = split_gap_cells(SplitDirection::Vertical, &cell_dims);
 
         fn edge_intersects(
             active_start: usize,
@@ -1504,7 +1529,7 @@ impl TabInner {
         for pane in &panes {
             let score = match direction {
                 PaneDirection::Right => {
-                    if pane.left == active.left + active.width + 1
+                    if pane.left == active.left + active.width + gap_x
                         && edge_intersects(active.top, active.height, pane.top, pane.height)
                     {
                         1 + recency.score(pane.index)
@@ -1513,7 +1538,7 @@ impl TabInner {
                     }
                 }
                 PaneDirection::Left => {
-                    if pane.left + pane.width + 1 == active.left
+                    if pane.left + pane.width + gap_x == active.left
                         && edge_intersects(active.top, active.height, pane.top, pane.height)
                     {
                         1 + recency.score(pane.index)
@@ -1522,7 +1547,7 @@ impl TabInner {
                     }
                 }
                 PaneDirection::Up => {
-                    if pane.top + pane.height + 1 == active.top
+                    if pane.top + pane.height + gap_y == active.top
                         && edge_intersects(active.left, active.width, pane.left, pane.width)
                     {
                         1 + recency.score(pane.index)
@@ -1531,7 +1556,7 @@ impl TabInner {
                     }
                 }
                 PaneDirection::Down => {
-                    if active.top + active.height + 1 == pane.top
+                    if active.top + active.height + gap_y == pane.top
                         && edge_intersects(active.left, active.width, pane.left, pane.width)
                     {
                         1 + recency.score(pane.index)
@@ -1872,15 +1897,16 @@ impl TabInner {
         request: SplitRequest,
     ) -> Option<SplitDirectionAndSize> {
         let cell_dims = self.cell_dimensions();
+        let gap = split_gap_cells(request.direction, &cell_dims);
 
-        fn split_dimension(dim: usize, request: SplitRequest) -> (usize, usize) {
+        fn split_dimension(dim: usize, request: SplitRequest, gap: usize) -> (usize, usize) {
             let target_size = match request.size {
                 SplitSize::Cells(n) => n,
                 SplitSize::Percent(n) => (dim * (n as usize)) / 100,
             }
             .max(1);
 
-            let remain = dim.saturating_sub(target_size + 1);
+            let remain = dim.saturating_sub(target_size + gap);
 
             if request.target_is_second {
                 (remain, target_size)
@@ -1894,12 +1920,12 @@ impl TabInner {
 
             let ((width1, width2), (height1, height2)) = match request.direction {
                 SplitDirection::Horizontal => (
-                    split_dimension(size.cols as usize, request),
+                    split_dimension(size.cols as usize, request, gap),
                     (size.rows as usize, size.rows as usize),
                 ),
                 SplitDirection::Vertical => (
                     (size.cols as usize, size.cols as usize),
-                    split_dimension(size.rows as usize, request),
+                    split_dimension(size.rows as usize, request, gap),
                 ),
             };
 
@@ -1929,12 +1955,13 @@ impl TabInner {
         self.iter_panes().iter().nth(pane_index).map(|pos| {
             let ((width1, width2), (height1, height2)) = match request.direction {
                 SplitDirection::Horizontal => (
-                    split_dimension(pos.width, request),
+                    split_dimension(pos.width, request, gap),
                     (pos.height, pos.height),
                 ),
-                SplitDirection::Vertical => {
-                    ((pos.width, pos.width), split_dimension(pos.height, request))
-                }
+                SplitDirection::Vertical => (
+                    (pos.width, pos.width),
+                    split_dimension(pos.height, request, gap),
+                ),
             };
 
             SplitDirectionAndSize {

--- a/wezterm-gui/src/termwindow/render/pane.rs
+++ b/wezterm-gui/src/termwindow/render/pane.rs
@@ -107,30 +107,42 @@ impl crate::TermWindow {
 
         let cell_width = self.render_metrics.cell_size.width as f32;
         let cell_height = self.render_metrics.cell_size.height as f32;
+        // Bleed the pane's own (correctly active/inactive-dimmed) background
+        // out to the middle of any pane_padding gutter it borders, so the
+        // gutter is never left showing the always-undimmed window background
+        // underneath. Matches where paint_split centers the divider line.
+        let (_, gap_x_cells) = self.config.pane_padding.split_gap_cells(
+            true,
+            cell_width,
+            cell_height,
+            self.dimensions.dpi as f32,
+        );
+        let (_, gap_y_cells) = self.config.pane_padding.split_gap_cells(
+            false,
+            cell_width,
+            cell_height,
+            self.dimensions.dpi as f32,
+        );
+        let gap_x = gap_x_cells as f32 * cell_width;
+        let gap_y = gap_y_cells as f32 * cell_height;
         let background_rect = {
             // We want to fill out to the edges of the splits
             let (x, width_delta) = if pos.left == 0 {
-                (
-                    0.,
-                    padding_left + border.left.get() as f32 + (cell_width / 2.0),
-                )
+                (0., padding_left + border.left.get() as f32 + (gap_x / 2.0))
             } else {
                 (
-                    padding_left + border.left.get() as f32 - (cell_width / 2.0)
+                    padding_left + border.left.get() as f32 - (gap_x / 2.0)
                         + (pos.left as f32 * cell_width),
-                    cell_width,
+                    gap_x,
                 )
             };
 
             let (y, height_delta) = if pos.top == 0 {
-                (
-                    (top_pixel_y - padding_top),
-                    padding_top + (cell_height / 2.0),
-                )
+                ((top_pixel_y - padding_top), padding_top + (gap_y / 2.0))
             } else {
                 (
-                    top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),
-                    cell_height,
+                    top_pixel_y + (pos.top as f32 * cell_height) - (gap_y / 2.0),
+                    gap_y,
                 )
             };
             euclid::rect(
@@ -602,29 +614,42 @@ impl crate::TermWindow {
         let border = self.get_os_border();
         let top_pixel_y = top_bar_height + padding_top + border.top.get() as f32;
 
+        // Bleed the pane's own (correctly active/inactive-dimmed) background
+        // out to the middle of any pane_padding gutter it borders, so the
+        // gutter is never left showing the always-undimmed window background
+        // underneath. Matches where paint_split centers the divider line.
+        let (_, gap_x_cells) = self.config.pane_padding.split_gap_cells(
+            true,
+            cell_width,
+            cell_height,
+            self.dimensions.dpi as f32,
+        );
+        let (_, gap_y_cells) = self.config.pane_padding.split_gap_cells(
+            false,
+            cell_width,
+            cell_height,
+            self.dimensions.dpi as f32,
+        );
+        let gap_x = gap_x_cells as f32 * cell_width;
+        let gap_y = gap_y_cells as f32 * cell_height;
+
         // We want to fill out to the edges of the splits
         let (x, width_delta) = if pos.left == 0 {
-            (
-                0.,
-                padding_left + border.left.get() as f32 + (cell_width / 2.0),
-            )
+            (0., padding_left + border.left.get() as f32 + (gap_x / 2.0))
         } else {
             (
-                padding_left + border.left.get() as f32 - (cell_width / 2.0)
+                padding_left + border.left.get() as f32 - (gap_x / 2.0)
                     + (pos.left as f32 * cell_width),
-                cell_width,
+                gap_x,
             )
         };
 
         let (y, height_delta) = if pos.top == 0 {
-            (
-                (top_pixel_y - padding_top),
-                padding_top + (cell_height / 2.0),
-            )
+            ((top_pixel_y - padding_top), padding_top + (gap_y / 2.0))
         } else {
             (
-                top_pixel_y + (pos.top as f32 * cell_height) - (cell_height / 2.0),
-                cell_height,
+                top_pixel_y + (pos.top as f32 * cell_height) - (gap_y / 2.0),
+                gap_y,
             )
         };
 

--- a/wezterm-gui/src/termwindow/render/split.rs
+++ b/wezterm-gui/src/termwindow/render/split.rs
@@ -16,6 +16,36 @@ impl crate::TermWindow {
         let cell_width = self.render_metrics.cell_size.width as f32;
         let cell_height = self.render_metrics.cell_size.height as f32;
 
+        // pane_padding widens the reserved gap around a split beyond the
+        // bare 1-cell divider; center the rendered line (and the clickable
+        // hit region) within that gap rather than assuming it's always
+        // exactly 1 cell wide. `leading` is how many of the gap's cells sit
+        // before the divider line (on the first/top pane's side).
+        let (leading, gap_cells) = self.config.pane_padding.split_gap_cells(
+            split.direction == SplitDirection::Horizontal,
+            cell_width,
+            cell_height,
+            self.dimensions.dpi as f32,
+        );
+        let gap_cells = gap_cells as f32;
+        let leading = leading as f32;
+
+        // The line is drawn past the ends of the split's own span so that it
+        // visually connects with a perpendicular divider at a T or + junction
+        // - that divider sits at the center of *its* gap, so the overshoot
+        // must reach that center rather than a flat half-cell once
+        // pane_padding widens gaps beyond the bare 1-cell divider. Assumes
+        // symmetric padding (equal on both sides of the perpendicular gap),
+        // which holds for any gutter-style config; centering on the gap's
+        // total width is exact in that case.
+        let (_, perp_gap_cells) = self.config.pane_padding.split_gap_cells(
+            split.direction != SplitDirection::Horizontal,
+            cell_width,
+            cell_height,
+            self.dimensions.dpi as f32,
+        );
+        let overshoot = perp_gap_cells as f32 / 2.0;
+
         let border = self.get_os_border();
         let first_row_offset = if self.show_tab_bar && !self.config.tab_bar_at_bottom {
             self.tab_bar_pixel_height()?
@@ -33,10 +63,10 @@ impl crate::TermWindow {
                 layers,
                 2,
                 euclid::rect(
-                    pos_x + (cell_width / 2.0),
-                    pos_y - (cell_height / 2.0),
+                    pos_x + (leading + 0.5) * cell_width,
+                    pos_y - (overshoot * cell_height),
                     self.render_metrics.underline_height as f32,
-                    (1. + split.size as f32) * cell_height,
+                    (split.size as f32 + 2.0 * overshoot) * cell_height,
                 ),
                 foreground,
             )?;
@@ -44,7 +74,7 @@ impl crate::TermWindow {
                 x: border.left.get() as usize
                     + padding_left as usize
                     + (split.left * cell_width as usize),
-                width: cell_width as usize,
+                width: (gap_cells * cell_width) as usize,
                 y: padding_top as usize
                     + first_row_offset as usize
                     + split.top * cell_height as usize,
@@ -56,9 +86,9 @@ impl crate::TermWindow {
                 layers,
                 2,
                 euclid::rect(
-                    pos_x - (cell_width / 2.0),
-                    pos_y + (cell_height / 2.0),
-                    (1.0 + split.size as f32) * cell_width,
+                    pos_x - (overshoot * cell_width),
+                    pos_y + (leading + 0.5) * cell_height,
+                    (split.size as f32 + 2.0 * overshoot) * cell_width,
                     self.render_metrics.underline_height as f32,
                 ),
                 foreground,
@@ -71,7 +101,7 @@ impl crate::TermWindow {
                 y: padding_top as usize
                     + first_row_offset as usize
                     + split.top * cell_height as usize,
-                height: cell_height as usize,
+                height: (gap_cells * cell_height) as usize,
                 item_type: UIItemType::Split(split.clone()),
             });
         }


### PR DESCRIPTION
## Summary

wezterm currently supports `window_padding` for the outer edges of the
window, but there's no way to widen the gap between panes in a split -
you're stuck with the fixed 1-cell divider. This adds `pane_padding`,
which reserves extra gutter cells on whichever side(s) of a pane
border a sibling pane, using the same unit system as `window_padding`
(`px`/`pt`/`cell`/`%`).

```lua
config.pane_padding = {
  left = 0,
  right = 0,
  top = 0,
  bottom = 0,
}
```

It defaults to `0` on every edge, so existing configs are unaffected
until it's explicitly set.

## Details

* `PanePadding::split_gap_cells` (`config/src/config.rs`) resolves the
  configured padding on each side of a split to a whole number of
  gutter cells, given the pixel size of a cell. It's the single
  source of truth consumed by layout, rendering, and hit-testing.
* `mux/src/tab.rs`: pane geometry (resize, drag-clamp, min-size,
  split creation, directional pane navigation) now reserves the
  configured gutter instead of the hardcoded 1-cell divider.
* `wezterm-gui/src/termwindow/render/split.rs`: the divider line (and
  its clickable hit region) is centered within the widened gutter, and
  its overshoot past the ends of the split is computed from the
  perpendicular gap so it still visually connects at split junctions.
* `wezterm-gui/src/termwindow/render/pane.rs`: each pane's own
  background fill (which already respects `inactive_pane_hsb`
  dimming) now bleeds out to the middle of the gutter it borders,
  instead of a fixed half-cell. Without this, a widened gutter would
  fall through to the undimmed window background, showing a visibly
  different color than the pane it belongs to. No new configuration
  was added for this - it reuses the existing per-pane dimming
  mechanism, consistent with how `inactive_pane_hsb` already governs
  pane-adjacent chrome.

## Test plan

- [x] Added unit tests for `PanePadding::split_gap_cells` covering
      zero padding, symmetric padding, asymmetric padding, and a
      degenerate zero-size-cell case (`cargo test -p config`).
- [x] `cargo test -p mux tab_splitting` still passes.
- [x] `cargo check -p config -p mux -p wezterm-gui` is clean.
- [x] Manually verified with horizontal and vertical splits, at
      several padding values, including 2x2 and 3-way splits (T and +
      junctions): divider lines connect correctly, and inactive-pane
      gutters match their pane's dimmed color instead of showing a
      seam.