### PR TITLE
termwiz: Add Action::ClearLine for LineEditor

### DIFF
--- a/termwiz/src/lineedit/actions.rs
+++ b/termwiz/src/lineedit/actions.rs
@@ -14,6 +14,7 @@ pub enum Movement {
 #[derive(Debug, Clone)]
 pub enum Action {
     AcceptLine,
+    ClearLine,
     Cancel,
     EndOfFile,
     InsertChar(RepeatCount, char),

--- a/termwiz/src/lineedit/mod.rs
+++ b/termwiz/src/lineedit/mod.rs
@@ -702,6 +702,11 @@ impl<'term> LineEditor<'term> {
 
                 self.state = EditorState::Accepted;
             }
+            Action::ClearLine => {
+                self.clear_completion();
+                self.cancel_search_state();
+                self.line.clear();
+            }
             Action::EndOfFile => {
                 return Err(
                     std::io::Error::new(std::io::ErrorKind::UnexpectedEof, "End Of File").into(),


### PR DESCRIPTION
This was needed to implement #8015 
Tested manually with #8015 

I'm not 100% sure about the clear impl, especially around how the search state works and should be managed 🤔