### PR TITLE
Add dim_tint_factor config option for SGR dim/faint color brightness

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -127,6 +127,17 @@ pub struct Config {
     #[dynamic(default)]
     pub bold_brightens_ansi_colors: BoldBrightening,
 
+    /// Controls the brightness of text rendered with the dim/faint SGR attribute
+    /// (SGR 2, `Intensity::Half`).  This is a multiplier applied to the RGB
+    /// components of the foreground color.  A value of `1.0` (the default) means
+    /// no additional dimming beyond the lighter font weight that WezTerm already
+    /// selects for dim text.  Lower values make dim text progressively darker;
+    /// `0.5` halves the brightness, `0.0` renders it as black.
+    /// This multiplier is applied on top of the font-weight substitution, so both
+    /// effects are active simultaneously.
+    #[dynamic(default = "default_dim_tint_factor")]
+    pub dim_tint_factor: f64,
+
     /// The color palette
     pub colors: Option<Palette>,
 
@@ -904,6 +915,10 @@ impl_lua_conversion_dynamic!(Config);
 
 fn default_one() -> usize {
     1
+}
+
+fn default_dim_tint_factor() -> f64 {
+    1.0
 }
 
 fn default_ulimit_nofile() -> u64 {

--- a/docs/config/lua/config/dim_tint_factor.md
+++ b/docs/config/lua/config/dim_tint_factor.md
@@ -1,0 +1,26 @@
+---
+tags:
+  - appearance
+---
+# `dim_tint_factor = 1.0`
+
+Controls the brightness of text rendered with the dim/faint SGR attribute
+(SGR 2, also known as `Intensity::Half`).
+
+The value is a multiplier in the range `0.0`–`1.0` applied to the RGB
+components of the foreground color when a cell has the dim attribute set:
+
+* `1.0` (the default) — no additional color change beyond the lighter font
+  weight that WezTerm already selects for dim text via `font_rules`.
+* `0.5` — halves the brightness of dim text.
+* `0.0` — renders dim text as black (or the darkest possible shade).
+
+This multiplier is applied **in addition to** the font-weight substitution,
+so both effects are active simultaneously when the value is less than `1.0`.
+
+```lua
+config.dim_tint_factor = 0.5
+```
+
+Note: the multiplier is applied in the linear light color space, so the
+perceptual effect is consistent across different base colors.

--- a/wezterm-gui/src/termwindow/render/mod.rs
+++ b/wezterm-gui/src/termwindow/render/mod.rs
@@ -910,7 +910,7 @@ fn resolve_fg_color_attr(
     config: &ConfigHandle,
     style: &config::TextStyle,
 ) -> LinearRgba {
-    match fg {
+    let color = match fg {
         wezterm_term::color::ColorAttribute::Default => {
             if let Some(fg) = style.foreground {
                 fg.into()
@@ -934,7 +934,18 @@ fn resolve_fg_color_attr(
         }
         _ => palette.resolve_fg(fg),
     }
-    .to_linear()
+    .to_linear();
+
+    // Apply dim_tint_factor when the cell has the dim/faint SGR attribute
+    // (Intensity::Half).  A factor of 1.0 (the default) is a no-op; values
+    // below 1.0 darken the color proportionally.
+    if attrs.intensity() == wezterm_term::Intensity::Half {
+        let factor = config.dim_tint_factor as f32;
+        let (r, g, b, a) = color.tuple();
+        LinearRgba::with_components(r * factor, g * factor, b * factor, a)
+    } else {
+        color
+    }
 }
 
 fn update_next_frame_time(storage: &mut Option<Instant>, next_due: Option<Instant>) {


### PR DESCRIPTION
## Summary

WezTerm currently handles `Intensity::Half` (SGR 2, dim/faint) only by substituting a lighter font weight via `font_rules`. No color transformation is applied, so dim text often looks nearly identical in brightness to normal text, especially on color schemes with saturated ANSI colors.

This PR adds a `dim_tint_factor` config option — a floating-point multiplier (default `1.0`) applied to the RGB components of the foreground color when a cell has the dim attribute set. Values below `1.0` progressively darken dim text. The multiplier is applied in the linear light color space, on top of the existing font-weight substitution.

## Usage

```lua
config.dim_tint_factor = 0.5  -- halves brightness of dim/faint text
```

## Changes

- `config/src/config.rs`: add `dim_tint_factor: f64` field with default `1.0`
- `wezterm-gui/src/termwindow/render/mod.rs`: apply factor in `resolve_fg_color_attr` when `attrs.intensity() == Intensity::Half`
- `docs/config/lua/config/dim_tint_factor.md`: documentation

## Behaviour

- Default value `1.0` is a no-op — no change to existing behaviour
- The font-weight substitution (lighter font for dim text) continues to work as before; this is an additive color effect
- Multiplier is applied per-cell in the linear color space before the `foreground_text_hsb` shader transform