### PR TITLE
termwiz(lineedit): Add Ctrl-u for Kill to StartOfLine

### DIFF
--- a/termwiz/src/lineedit/mod.rs
+++ b/termwiz/src/lineedit/mod.rs
@@ -497,6 +497,10 @@ impl<'term> LineEditor<'term> {
                 modifiers: Modifiers::CTRL,
             }) => Some(Action::Repaint),
             InputEvent::Key(KeyEvent {
+                key: KeyCode::Char('U'),
+                modifiers: Modifiers::CTRL,
+            }) => Some(Action::Kill(Movement::StartOfLine)),
+            InputEvent::Key(KeyEvent {
                 key: KeyCode::Char('K'),
                 modifiers: Modifiers::CTRL,
             }) => Some(Action::Kill(Movement::EndOfLine)),


### PR DESCRIPTION
I've been missing that keybind many times before e.g. when renaming my tabs using a `PromptInputLine`!

I initially added this to the prompt line overlay, but since similar Ctrl-k was already implemented to Kill to EndOfLine on the LineEditor in termwiz, adding Ctrl-u there felt like a logical addition.
.. Not sure why it wasn't impl from the beginning 🤔