### PR TITLE
Fix pane focus ping-ponging between two panes

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -441,7 +441,7 @@ macro_rules! pdu {
 /// The overall version of the codec.
 /// This must be bumped when backwards incompatible changes
 /// are made to the types and protocol.
-pub const CODEC_VERSION: usize = 45;
+pub const CODEC_VERSION: usize = 46;
 
 // Defines the Pdu enum.
 // Each struct has an explicit identifying number.
@@ -502,6 +502,7 @@ pdu! {
     GetPaneDirection: 60,
     GetPaneDirectionResponse: 61,
     AdjustPaneSize: 62,
+    PaneFocusAcknowledged: 63,
 }
 
 impl Pdu {
@@ -594,7 +595,7 @@ impl Pdu {
             | Pdu::SetPalette(SetPalette { pane_id, .. })
             | Pdu::NotifyAlert(NotifyAlert { pane_id, .. })
             | Pdu::SetClipboard(SetClipboard { pane_id, .. })
-            | Pdu::PaneFocused(PaneFocused { pane_id })
+            | Pdu::PaneFocused(PaneFocused { pane_id, .. })
             | Pdu::PaneRemoved(PaneRemoved { pane_id }) => Some(*pane_id),
             _ => None,
         }
@@ -822,6 +823,7 @@ pub struct WindowTitleChanged {
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub struct PaneFocused {
     pub pane_id: PaneId,
+    pub focus_seq: u64,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
@@ -839,6 +841,12 @@ pub struct SetClientId {
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub struct SetFocusedPane {
     pub pane_id: PaneId,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug)]
+pub struct PaneFocusAcknowledged {
+    pub pane_id: PaneId,
+    pub focus_seq: u64,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
@@ -1248,6 +1256,29 @@ mod test {
             },
             Pdu::decode(encoded.as_slice()).unwrap()
         );
+    }
+
+    #[test]
+    fn pane_focus_pdus_round_trip_with_sequence() {
+        // The notification and its acknowledgement must preserve the same
+        // correlation sequence across the wire.
+        for pdu in [
+            Pdu::PaneFocused(PaneFocused {
+                pane_id: 42,
+                focus_seq: 7,
+            }),
+            Pdu::PaneFocusAcknowledged(PaneFocusAcknowledged {
+                pane_id: 42,
+                focus_seq: 7,
+            }),
+        ] {
+            let mut encoded = Vec::new();
+            pdu.encode(&mut encoded, 0x43).unwrap();
+            assert_eq!(
+                DecodedPdu { serial: 0x43, pdu },
+                Pdu::decode(encoded.as_slice()).unwrap()
+            );
+        }
     }
 
     #[test]

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -1,7 +1,7 @@
 use crate::client::{ClientId, ClientInfo};
 use crate::pane::{CachePolicy, Pane, PaneId};
 use crate::ssh_agent::AgentProxy;
-use crate::tab::{SplitRequest, Tab, TabId};
+use crate::tab::{NotifyMux, SplitRequest, Tab, TabId};
 use crate::window::{Window, WindowId};
 use anyhow::{anyhow, Context, Error};
 use config::keyassignment::SpawnTabDomain;
@@ -82,6 +82,9 @@ pub enum MuxNotification {
         window_id: WindowId,
     },
     PaneFocused(PaneId),
+    /// Focus received from another mux has been applied locally. Refresh local
+    /// UI state and propagate downstream without sending it back upstream.
+    PaneFocusReconciled(PaneId),
     TabResized(TabId),
     TabTitleChanged {
         tab_id: TabId,
@@ -510,6 +513,13 @@ impl Mux {
         }
     }
 
+    /// Record acknowledged client state without synthesizing focus events.
+    pub fn record_focus_metadata_for_client(&self, client_id: &ClientId, pane_id: PaneId) {
+        if let Some(info) = self.clients.write().get_mut(client_id) {
+            info.update_focused_pane(pane_id);
+        }
+    }
+
     pub fn resolve_focused_pane(
         &self,
         client_id: &ClientId,
@@ -540,9 +550,21 @@ impl Mux {
         }
     }
 
-    /// Called by PaneFocused event handlers to reconcile a remote
-    /// pane focus event and apply its effects locally
     pub fn focus_pane_and_containing_tab(&self, pane_id: PaneId) -> anyhow::Result<()> {
+        self.focus_pane_and_containing_tab_with_notify(pane_id, NotifyMux::Yes)
+    }
+
+    /// Reconcile a focus event already decided elsewhere without broadcasting
+    /// another PaneFocused notification.
+    pub fn reconcile_pane_focus(&self, pane_id: PaneId) -> anyhow::Result<()> {
+        self.focus_pane_and_containing_tab_with_notify(pane_id, NotifyMux::No)
+    }
+
+    fn focus_pane_and_containing_tab_with_notify(
+        &self,
+        pane_id: PaneId,
+        notify_mux: NotifyMux,
+    ) -> anyhow::Result<()> {
         let pane = self
             .get_pane(pane_id)
             .ok_or_else(|| anyhow::anyhow!("pane {pane_id} not found"))?;
@@ -567,7 +589,7 @@ impl Mux {
             .get_tab(tab_id)
             .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
 
-        tab.set_active_pane(&pane);
+        tab.set_active_pane_with_notify(&pane, notify_mux);
 
         Ok(())
     }

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -20,6 +20,17 @@ pub type Cursor = bintree::Cursor<Arc<dyn Pane>, SplitDirectionAndSize>;
 static TAB_ID: ::std::sync::atomic::AtomicUsize = ::std::sync::atomic::AtomicUsize::new(0);
 pub type TabId = usize;
 
+/// Controls whether changing the active pane broadcasts [`MuxNotification::PaneFocused`].
+///
+/// Use [`NotifyMux::No`] only while applying a focus event that was already
+/// broadcast or received from another mux; normal focus actions must notify.
+/// See <https://github.com/wezterm/wezterm/issues/4390>.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum NotifyMux {
+    Yes,
+    No,
+}
+
 #[derive(Default)]
 struct Recency {
     count: usize,
@@ -699,7 +710,15 @@ impl Tab {
     }
 
     pub fn set_active_pane(&self, pane: &Arc<dyn Pane>) {
-        self.inner.lock().set_active_pane(pane)
+        self.set_active_pane_with_notify(pane, NotifyMux::Yes)
+    }
+
+    /// Activates `pane`, optionally broadcasting [`MuxNotification::PaneFocused`].
+    ///
+    /// Normal user actions should call [`Tab::set_active_pane`]. Suppression is
+    /// reserved for reconciling a focus event that has already been broadcast.
+    pub fn set_active_pane_with_notify(&self, pane: &Arc<dyn Pane>, notify_mux: NotifyMux) {
+        self.inner.lock().set_active_pane(pane, notify_mux)
     }
 
     pub fn set_active_idx(&self, pane_index: usize) {
@@ -1747,7 +1766,7 @@ impl TabInner {
         self.active
     }
 
-    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>) {
+    fn set_active_pane(&mut self, pane: &Arc<dyn Pane>, notify_mux: NotifyMux) {
         let prior = self.get_active_pane();
 
         if is_pane(pane, &prior.as_ref()) {
@@ -1768,22 +1787,26 @@ impl TabInner {
         {
             self.active = item.index;
             self.recency.tag(item.index);
-            self.advise_focus_change(prior);
+            self.advise_focus_change(prior, notify_mux);
         }
     }
 
-    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>) {
+    fn advise_focus_change(&mut self, prior: Option<Arc<dyn Pane>>, notify_mux: NotifyMux) {
         let mux = Mux::get();
         let current = self.get_active_pane();
         match (prior, current) {
             (Some(prior), Some(current)) if prior.pane_id() != current.pane_id() => {
                 prior.focus_changed(false);
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify_mux == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (None, Some(current)) => {
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                if notify_mux == NotifyMux::Yes {
+                    mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                }
             }
             (Some(prior), None) => {
                 prior.focus_changed(false);
@@ -1798,7 +1821,7 @@ impl TabInner {
         let prior = self.get_active_pane();
         self.active = pane_index;
         self.recency.tag(pane_index);
-        self.advise_focus_change(prior);
+        self.advise_focus_change(prior, NotifyMux::Yes);
     }
 
     fn assign_pane(&mut self, pane: &Arc<dyn Pane>) {
@@ -1861,7 +1884,7 @@ impl TabInner {
         if keep_focus {
             self.set_active_idx(pane_index);
         } else {
-            self.advise_focus_change(Some(pane));
+            self.advise_focus_change(Some(pane), NotifyMux::Yes);
         }
         None
     }
@@ -2198,6 +2221,7 @@ impl Into<String> for SerdeUrl {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::client::ClientId;
     use crate::renderable::*;
     use parking_lot::{MappedMutexGuard, Mutex};
     use rangeset::RangeSet;
@@ -2206,6 +2230,8 @@ mod test {
     use url::Url;
     use wezterm_term::color::ColorPalette;
     use wezterm_term::{KeyCode, KeyModifiers, Line, MouseEvent, StableRowIndex};
+
+    static MUX_TEST_GUARD: Mutex<()> = Mutex::new(());
 
     struct FakePane {
         id: PaneId,
@@ -2219,6 +2245,26 @@ mod test {
                 size: Mutex::new(size),
             })
         }
+    }
+
+    fn two_pane_tab(size: TerminalSize) -> (Arc<Tab>, Arc<dyn Pane>, Arc<dyn Pane>) {
+        let tab = Arc::new(Tab::new(&size));
+        let pane_1 = FakePane::new(1, size);
+        tab.assign_pane(&pane_1);
+        let pane_2 = FakePane::new(2, size);
+        let split = tab
+            .compute_split_size(
+                0,
+                SplitRequest {
+                    direction: SplitDirection::Horizontal,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        tab.split_and_insert(0, SplitRequest::default(), Arc::clone(&pane_2))
+            .unwrap();
+        pane_1.resize(split.first).unwrap();
+        (tab, pane_1, pane_2)
     }
 
     impl Pane for FakePane {
@@ -2519,6 +2565,99 @@ mod test {
 
     fn is_send_and_sync<T: Send + Sync>() -> bool {
         true
+    }
+
+    #[test]
+    fn user_pane_focus_emits_one_focus_notification() {
+        // A user-initiated focus change must retain the default broadcast.
+        let _guard = MUX_TEST_GUARD.lock();
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+
+        let mux = Arc::new(Mux::new(None));
+        Mux::set_mux(&mux);
+
+        let notified_panes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&notified_panes);
+        mux.subscribe(move |notification| {
+            if let MuxNotification::PaneFocused(pane_id) = notification {
+                recorded.lock().push(pane_id);
+            }
+            true
+        });
+
+        let (tab, pane_1, _pane_2) = two_pane_tab(size);
+
+        tab.set_active_pane(&pane_1);
+
+        assert_eq!(1, tab.get_active_pane().unwrap().pane_id());
+        assert_eq!(vec![1], *notified_panes.lock());
+
+        Mux::shutdown();
+    }
+
+    #[test]
+    fn mux_focus_action_notifies_but_reconciliation_does_not() {
+        // Reconciliation applies an already-decided focus without feeding it
+        // back, while the normal user-action API must still broadcast.
+        let _guard = MUX_TEST_GUARD.lock();
+        let _executor = promise::spawn::ScopedExecutor::new();
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+
+        let mux = Arc::new(Mux::new(None));
+        Mux::set_mux(&mux);
+
+        let (tab, pane_1, pane_2) = two_pane_tab(size);
+
+        mux.add_tab_no_panes(&tab);
+        mux.add_pane(&pane_1).unwrap();
+        mux.add_pane(&pane_2).unwrap();
+        let window = mux.new_empty_window(None, None);
+        mux.add_tab_to_window(&tab, *window).unwrap();
+
+        let notified_panes = Arc::new(Mutex::new(Vec::new()));
+        let recorded = Arc::clone(&notified_panes);
+        mux.subscribe(move |notification| {
+            if let MuxNotification::PaneFocused(pane_id) = notification {
+                recorded.lock().push(pane_id);
+            }
+            true
+        });
+
+        mux.reconcile_pane_focus(1).unwrap();
+
+        assert_eq!(1, tab.get_active_pane().unwrap().pane_id());
+        assert!(notified_panes.lock().is_empty());
+
+        mux.focus_pane_and_containing_tab(2).unwrap();
+
+        assert_eq!(2, tab.get_active_pane().unwrap().pane_id());
+        assert_eq!(vec![2], *notified_panes.lock());
+
+        let client_id = Arc::new(ClientId::new());
+        mux.register_client(Arc::clone(&client_id));
+        mux.record_focus_metadata_for_client(&client_id, 1);
+        let client = mux
+            .iter_clients()
+            .into_iter()
+            .find(|client| client.client_id == client_id)
+            .unwrap();
+        assert_eq!(Some(1), client.focused_pane_id);
+        assert_eq!(vec![2], *notified_panes.lock());
+
+        drop(window);
+        Mux::shutdown();
     }
 
     #[test]

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -1,7 +1,7 @@
 use crate::domain::{DomainId, WriterWrapper};
 use crate::localpane::LocalPane;
 use crate::pane::{alloc_pane_id, PaneId};
-use crate::tab::{SplitDirection, SplitRequest, SplitSize, Tab, TabId};
+use crate::tab::{NotifyMux, SplitDirection, SplitRequest, SplitSize, Tab, TabId};
 use crate::tmux::{AttachState, TmuxDomain, TmuxDomainState, TmuxRemotePane, TmuxTab};
 use crate::tmux_pty::{TmuxChild, TmuxPty};
 use crate::{Mux, MuxNotification, Pane};
@@ -341,7 +341,8 @@ impl TmuxDomainState {
 
                     match mux.get_tab(local_tab.tab_id) {
                         Some(tab) => {
-                            tab.set_active_pane(&local_pane);
+                            // The synchronized tmux state is broadcast below.
+                            tab.set_active_pane_with_notify(&local_pane, NotifyMux::No);
                             mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
                         }
                         None => {}

--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -113,9 +113,15 @@ macro_rules! rpc {
     };
 }
 
-fn process_unilateral_inner(pane_id: PaneId, local_domain_id: DomainId, decoded: DecodedPdu) {
+fn process_unilateral_inner(
+    pane_id: PaneId,
+    local_domain_id: DomainId,
+    decoded: DecodedPdu,
+    pane_focus_ticket: Option<u64>,
+) {
     promise::spawn::spawn(async move {
-        process_unilateral_inner_async(pane_id, local_domain_id, decoded).await?;
+        process_unilateral_inner_async(pane_id, local_domain_id, decoded, pane_focus_ticket)
+            .await?;
         Ok::<(), anyhow::Error>(())
     })
     .detach();
@@ -125,6 +131,7 @@ async fn process_unilateral_inner_async(
     pane_id: PaneId,
     local_domain_id: DomainId,
     decoded: DecodedPdu,
+    pane_focus_ticket: Option<u64>,
 ) -> anyhow::Result<()> {
     let mux = match Mux::try_get() {
         Some(mux) => mux,
@@ -188,6 +195,11 @@ async fn process_unilateral_inner_async(
             decoded.pdu
         )
     })?;
+    if let Some(ticket) = pane_focus_ticket {
+        if !client_domain.is_current_pane_focus_ticket(ticket) {
+            return Ok(());
+        }
+    }
     client_pane.process_unilateral(decoded.pdu).await
 }
 
@@ -321,8 +333,21 @@ fn process_unilateral(
     }
 
     if let Some(pane_id) = decoded.pdu.pane_id() {
+        let pane_focus_ticket = if matches!(&decoded.pdu, Pdu::PaneFocused(_)) {
+            if let Some(domain) = Mux::try_get().and_then(|mux| mux.get_domain(local_domain_id)) {
+                if let Some(domain) = domain.downcast_ref::<ClientDomain>() {
+                    Some(domain.next_pane_focus_ticket())
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        };
         promise::spawn::spawn_into_main_thread(async move {
-            process_unilateral_inner(pane_id, local_domain_id, decoded)
+            process_unilateral_inner(pane_id, local_domain_id, decoded, pane_focus_ticket)
         })
         .detach();
     } else {
@@ -1087,6 +1112,10 @@ impl Client {
                             Ok(_) => {
                                 backoff = BASE_INTERVAL;
                                 log::error!("Reconnected!");
+                                // The reader resumes only after this branch, so
+                                // invalidate old-socket focus work before any
+                                // PDU from the new connection can be received.
+                                ClientDomain::invalidate_pane_focus_tickets(local_domain_id);
                                 promise::spawn::spawn_into_main_thread(async move {
                                     ClientDomain::reattach(local_domain_id, ui).await.ok();
                                 })
@@ -1377,6 +1406,7 @@ impl Client {
     rpc!(list_clients, GetClientList = (), GetClientListResponse);
     rpc!(set_window_workspace, SetWindowWorkspace, UnitResponse);
     rpc!(set_focused_pane_id, SetFocusedPane, UnitResponse);
+    rpc!(acknowledge_pane_focus, PaneFocusAcknowledged, UnitResponse);
     rpc!(get_image_cell, GetImageCell, GetImageCellResponse);
     rpc!(set_configured_palette_for_pane, SetPalette, UnitResponse);
     rpc!(set_tab_title, TabTitleChanged, UnitResponse);

--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -14,8 +14,26 @@ use mux::{Mux, MuxNotification};
 use portable_pty::CommandBuilder;
 use promise::spawn::spawn_into_new_thread;
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use wezterm_term::TerminalSize;
+
+#[derive(Default)]
+struct PaneFocusTickets(AtomicU64);
+
+impl PaneFocusTickets {
+    fn next(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    fn is_current(&self, ticket: u64) -> bool {
+        self.0.load(Ordering::SeqCst) == ticket
+    }
+
+    fn invalidate(&self) {
+        self.next();
+    }
+}
 
 pub struct ClientInner {
     pub client: Client,
@@ -255,6 +273,7 @@ pub struct ClientDomain {
     label: String,
     inner: Mutex<Option<Arc<ClientInner>>>,
     local_domain_id: DomainId,
+    pane_focus_tickets: PaneFocusTickets,
 }
 
 async fn update_remote_workspace(
@@ -405,11 +424,30 @@ impl ClientDomain {
             label,
             inner: Mutex::new(None),
             local_domain_id,
+            pane_focus_tickets: PaneFocusTickets::default(),
         }
     }
 
     fn inner(&self) -> Option<Arc<ClientInner>> {
         self.inner.lock().unwrap().as_ref().map(Arc::clone)
+    }
+
+    pub(crate) fn next_pane_focus_ticket(&self) -> u64 {
+        self.pane_focus_tickets.next()
+    }
+
+    pub(crate) fn is_current_pane_focus_ticket(&self, ticket: u64) -> bool {
+        self.pane_focus_tickets.is_current(ticket)
+    }
+
+    pub(crate) fn invalidate_pane_focus_tickets(domain_id: DomainId) {
+        if let Some(mux) = Mux::try_get() {
+            if let Some(domain) = mux.get_domain(domain_id) {
+                if let Some(domain) = domain.downcast_ref::<Self>() {
+                    domain.pane_focus_tickets.invalidate();
+                }
+            }
+        }
     }
 
     pub fn connect_automatically(&self) -> bool {
@@ -418,6 +456,9 @@ impl ClientDomain {
 
     pub fn perform_detach(&self) {
         log::info!("detached domain {}", self.local_domain_id);
+        // Work spawned by the old connection must not reconcile against pane
+        // mappings established by a later attach.
+        self.pane_focus_tickets.invalidate();
         self.inner.lock().unwrap().take();
         let mux = Mux::get();
         mux.domain_was_detached(self.local_domain_id);
@@ -934,6 +975,10 @@ impl Domain for ClientDomain {
             return Ok(());
         }
 
+        // Advance before opening the new connection, so no task from a prior
+        // socket can reconcile against this attach's pane mappings.
+        self.pane_focus_tickets.invalidate();
+
         let domain_id = self.local_domain_id;
         let config = self.config.clone();
 
@@ -1004,5 +1049,38 @@ impl Domain for ClientDomain {
         } else {
             DomainState::Detached
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::PaneFocusTickets;
+
+    #[test]
+    fn only_the_latest_received_focus_ticket_is_current() {
+        // Detached reconciliation tasks may finish out of order, so receipt of
+        // a newer focus event must invalidate all earlier local work tickets.
+        let tickets = PaneFocusTickets::default();
+
+        let first = tickets.next();
+        assert!(tickets.is_current(first));
+
+        let second = tickets.next();
+        assert!(!tickets.is_current(first));
+        assert!(tickets.is_current(second));
+    }
+
+    #[test]
+    fn connection_boundary_invalidates_in_flight_focus_ticket() {
+        // A detached task from an old socket must never become current again
+        // after a reconnect, even before the new socket receives a focus PDU.
+        let tickets = PaneFocusTickets::default();
+        let old_connection = tickets.next();
+
+        tickets.invalidate();
+
+        assert!(!tickets.is_current(old_connection));
+        let new_connection = tickets.next();
+        assert!(tickets.is_current(new_connection));
     }
 }

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -214,7 +214,7 @@ impl ClientPane {
 
                 self.client.expire_stale_mappings();
             }
-            Pdu::PaneFocused(PaneFocused { pane_id }) => {
+            Pdu::PaneFocused(PaneFocused { pane_id, focus_seq }) => {
                 // We get here whenever the pane focus is changed on the
                 // server. That might be due to the user here in the GUI
                 // doing things, or it may be due to a "remote"
@@ -226,9 +226,36 @@ impl ClientPane {
                 // it here.
                 log::trace!("advised of remote pane focus: {pane_id}");
 
+                // Record the server's decision before applying it locally.
+                // `focus_changed(true)` will then see that this remote pane is
+                // already focused and won't echo a SetFocusedPane request.
+                {
+                    let mut focused = self.client.focused_remote_pane_id.lock().unwrap();
+                    *focused = Some(pane_id);
+                }
+
                 let mux = Mux::get();
-                if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
+                if let Err(err) = mux.reconcile_pane_focus(self.local_pane_id) {
+                    // Don't let a failed reconciliation suppress a later local
+                    // attempt to report this pane to the server.
+                    let mut focused = self.client.focused_remote_pane_id.lock().unwrap();
+                    if *focused == Some(pane_id) {
+                        focused.take();
+                    }
                     log::error!("Error reconciling remote PaneFocused notification: {err:#}");
+                } else {
+                    // The PDU bypassed the local mux notification stream. Let
+                    // local UI subscribers repaint without triggering another
+                    // focus reconciliation or forwarding anything upstream.
+                    mux.notify(MuxNotification::PaneFocusReconciled(self.local_pane_id));
+                    let client = Arc::clone(&self.client);
+                    promise::spawn::spawn(async move {
+                        client
+                            .client
+                            .acknowledge_pane_focus(PaneFocusAcknowledged { pane_id, focus_seq })
+                            .await
+                    })
+                    .detach();
                 }
             }
             _ => bail!("unhandled unilateral pdu: {:?}", pdu),

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -80,12 +80,13 @@ impl GuiFrontEnd {
                 MuxNotification::PaneFocused(pane_id) => {
                     promise::spawn::spawn_into_main_thread(async move {
                         let mux = Mux::get();
-                        if let Err(err) = mux.focus_pane_and_containing_tab(pane_id) {
+                        if let Err(err) = mux.reconcile_pane_focus(pane_id) {
                             log::error!("Error reconciling PaneFocused notification: {err:#}");
                         }
                     })
                     .detach();
                 }
+                MuxNotification::PaneFocusReconciled(_) => {}
                 MuxNotification::TabTitleChanged { .. } => {}
                 MuxNotification::WindowTitleChanged { .. } => {}
                 MuxNotification::TabResized(_) => {}

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1301,7 +1301,7 @@ impl TermWindow {
                 MuxNotification::SaveToDownloads { .. } => {
                     // Handled by frontend
                 }
-                MuxNotification::PaneFocused(_) => {
+                MuxNotification::PaneFocused(_) | MuxNotification::PaneFocusReconciled(_) => {
                     // Also handled by clientpane
                     self.update_title_post_status();
                 }
@@ -1469,6 +1469,7 @@ impl TermWindow {
                     | Alert::Bell,
             }
             | MuxNotification::PaneFocused(pane_id)
+            | MuxNotification::PaneFocusReconciled(pane_id)
             | MuxNotification::PaneRemoved(pane_id)
             | MuxNotification::PaneOutput(pane_id) => {
                 // Check window validity and propagate to the window event handler

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -23,6 +23,23 @@ enum Item {
     Readable,
 }
 
+fn pane_focus_notification_pdu(
+    handler: &mut SessionHandler,
+    notification: &MuxNotification,
+) -> Option<anyhow::Result<Pdu>> {
+    let pane_id = match notification {
+        MuxNotification::PaneFocused(pane_id) | MuxNotification::PaneFocusReconciled(pane_id) => {
+            *pane_id
+        }
+        _ => return None,
+    };
+    Some(
+        handler
+            .next_pane_focus_notification(pane_id)
+            .map(Pdu::PaneFocused),
+    )
+}
+
 pub async fn process<T>(stream: T) -> anyhow::Result<()>
 where
     T: 'static,
@@ -166,8 +183,12 @@ where
                     stream.flush().await.context("flushing PDU to client")?;
                 }
             }
-            Ok(Item::Notif(MuxNotification::PaneFocused(pane_id))) => {
-                Pdu::PaneFocused(codec::PaneFocused { pane_id })
+            Ok(Item::Notif(
+                notification @ (MuxNotification::PaneFocused(_)
+                | MuxNotification::PaneFocusReconciled(_)),
+            )) => {
+                pane_focus_notification_pdu(&mut handler, &notification)
+                    .expect("matched pane focus notification")?
                     .encode_async(&mut stream, 0)
                     .await?;
                 stream.flush().await.context("flushing PDU to client")?;
@@ -209,5 +230,30 @@ where
                 return Ok(());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn reconciled_focus_is_forwarded_as_a_sequenced_focus_pdu() {
+        // An upstream focus reconciliation must reach downstream clients as a
+        // normal focus PDU without being echoed back to the upstream domain.
+        let mut handler = SessionHandler::new(PduSender::new(|_| Ok(())));
+
+        let pdu =
+            pane_focus_notification_pdu(&mut handler, &MuxNotification::PaneFocusReconciled(42))
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(
+            Pdu::PaneFocused(codec::PaneFocused {
+                pane_id: 42,
+                focus_seq: 1,
+            }),
+            pdu
+        );
     }
 }

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -6,16 +6,18 @@ use mux::client::ClientId;
 use mux::domain::SplitSource;
 use mux::pane::{CachePolicy, Pane, PaneId};
 use mux::renderable::{RenderableDimensions, StableCursorPosition};
-use mux::tab::TabId;
+use mux::tab::{NotifyMux, TabId};
 use mux::{Mux, MuxNotification};
 use promise::spawn::spawn_into_main_thread;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use termwiz::surface::SequenceNo;
 use url::Url;
 use wezterm_term::terminal::Alert;
 use wezterm_term::StableRowIndex;
+
+const MAX_PENDING_PANE_FOCUS: usize = 256;
 
 #[derive(Clone)]
 pub struct PduSender {
@@ -201,6 +203,9 @@ pub struct SessionHandler {
     per_pane: HashMap<TabId, Arc<Mutex<PerPane>>>,
     client_id: Option<Arc<ClientId>>,
     proxy_client_id: Option<ClientId>,
+    last_sent_pane_focus_seq: u64,
+    last_acknowledged_pane_focus_seq: u64,
+    pending_pane_focus: BTreeMap<u64, PaneId>,
 }
 
 impl Drop for SessionHandler {
@@ -219,7 +224,44 @@ impl SessionHandler {
             per_pane: HashMap::new(),
             client_id: None,
             proxy_client_id: None,
+            last_sent_pane_focus_seq: 0,
+            last_acknowledged_pane_focus_seq: 0,
+            pending_pane_focus: BTreeMap::new(),
         }
+    }
+
+    pub(crate) fn next_pane_focus_notification(
+        &mut self,
+        pane_id: PaneId,
+    ) -> anyhow::Result<PaneFocused> {
+        let focus_seq = self
+            .last_sent_pane_focus_seq
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("pane focus sequence exhausted"))?;
+        self.last_sent_pane_focus_seq = focus_seq;
+        self.pending_pane_focus.insert(focus_seq, pane_id);
+        while self.pending_pane_focus.len() > MAX_PENDING_PANE_FOCUS {
+            self.pending_pane_focus.pop_first();
+        }
+        Ok(PaneFocused { pane_id, focus_seq })
+    }
+
+    fn accept_pane_focus_acknowledgement(&mut self, pane_id: PaneId, focus_seq: u64) -> bool {
+        if focus_seq <= self.last_acknowledged_pane_focus_seq
+            || self.pending_pane_focus.get(&focus_seq) != Some(&pane_id)
+        {
+            return false;
+        }
+
+        self.last_acknowledged_pane_focus_seq = focus_seq;
+        self.pending_pane_focus
+            .retain(|pending_seq, _| *pending_seq > focus_seq);
+        true
+    }
+
+    fn supersede_pending_pane_focus_acknowledgements(&mut self) {
+        self.last_acknowledged_pane_focus_seq = self.last_sent_pane_focus_seq;
+        self.pending_pane_focus.clear();
     }
 
     pub(crate) fn per_pane(&mut self, pane_id: PaneId) -> Arc<Mutex<PerPane>> {
@@ -329,6 +371,12 @@ impl SessionHandler {
                 send_response(Ok(Pdu::UnitResponse(UnitResponse {})))
             }
             Pdu::SetFocusedPane(SetFocusedPane { pane_id }) => {
+                // A direct client action is newer than any server focus still
+                // awaiting acknowledgement on this connection. Don't allow a
+                // late acknowledgement to overwrite the action's metadata.
+                if Mux::get().resolve_pane_id(pane_id).is_some() {
+                    self.supersede_pending_pane_focus_acknowledgements();
+                }
                 let client_id = self.client_id.clone();
                 spawn_into_main_thread(async move {
                     catch(
@@ -358,7 +406,9 @@ impl SessionHandler {
                             let tab = mux
                                 .get_tab(tab_id)
                                 .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
-                            tab.set_active_pane(&pane);
+                            // The server broadcasts this focus below after
+                            // recording it for the current client.
+                            tab.set_active_pane_with_notify(&pane, NotifyMux::No);
 
                             mux.record_focus_for_current_identity(pane_id);
                             mux.notify(mux::MuxNotification::PaneFocused(pane_id));
@@ -369,6 +419,17 @@ impl SessionHandler {
                     )
                 })
                 .detach();
+            }
+            Pdu::PaneFocusAcknowledged(PaneFocusAcknowledged { pane_id, focus_seq }) => {
+                let mux = Mux::get();
+                if mux.resolve_pane_id(pane_id).is_some()
+                    && self.accept_pane_focus_acknowledgement(pane_id, focus_seq)
+                {
+                    if let Some(client_id) = &self.client_id {
+                        mux.record_focus_metadata_for_client(client_id, pane_id);
+                    }
+                }
+                send_response(Ok(Pdu::UnitResponse(UnitResponse {})));
             }
             Pdu::GetClientList(GetClientList) => {
                 spawn_into_main_thread(async move {
@@ -1124,4 +1185,93 @@ async fn move_pane(
         tab_id: tab.tab_id(),
         window_id,
     }))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn handler() -> SessionHandler {
+        SessionHandler::new(PduSender::new(|_| Ok(())))
+    }
+
+    #[test]
+    fn pane_focus_acknowledgements_are_correlated_and_monotonic() {
+        // Only acknowledgements for a pane that was actually sent may advance
+        // the client's successfully-applied focus state.
+        let mut handler = handler();
+        let first = handler.next_pane_focus_notification(10).unwrap();
+        let second = handler.next_pane_focus_notification(20).unwrap();
+
+        // A remains a valid applied focus even if B was delivered before A's
+        // acknowledgement and B subsequently fails to apply.
+        assert!(handler.accept_pane_focus_acknowledgement(first.pane_id, first.focus_seq));
+
+        // An acknowledged sequence cannot move backwards or name another pane.
+        assert!(!handler.accept_pane_focus_acknowledgement(first.pane_id, first.focus_seq));
+        assert!(!handler.accept_pane_focus_acknowledgement(99, second.focus_seq));
+
+        assert!(handler.accept_pane_focus_acknowledgement(second.pane_id, second.focus_seq));
+        assert!(!handler.accept_pane_focus_acknowledgement(30, second.focus_seq + 1));
+    }
+
+    #[test]
+    fn pane_focus_notifications_have_connection_local_sequences() {
+        // A reconnect starts a fresh correlation sequence; client-side stale
+        // work filtering uses an independent local receipt ticket.
+        let mut first_connection = handler();
+        assert_eq!(
+            PaneFocused {
+                pane_id: 10,
+                focus_seq: 1,
+            },
+            first_connection.next_pane_focus_notification(10).unwrap()
+        );
+        assert_eq!(
+            PaneFocused {
+                pane_id: 20,
+                focus_seq: 2,
+            },
+            first_connection.next_pane_focus_notification(20).unwrap()
+        );
+
+        let mut reconnected = handler();
+        assert_eq!(
+            PaneFocused {
+                pane_id: 30,
+                focus_seq: 1,
+            },
+            reconnected.next_pane_focus_notification(30).unwrap()
+        );
+    }
+
+    #[test]
+    fn pending_focus_acknowledgements_are_bounded() {
+        // A client that never acknowledges focus must not grow per-connection
+        // correlation state without bound; the newest notification remains valid.
+        let mut handler = handler();
+        let mut newest = None;
+        for pane_id in 0..=MAX_PENDING_PANE_FOCUS {
+            newest = Some(handler.next_pane_focus_notification(pane_id).unwrap());
+        }
+
+        assert_eq!(MAX_PENDING_PANE_FOCUS, handler.pending_pane_focus.len());
+        assert!(!handler.accept_pane_focus_acknowledgement(0, 1));
+        let newest = newest.unwrap();
+        assert!(handler.accept_pane_focus_acknowledgement(newest.pane_id, newest.focus_seq));
+    }
+
+    #[test]
+    fn direct_focus_request_supersedes_pending_acknowledgements() {
+        // Once a newer local action is received, an older remote-focus ACK must
+        // not be able to move that client's focus metadata backwards.
+        let mut handler = handler();
+        let pending = handler.next_pane_focus_notification(10).unwrap();
+
+        handler.supersede_pending_pane_focus_acknowledgements();
+
+        assert!(!handler.accept_pane_focus_acknowledgement(pending.pane_id, pending.focus_seq));
+        let later = handler.next_pane_focus_notification(20).unwrap();
+        assert!(handler.accept_pane_focus_acknowledgement(later.pane_id, later.focus_seq));
+    }
 }


### PR DESCRIPTION
## Problem

Switching panes twice in quick succession can leave focus ping-ponging between
the panes indefinitely. No further input is required to sustain it; the GUI can
spin at close to 100% CPU and pane-focus commands stop completing.

This is #4390 and matches the focus-loop reports in #4517 and #4693.

## Root cause

Focus received from another part of the mux was reconciled through the same
path as a new user action. Activating the pane therefore emitted another
`PaneFocused` notification. If two focus changes were queued before either was
fully reconciled, applying each notification recreated the other and the queue
never drained.

The same path is used by local GUIs, standalone mux servers, client domains,
and tmux domains, so suppressing the notification only in `GuiFrontEnd` does
not address remote or chained mux paths.

## Approach

- Distinguish a new focus action from reconciliation in the mux layer. Normal
  actions still broadcast `PaneFocused`; an already-decided focus is applied
  with notification suppressed.
- Preserve pane `focus_changed` callbacks during reconciliation, but pre-record
  inbound remote focus so `ClientPane` does not echo `SetFocusedPane` upstream.
- Emit a directional `PaneFocusReconciled` notification for local UI refresh
  and downstream mux propagation without feeding the event back upstream.
- Assign local receipt tickets to remote focus work so an older detached task
  cannot overwrite a newer notification. Invalidate those tickets at attach,
  detach, and automatic reconnect boundaries.
- Add a sequenced `PaneFocusAcknowledged` PDU (codec version 46). The server
  updates per-client `focused_pane_id` metadata only after the client applies
  the focus successfully. ACKs are correlated with the pane and connection
  sequence, monotonic, bounded, rejected for removed panes, and superseded by
  a newer direct client focus request.

This keeps normal user focus propagation intact while preventing an inbound
focus decision from being reintroduced as a new decision.

## Verification

Automated checks on macOS arm64 with Rust 1.97.1:

- `cargo test --all`
- `cargo check -p codec -p mux -p wezterm-client -p wezterm-mux-server-impl -p wezterm-gui`
- `cargo fmt --check`
- `git diff --check`

The added regression coverage checks:

- normal focus emits one notification while reconciliation emits none;
- codec round-trips preserve focus sequence numbers;
- only the newest local receipt ticket may reconcile;
- attach/reconnect boundaries invalidate old-socket work;
- ACK correlation, monotonicity, bounds, and direct-focus supersession;
- acknowledged focus updates metadata without synthesizing focus callbacks;
- reconciled focus is forwarded to downstream mux clients.

Runtime harness results:

- Stock baseline: 3/3 isolated runs wedged, with the GUI alive at about 93-95%
  CPU and focus/status commands timing out.
- Patched single GUI: 40 concurrent focus pairs (80 commands), 0 stalls,
  0/16 unresponsive probes, 0 focus flips after input stopped, and 0.1% CPU.
- Two GUIs attached to one standalone mux: `activate-pane`,
  `activate-pane-direction`, an 80-command concurrent burst, and
  `activate-tab` all converged in the mux, both rendered GUIs, and
  `list-clients` metadata.
- Chained mux: focus changes from an upstream mux reached an intermediate mux
  client domain and a downstream GUI without looping back upstream.
- Sequential focus, burst-then-explicit-final-focus, directional focus, and
  no-op direction functional checks all passed.

The runtime harnesses used isolated Unix-domain sockets on macOS. They exercise
the remote client PDU and chained mux paths, but I have not run the original
Linux Wayland/KDE reproduction over an actual SSH transport. Also, a short-lived
CLI disconnect can still produce an existing `Broken pipe` log line; this PR
does not claim to remove every such log message.

Closes #4390.
