### PR TITLE
sixel: default omitted `!` repeat count to 1

### DIFF
--- a/wezterm-escape-parser/src/parser/sixel.rs
+++ b/wezterm-escape-parser/src/parser/sixel.rs
@@ -53,8 +53,18 @@ impl SixelBuilder {
                 self.sixel.data.push(SixelData::NewLine);
             }
             0x3f..=0x7e if self.current_command == b'!' => {
+                // An omitted repeat count leaves params[0] at the -1 sentinel;
+                // per DEC, `!` (DECGRI) defaults to 1 when Pn is absent. Without
+                // this, `-1 as u32` becomes 4294967295 and the consumer loops
+                // billions of times on a tiny input. Mirrors the `"` raster
+                // branch's -1 handling below.
+                let repeat_count = if self.params[0] < 0 {
+                    1
+                } else {
+                    self.params[0] as u32
+                };
                 self.sixel.data.push(SixelData::Repeat {
-                    repeat_count: self.params[0] as u32,
+                    repeat_count,
                     data: data - 0x3f,
                 });
                 self.finish_command();
@@ -192,6 +202,41 @@ mod test {
     use crate::{Action, Esc, EscCode};
     use alloc::boxed::Box;
     use k9::assert_equal as assert_eq;
+
+    #[test]
+    fn sixel_repeat_omitted_count_defaults_to_one() {
+        // `!` (DECGRI) with no repeat count must default to 1. Previously the
+        // -1 "unspecified" sentinel was cast to u32, yielding 4294967295 and a
+        // multi-billion-iteration loop in the consumer from a tiny input.
+        let mut p = Parser::new();
+        let actions = p.parse_as_vec(b"\x1bPq!~\x1b\\");
+        let sixel = match &actions[0] {
+            Action::Sixel(s) => s,
+            other => panic!("expected Sixel action, got {:?}", other),
+        };
+        assert_eq!(
+            sixel.data,
+            vec![SixelData::Repeat {
+                repeat_count: 1,
+                data: 0x3f
+            }]
+        );
+
+        // An explicit repeat count is still honored.
+        let mut p = Parser::new();
+        let actions = p.parse_as_vec(b"\x1bPq!3~\x1b\\");
+        let sixel = match &actions[0] {
+            Action::Sixel(s) => s,
+            other => panic!("expected Sixel action, got {:?}", other),
+        };
+        assert_eq!(
+            sixel.data,
+            vec![SixelData::Repeat {
+                repeat_count: 3,
+                data: 0x3f
+            }]
+        );
+    }
 
     #[test]
     fn sixel() {


### PR DESCRIPTION
## Summary

In the sixel parser (`wezterm-escape-parser/src/parser/sixel.rs`), the `!` (DECGRI "graphics repeat") handler reads the repeat count as:

```rust
repeat_count: self.params[0] as u32,
```

`params` is initialised to `-1` (the "parameter unspecified" sentinel). When the repeat count is omitted, `params[0]` is still `-1`, and `(-1i64) as u32` wraps to **4294967295**. So a sequence like `ESC P q ! ~ ESC \` yields `Repeat { repeat_count: 4294967295 }`.

The consumer (`term/src/terminalstate/sixel.rs`) then runs `for _ in 0..repeat_count { … }`, i.e. ~4.3 billion iterations for a handful of input bytes — a significant CPU/UI stall on the output-processing path, reachable by anything that writes to the terminal (a `cat`-ed file, or a remote host over SSH). In a debug build the `x` counter also overflow-panics.

The sibling `"` raster-attributes branch already special-cases the `-1` sentinel (e.g. `pan = if self.params[0] == -1 { 2 } else { … }`); the repeat branch just missed it.

## Fix

Per the DEC spec, an omitted `Pn` for `!` defaults to `1`. Handle the sentinel the same way:

```rust
let repeat_count = if self.params[0] < 0 {
    1
} else {
    self.params[0] as u32
};
```

An explicit repeat count is unchanged. Added `sixel_repeat_omitted_count_defaults_to_one` to the existing test module; `cargo test -p wezterm-escape-parser` passes.
