### PR TITLE
overlays(prompt,debug): Clear line before Cancel when pressing Escape

### DIFF
--- a/wezterm-gui/src/overlay/debug.rs
+++ b/wezterm-gui/src/overlay/debug.rs
@@ -106,7 +106,10 @@ impl LineEditorHost for LuaReplHost {
             InputEvent::Key(KeyEvent {
                 key: KeyCode::Escape,
                 ..
-            }) => line.is_empty().then_some(Action::Cancel),
+            }) => match line.is_empty() {
+                true => Some(Action::Cancel),
+                false => Some(Action::ClearLine),
+            },
             _ => None,
         }
     }

--- a/wezterm-gui/src/overlay/prompt.rs
+++ b/wezterm-gui/src/overlay/prompt.rs
@@ -35,7 +35,10 @@ impl LineEditorHost for PromptHost {
             InputEvent::Key(KeyEvent {
                 key: KeyCode::Escape,
                 ..
-            }) => line.is_empty().then_some(Action::Cancel),
+            }) => match line.is_empty() {
+                true => Some(Action::Cancel),
+                false => Some(Action::ClearLine),
+            },
             _ => None,
         }
     }


### PR DESCRIPTION
This helps e.g. in the debug overlay, to avoid exiting it by easy mistake. This is especially for people that are used to modal editors (vim, ..) where pressing Escape becomes a _reflex_ after some text input 😬

note: recent commit 63061d7797fecd37366e605d39daddc105a43698 refactored these `resolve_action` impl to be more easily extensible.