### PR TITLE
cairo: Remove unused features

### DIFF
--- a/deps/cairo/Cargo.toml
+++ b/deps/cairo/Cargo.toml
@@ -22,14 +22,13 @@ pdf = []
 svg = []
 ps = []
 script = []
-win32-surface = []
-xlib = []
-xcb = []
-freetype = []
-use_glib = []
 
 [dependencies]
 libc.workspace = true
 
 [build-dependencies]
 cc.workspace = true
+
+[lints.rust]
+# Avoid diagnostics for features that are no longer defined but are still referenced by conditional compilation.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("freetype","use_glib","win32-surface","x11","xcb","xlib"))'] }


### PR DESCRIPTION
Remove unused `cairo-sys-rs` features that cause `cargo check --all-features` at the workspace root to fail.

```console
$ cargo check -q -p cairo-sys-rs --all-features
error[E0463]: can't find crate for `x11`
  --> deps/cairo/src/lib.rs:12:1
   |
12 | extern crate x11;
   | ^^^^^^^^^^^^^^^^^ can't find crate

For more information about this error, try `rustc --explain E0463`.
error: could not compile `cairo-sys-rs` (lib) due to 1 previous error
```

Compared to commit d7ede9fb04fa59f334986e08dcfa99ba065d9d1a, this approach is cleaner because it removes the unnecessary feature flags instead of working around the issue.
