### PR TITLE
term: preserve cursor at start of line during rewrap

### DIFF
--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -149,7 +149,7 @@ impl Screen {
                 // line and it won't resize with the line correctly.
                 // Put it back on the prior line. The cursor is now
                 // technically outside of the viewport width.
-                if adjusted_cursor.0 == 0 && adjusted_cursor.1 > 0 {
+                if x > 0 && adjusted_cursor.0 == 0 && adjusted_cursor.1 > 0 {
                     if physical_cols < self.physical_cols {
                         // getting smaller: preserve its original position
                         // on the prior line

--- a/term/src/test/mod.rs
+++ b/term/src/test/mod.rs
@@ -916,6 +916,22 @@ fn test_resize_2162() {
     term.assert_cursor_pos(19, 0, None, Some(7));
 }
 
+/// A cursor with logical x=0 is at the start of a logical line,
+/// not a wrapped continuation.
+#[test]
+fn test_resize_cursor_issue_7994() {
+    let mut term = TestTerm::new(4, 20, 0);
+    term.print("start\r\n");
+    term.assert_cursor_pos(0, 1, None, None);
+
+    term.resize(TerminalSize {
+        rows: 4,
+        cols: 21,
+        ..Default::default()
+    });
+    term.assert_cursor_pos(0, 1, None, None);
+}
+
 /// Test the behavior of wrapped lines when we resize the terminal
 /// wider and then narrower.
 #[test]


### PR DESCRIPTION
> [!NOTE]
> This change was developed with assistance from OpenAI Codex. I reviewed and verified the proposed fix, tests, and PR description.

## Summary

- preserve a cursor at the start of a logical line when the terminal width changes
- restrict the wrapped-line cursor adjustment to non-zero logical offsets
- add a regression test for #7994

Fixes #7994.

## Root cause

When the terminal width changes, `Screen::rewrap_lines` converts the cursor position into an offset within its logical line and then calculates its new physical row and column.

The existing special case handles a cursor that lands exactly at a wrapping boundary:

https://github.com/wezterm/wezterm/blob/4b1c3c151eb530e569f867e1461693c56fe89695/term/src/screen.rs#L142-L165

It moves the cursor back to the preceding physical row so that the cursor remains associated with the wrapped logical line.

However, this condition also matches an ordinary cursor at the start of a logical line, where the logical offset `x` is zero. For example, after:

```
start\r\n
```

the cursor is normally at `(x=0, y=1)`. When the terminal is widened, the special case incorrectly treats it as a wrapping boundary, moves it to the previous row, and sets its column to `physical_cols`.

The subsequent output is therefore rendered at the wrong position.

The fix is to apply the special case only when the logical offset is non-zero:

```rust
if x > 0 && adjusted_cursor.0 == 0 && adjusted_cursor.1 > 0 {
```

A positive logical offset that maps to physical column zero represents a real wrapping boundary. A zero logical offset represents the ordinary start of a logical line and should not be adjusted.

Although #7994 was reproduced on Windows, this code is part of the platform-independent terminal reflow implementation.

## Relation to #2162
The special-case adjustment was introduced in commit [4bf89e0c1](https://github.com/wezterm/wezterm/commit/4bf89e0c1062b04b82699f0911d3936c0d9ed0a0) to address cursor drift at exact wrapping boundaries reported in #2162.

This change keeps that behavior for non-zero logical offsets while excluding the distinct `x == 0` case. In other words, it narrows the #2162 workaround rather than removing it.

The existing `test_resize_2162*` tests continue to pass.

## Testing
The new regression test:

1. writes `start\r\n`
2. verifies that the cursor is at `(0, 1)`
3. changes the terminal column count
4. verifies that the cursor remains at `(0, 1)`

Tests run:
```console
cargo test -p wezterm-term test_resize_cursor_issue_7994
cargo test -p wezterm-term test_resize_2162
```