### PR TITLE
Add directional pane swapping

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -595,6 +595,7 @@ pub enum KeyAssignment {
 
     AdjustPaneSize(PaneDirection, usize),
     ActivatePaneDirection(PaneDirection),
+    SwapPaneDirection(PaneDirection),
     ActivatePaneByIndex(usize),
     TogglePaneZoomState,
     SetPaneZoomState(bool),

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -865,6 +865,7 @@ pub fn add_to_config_reload_watch_list<'lua>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::keyassignment::PaneDirection;
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -949,6 +950,27 @@ assert(wezterm.emit('bar', 42, 'woot') == true)
 
         assert_eq!(*total.lock().unwrap(), 6);
 
+        Ok(())
+    }
+
+    #[test]
+    fn exposes_swap_pane_direction_action_to_lua() -> anyhow::Result<()> {
+        let lua = make_lua_context(Path::new("testing"))?;
+
+        for (direction, expected) in [
+            ("Left", PaneDirection::Left),
+            ("Right", PaneDirection::Right),
+            ("Up", PaneDirection::Up),
+            ("Down", PaneDirection::Down),
+            ("Next", PaneDirection::Next),
+            ("Prev", PaneDirection::Prev),
+        ] {
+            let script =
+                format!("return require('wezterm').action.SwapPaneDirection '{direction}'");
+            let action: KeyAssignment = lua.load(script).eval()?;
+
+            assert_eq!(action, KeyAssignment::SwapPaneDirection(expected));
+        }
         Ok(())
     }
 }

--- a/docs/config/lua/keyassignment/ActivatePaneDirection.md
+++ b/docs/config/lua/keyassignment/ActivatePaneDirection.md
@@ -54,3 +54,6 @@ the highest of the active pane is already the lowest pane index.
 
 Ambiguous moves are now resolved by selecting the most recently activated pane
 in a given direction, instead of based on the edge intersection.
+
+See also [SwapPaneDirection](SwapPaneDirection.md) to swap with the selected
+adjacent pane instead of activating it.

