### PR TITLE
fix(windows): remove unclickable ghost buttons when using RESIZE deco…

### DIFF
--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -389,7 +389,7 @@ fn apply_decoration_immediate(hwnd: HWND, decorations: WindowDecorations) {
 
 fn decorations_to_style(decorations: WindowDecorations) -> u32 {
     if decorations == WindowDecorations::RESIZE {
-        WS_OVERLAPPEDWINDOW
+        WS_OVERLAPPEDWINDOW & !(WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX)
     } else if decorations == WindowDecorations::TITLE {
         WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX
     } else if decorations == WindowDecorations::NONE {


### PR DESCRIPTION
 When using `window_decorations = "RESIZE"` on Windows 11 (especially with Acrylic/Mica backdrops), the minimize, maximize, and close buttons still show up in the corner, but you can't actually click them.

This happens because `WS_OVERLAPPEDWINDOW` includes the `WS_SYSMENU` flags. Windows DWM draws the buttons anyway,
but since the title bar
area is removed, they end up just being dead ghost buttons.

This PR just masks out the menu and box flags from `WS_OVERLAPPEDWINDOW` when only `RESIZE` is set. It keeps the resize borders and drop
shadows working fine, but gets rid of the broken buttons.