### PR TITLE
tmuxcc: fix TmuxPty* Write impl to return length of consumed data

### DIFF
--- a/mux/src/tmux_pty.rs
+++ b/mux/src/tmux_pty.rs
@@ -35,7 +35,7 @@ impl Write for TmuxPtyWriter {
             keys: buf.to_vec(),
         }));
         TmuxDomainState::schedule_send_next_command(self.domain_id);
-        Ok(0)
+        Ok(buf.len())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
@@ -56,7 +56,7 @@ impl Write for TmuxPty {
             keys: buf.to_vec(),
         }));
         TmuxDomainState::schedule_send_next_command(self.domain_id);
-        Ok(0)
+        Ok(buf.len())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {


### PR DESCRIPTION
Fixes #8003 

Although I'm not 100% sure this is right here, as technically we didn't send the data to tmux yet, it's scheduled to send but it's not sent yet 🤔

@joexue (I cannot add you as a reviewer for some reason..) and maybe @wez
👉 could you confirm this is correct?

---

#8003 bug report also suggested thess small additional behavior changes to:
* avoid queueing an empty send-keys command (note @bew: not sure this is actually needed, but why not)
* schedule command processing _only_ when non-empty input was given

👉 WDYT about that? 🤔