--- a/docs/config/lua/keyassignment/SwapPaneDirection.md
+++ b/docs/config/lua/keyassignment/SwapPaneDirection.md
@@ -1,0 +1,29 @@
+# `SwapPaneDirection`
+
+{{since('nightly')}}
+
+Swaps the active pane with the adjacent pane in the specified direction. Focus
+follows the pane that was active, so the same terminal remains active in its new
+position. If no pane exists in that direction, this action does nothing.
+
+Valid directions are `"Left"`, `"Right"`, `"Up"`, `"Down"`, `"Next"`, and
+`"Prev"`. Directional ambiguity is resolved by the same rules as
+[`ActivatePaneDirection`](ActivatePaneDirection.md).
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+local config = {}
+
+config.keys = {
+  { key = 'a', mods = 'ALT', action = act.SwapPaneDirection 'Left' },
+  { key = 'd', mods = 'ALT', action = act.SwapPaneDirection 'Right' },
+  { key = 'e', mods = 'ALT', action = act.SwapPaneDirection 'Up' },
+  { key = 's', mods = 'ALT', action = act.SwapPaneDirection 'Down' },
+}
+
+return config
+```
+
+See also [PaneSelect](PaneSelect.md) for selecting a pane to swap and
+[RotatePanes](RotatePanes.md) for rotating all panes.

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -654,6 +654,11 @@ impl Tab {
         self.inner.lock().activate_pane_direction(direction)
     }
 
+    /// Swap the active pane with an adjacent pane and keep the original pane active.
+    pub fn swap_active_pane_direction(&self, direction: PaneDirection) {
+        self.inner.lock().swap_active_pane_direction(direction)
+    }
+
     /// Returns an adjacent pane in the specified direction.
     /// In cases where there are multiple adjacent panes in the
     /// intended direction, we take the pane that has the largest
@@ -1449,6 +1454,12 @@ impl TabInner {
         let mux = Mux::get();
         if let Some(window_id) = mux.window_containing_tab(self.id) {
             mux.notify(MuxNotification::WindowInvalidated(window_id));
+        }
+    }
+
+    fn swap_active_pane_direction(&mut self, direction: PaneDirection) {
+        if let Some(pane_idx) = self.get_pane_direction(direction, false) {
+            self.swap_active_with_index(pane_idx, true);
         }
     }
 
@@ -2515,6 +2526,93 @@ mod test {
         assert_eq!(24, panes[2].height);
         assert_eq!(400, panes[2].pixel_width);
         assert_eq!(600, panes[2].pixel_height);
+    }
+
+    #[test]
+    fn swaps_active_pane_in_each_direction_and_keeps_it_active() {
+        let mux = Arc::new(Mux::new(None));
+        Mux::set_mux(&mux);
+
+        for (split_direction, pane_direction, initial_idx, expected_active_idx) in [
+            (SplitDirection::Horizontal, PaneDirection::Left, 1, 0),
+            (SplitDirection::Horizontal, PaneDirection::Right, 0, 1),
+            (SplitDirection::Vertical, PaneDirection::Up, 1, 0),
+            (SplitDirection::Vertical, PaneDirection::Down, 0, 1),
+            (SplitDirection::Horizontal, PaneDirection::Next, 0, 1),
+            (SplitDirection::Horizontal, PaneDirection::Prev, 1, 0),
+        ] {
+            let size = TerminalSize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 800,
+                pixel_height: 600,
+                dpi: 96,
+            };
+
+            let tab = Tab::new(&size);
+            tab.assign_pane(&FakePane::new(1, size));
+            let split_size = tab
+                .compute_split_size(
+                    0,
+                    SplitRequest {
+                        direction: split_direction,
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            tab.split_and_insert(
+                0,
+                SplitRequest {
+                    direction: split_direction,
+                    ..Default::default()
+                },
+                FakePane::new(2, split_size.second),
+            )
+            .unwrap();
+            tab.set_active_idx(initial_idx);
+
+            // The pane IDs change position, while focus follows the originally active pane.
+            let expected_active_pane_id = tab.get_active_pane().unwrap().pane_id();
+            tab.swap_active_pane_direction(pane_direction);
+
+            let panes = tab.iter_panes();
+            assert_eq!(2, panes[0].pane.pane_id(), "{pane_direction:?}");
+            assert_eq!(1, panes[1].pane.pane_id(), "{pane_direction:?}");
+            assert_eq!(
+                expected_active_idx,
+                tab.get_active_idx(),
+                "{pane_direction:?}"
+            );
+            assert_eq!(
+                expected_active_pane_id,
+                tab.get_active_pane().unwrap().pane_id(),
+                "{pane_direction:?}"
+            );
+        }
+
+        Mux::shutdown();
+    }
+
+    #[test]
+    fn swap_active_pane_direction_without_neighbor_is_a_noop() {
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+
+        let tab = Tab::new(&size);
+        tab.assign_pane(&FakePane::new(1, size));
+
+        // A missing directional neighbor must leave the pane tree and focus untouched.
+        tab.swap_active_pane_direction(PaneDirection::Left);
+
+        let panes = tab.iter_panes();
+        assert_eq!(1, panes.len());
+        assert_eq!(1, panes[0].pane.pane_id());
+        assert!(panes[0].is_active);
     }
 
     fn is_send_and_sync<T: Send + Sync>() -> bool {

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -1590,6 +1590,39 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &["Window", "Select Pane"],
             icon: Some("fa_long_arrow_down"),
         },
+        SwapPaneDirection(PaneDirection::Next | PaneDirection::Prev) => return None,
+        SwapPaneDirection(PaneDirection::Left) => CommandDef {
+            brief: "Swap Pane Left".into(),
+            doc: "Swaps the current pane with the pane to the left".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Window", "Swap Pane"],
+            icon: Some("fa_long_arrow_left"),
+        },
+        SwapPaneDirection(PaneDirection::Right) => CommandDef {
+            brief: "Swap Pane Right".into(),
+            doc: "Swaps the current pane with the pane to the right".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Window", "Swap Pane"],
+            icon: Some("fa_long_arrow_right"),
+        },
+        SwapPaneDirection(PaneDirection::Up) => CommandDef {
+            brief: "Swap Pane Up".into(),
+            doc: "Swaps the current pane with the pane above".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Window", "Swap Pane"],
+            icon: Some("fa_long_arrow_up"),
+        },
+        SwapPaneDirection(PaneDirection::Down) => CommandDef {
+            brief: "Swap Pane Down".into(),
+            doc: "Swaps the current pane with the pane below".into(),
+            keys: vec![],
+            args: &[ArgType::ActivePane],
+            menubar: &["Window", "Swap Pane"],
+            icon: Some("fa_long_arrow_down"),
+        },
         TogglePaneZoomState => CommandDef {
             brief: "Toggle Pane Zoom".into(),
             doc: "Toggles the zoom state for the current pane".into(),
@@ -2132,6 +2165,10 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         ActivatePaneDirection(PaneDirection::Right),
         ActivatePaneDirection(PaneDirection::Up),
         ActivatePaneDirection(PaneDirection::Down),
+        SwapPaneDirection(PaneDirection::Left),
+        SwapPaneDirection(PaneDirection::Right),
+        SwapPaneDirection(PaneDirection::Up),
+        SwapPaneDirection(PaneDirection::Down),
         TogglePaneZoomState,
         ActivateLastTab,
         ShowLauncher,
@@ -2144,4 +2181,27 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         // ----------------- Misc
         OpenLinkAtMouseCursor,
     ];
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn swap_pane_direction_command_metadata_is_exhaustive() {
+        for (direction, expected_brief) in [
+            (PaneDirection::Left, "Swap Pane Left"),
+            (PaneDirection::Right, "Swap Pane Right"),
+            (PaneDirection::Up, "Swap Pane Up"),
+            (PaneDirection::Down, "Swap Pane Down"),
+        ] {
+            let command = derive_command_from_key_assignment(&SwapPaneDirection(direction))
+                .expect("cardinal pane directions should have command metadata");
+            assert_eq!(expected_brief, command.brief);
+        }
+
+        for direction in [PaneDirection::Next, PaneDirection::Prev] {
+            assert!(derive_command_from_key_assignment(&SwapPaneDirection(direction)).is_none());
+        }
+    }
 }

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2986,6 +2986,19 @@ impl TermWindow {
                     tab.activate_pane_direction(*direction);
                 }
             }
+            SwapPaneDirection(direction) => {
+                let mux = Mux::get();
+                let tab = match mux.get_active_tab_for_window(self.mux_window_id) {
+                    Some(tab) => tab,
+                    None => return Ok(PerformAssignmentResult::Handled),
+                };
+
+                let tab_id = tab.tab_id();
+
+                if self.tab_state(tab_id).overlay.is_none() {
+                    tab.swap_active_pane_direction(*direction);
+                }
+            }
             TogglePaneZoomState => {
                 let mux = Mux::get();
                 let tab = match mux.get_active_tab_for_window(self.mux_window_id) {


### PR DESCRIPTION
## Summary

Add a native `SwapPaneDirection` key assignment that swaps the active pane with the pane selected by WezTerm's existing directional-selection rules.

The original terminal remains focused in its new position. If there is no pane in a cardinal direction, the action is a no-op.

## Changes

- expose `wezterm.action.SwapPaneDirection` for all `PaneDirection` values
- reuse the mux's existing directional lookup and focus-preserving swap logic
- dispatch the action through the GUI and expose cardinal command metadata
- document the action with an Option+A/S/E/D example
- test Lua parsing, all six directions, focus retention, no-neighbor behavior, and command metadata

## Spec coverage

- R1: all existing pane directions use the current directional-selection rules
- R2: focus follows the original terminal and missing cardinal neighbors are safe
- AC1/AC2: covered by unit tests, GUI compilation, live cardinal smoke tests, and strict docs validation

## Audit

- code quality: PASS
- security: PASS
- performance: PASS
- tests: PASS

## Test plan

- `cargo build -p wezterm -p wezterm-gui`
- `cargo test --all` — 399 passed, 0 failed, 1 ignored
- `cargo fmt --all -- --check`
- `cargo clippy -p config -p mux -p wezterm-gui --all-targets --no-deps -- -A clippy::bad_bit_mask -A clippy::never_loop -A clippy::if_same_then_else`
- strict targeted MkDocs build
- manual horizontal and vertical swap smoke tests on macOS
