### PR TITLE
cargo: revert edition to 2021

### DIFF
--- a/wezterm-cell/Cargo.toml
+++ b/wezterm-cell/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Wez Furlong"]
 name = "wezterm-cell"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 repository = "https://github.com/wezterm/wezterm"
 description = "Model a Cell in a Terminal display"
 license = "MIT"

--- a/wezterm-escape-parser/Cargo.toml
+++ b/wezterm-escape-parser/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Wez Furlong"]
 name = "wezterm-escape-parser"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 repository = "https://github.com/wezterm/wezterm"
 description = "Escape Sequence Parser"
 license = "MIT"


### PR DESCRIPTION
```log
$ cargo +1.71.0 check -p filedescriptor                
error: failed to load manifest for workspace member `~/wezterm/strip-ansi-escapes`

Caused by:
  failed to load manifest for dependency `termwiz`

Caused by:
  failed to load manifest for dependency `wezterm-cell`

Caused by:
  failed to parse manifest at `~/wezterm/wezterm-cell/Cargo.toml`

Caused by:
  failed to parse the `edition` key

Caused by:
  this version of Cargo is older than the `2024` edition, and only supports `2015`, `2018`, and `2021` editions.
  ```