### PR TITLE
feat(selector): add ctrl-u and ctrl-w filter shortcuts

### DIFF
--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -8,7 +8,7 @@
 use crate::commands::derive_command_from_key_assignment;
 use crate::inputmap::InputMap;
 use crate::overlay::quickselect;
-use crate::overlay::selector::{matcher_pattern, matcher_score};
+use crate::overlay::selector::{apply_filter_edit, matcher_pattern, matcher_score};
 use crate::termwindow::TermWindowNotif;
 use config::configuration;
 use config::keyassignment::{KeyAssignment, SpawnCommand, SpawnTabDomain};
@@ -575,10 +575,12 @@ impl LauncherState {
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char(c),
-                    ..
+                    modifiers,
                 }) if self.filtering => {
-                    self.filter_term.push(c);
-                    self.update_filter();
+                    if let Some(filter_term) = apply_filter_edit(c, modifiers, &self.filter_term) {
+                        self.filter_term = filter_term;
+                        self.update_filter();
+                    }
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::UpArrow,

--- a/wezterm-gui/src/overlay/launcher.rs
+++ b/wezterm-gui/src/overlay/launcher.rs
@@ -573,6 +573,8 @@ impl LauncherState {
                 }) => {
                     break;
                 }
+                // Handle any other `Char` input as a filter edit action or report as unhandled.
+                // Keep this catch-all last among the `Char` arms.
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char(c),
                     modifiers,

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 use termwiz::cell::{AttributeChange, CellAttributes};
 use termwiz::color::ColorAttribute;
 use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers, MouseButtons, MouseEvent};
+use termwiz::lineedit::{LineEditBuffer, Movement};
 use termwiz::surface::{Change, Position};
 use termwiz::terminal::Terminal;
 use termwiz_funcs::truncate_right;
@@ -35,6 +36,26 @@ pub fn matcher_pattern(s: &str) -> Pattern {
         nucleo_matcher::pattern::CaseMatching::Ignore,
         nucleo_matcher::pattern::Normalization::Smart,
     )
+}
+
+/// Edits a cursor-less filter box via `LineEditBuffer`: Ctrl-w kills the
+/// trailing word, Ctrl-u clears, plain/shift keys insert; any other key returns
+/// `None`. Shared by all four filter overlays; lowercasing folds the Ctrl-letter
+/// case difference between terminal overlays and GUI modals.
+pub fn apply_filter_edit(c: char, mods: Modifiers, filter_term: &str) -> Option<String> {
+    let mut buffer = LineEditBuffer::new(filter_term, filter_term.len());
+    if mods.contains(Modifiers::CTRL) {
+        match c.to_ascii_lowercase() {
+            'w' => buffer.kill_text(Movement::BackwardWord(1), Movement::BackwardWord(1)),
+            'u' => buffer.clear(),
+            _ => return None,
+        }
+    } else if mods == Modifiers::NONE || mods == Modifiers::SHIFT {
+        buffer.insert_char(c);
+    } else {
+        return None;
+    }
+    Some(buffer.get_line().to_string())
 }
 
 struct SelectorState {
@@ -313,10 +334,12 @@ impl SelectorState {
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char(c),
-                    ..
+                    modifiers,
                 }) if self.filtering => {
-                    self.filter_term.push(c);
-                    self.update_filter();
+                    if let Some(filter_term) = apply_filter_edit(c, modifiers, &self.filter_term) {
+                        self.filter_term = filter_term;
+                        self.update_filter();
+                    }
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::UpArrow,
@@ -445,4 +468,57 @@ pub fn selector(
     state.update_filter();
     state.render(&mut term)?;
     state.run_loop(&mut term)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_filter_edit;
+    use termwiz::input::Modifiers;
+
+    #[test]
+    fn insert_unmodified_and_shifted() {
+        assert_eq!(
+            apply_filter_edit('a', Modifiers::NONE, "foo").as_deref(),
+            Some("fooa")
+        );
+        assert_eq!(
+            apply_filter_edit('A', Modifiers::SHIFT, "foo").as_deref(),
+            Some("fooA")
+        );
+    }
+
+    #[test]
+    fn ctrl_w_kills_trailing_word() {
+        assert_eq!(
+            apply_filter_edit('W', Modifiers::CTRL, "foo bar").as_deref(),
+            Some("foo ")
+        );
+    }
+
+    #[test]
+    fn ctrl_u_kills_to_start() {
+        assert_eq!(
+            apply_filter_edit('U', Modifiers::CTRL, "hello").as_deref(),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn ctrl_combos_accept_lowercase_from_gui_modals() {
+        assert_eq!(
+            apply_filter_edit('w', Modifiers::CTRL, "foo bar").as_deref(),
+            Some("foo ")
+        );
+        assert_eq!(
+            apply_filter_edit('u', Modifiers::CTRL, "hello").as_deref(),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn non_editing_keys_are_ignored() {
+        // Only Ctrl-w and Ctrl-u edit the filter; other Ctrl-combos are ignored.
+        assert_eq!(apply_filter_edit('A', Modifiers::CTRL, "foo"), None);
+        assert_eq!(apply_filter_edit('H', Modifiers::CTRL, "foo"), None);
+    }
 }

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -38,22 +38,25 @@ pub fn matcher_pattern(s: &str) -> Pattern {
     )
 }
 
-/// Edits a cursor-less filter box via `LineEditBuffer`: Ctrl-w kills the
-/// trailing word, Ctrl-u clears, plain/shift keys insert; any other key returns
-/// `None`. Shared by all four filter overlays; lowercasing folds the Ctrl-letter
-/// case difference between terminal overlays and GUI modals.
+/// Apply an edit action for given key input to the given `filter_term`.
+/// The cursor is assumed to be at the end.
+/// Returns the edited `filter_term` or None if the action wasn't handled.
 pub fn apply_filter_edit(c: char, mods: Modifiers, filter_term: &str) -> Option<String> {
     let mut buffer = LineEditBuffer::new(filter_term, filter_term.len());
-    if mods.contains(Modifiers::CTRL) {
-        match c.to_ascii_lowercase() {
-            'w' => buffer.kill_text(Movement::BackwardWord(1), Movement::BackwardWord(1)),
-            'u' => buffer.clear(),
-            _ => return None,
+    match (mods, c.to_ascii_lowercase()) {
+        (Modifiers::CTRL, 'w') => {
+            buffer.kill_text(Movement::BackwardWord(1), Movement::BackwardWord(1))
         }
-    } else if mods == Modifiers::NONE || mods == Modifiers::SHIFT {
-        buffer.insert_char(c);
-    } else {
-        return None;
+        (Modifiers::CTRL, 'u') => {
+            // Buffer is cursor-less, so 'cursor' is always at the end and deleting to BOL is
+            // equivalent to clearing the whole buffer.
+            buffer.clear()
+        }
+        (Modifiers::NONE | Modifiers::SHIFT, _) => {
+            // Insert char as-is
+            buffer.insert_char(c);
+        }
+        _ => return None, // Unhandled
     }
     Some(buffer.get_line().to_string())
 }
@@ -332,6 +335,8 @@ impl SelectorState {
                     self.trigger_event(None);
                     break;
                 }
+                // Handle any other `Char` input as a filter edit action or report as unhandled.
+                // Keep this catch-all last among the `Char` arms.
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char(c),
                     modifiers,

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -12,6 +12,7 @@ use std::rc::Rc;
 use termwiz::cell::{AttributeChange, CellAttributes};
 use termwiz::color::ColorAttribute;
 use termwiz::input::{InputEvent, KeyCode, KeyEvent, Modifiers, MouseButtons, MouseEvent};
+use termwiz::lineedit::{LineEditBuffer, Movement};
 use termwiz::surface::{Change, Position};
 use termwiz::terminal::Terminal;
 use termwiz_funcs::truncate_right;
@@ -310,6 +311,22 @@ impl SelectorState {
                 }) => {
                     self.trigger_event(None);
                     break;
+                }
+                InputEvent::Key(KeyEvent {
+                    key: KeyCode::Char('W'),
+                    modifiers: Modifiers::CTRL,
+                }) if self.filtering => {
+                    let mut buffer = LineEditBuffer::new(&self.filter_term, self.filter_term.len());
+                    buffer.kill_text(Movement::BackwardWord(1), Movement::BackwardWord(1));
+                    self.filter_term = buffer.get_line().to_string();
+                    self.update_filter();
+                }
+                InputEvent::Key(KeyEvent {
+                    key: KeyCode::Char('U'),
+                    modifiers: Modifiers::CTRL,
+                }) if self.filtering => {
+                    self.filter_term.clear();
+                    self.update_filter();
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char(c),

--- a/wezterm-gui/src/overlay/selector.rs
+++ b/wezterm-gui/src/overlay/selector.rs
@@ -55,6 +55,13 @@ struct SelectorState {
 }
 
 impl SelectorState {
+    fn kill_filter_text(&mut self, movement: Movement) {
+        let mut buffer = LineEditBuffer::new(&self.filter_term, self.filter_term.len());
+        buffer.kill_text(movement, movement);
+        self.filter_term = buffer.get_line().to_string();
+        self.update_filter();
+    }
+
     fn update_filter(&mut self) {
         if self.filter_term.is_empty() {
             self.filtered_entries = self.args.choices.clone();
@@ -316,21 +323,21 @@ impl SelectorState {
                     key: KeyCode::Char('W'),
                     modifiers: Modifiers::CTRL,
                 }) if self.filtering => {
-                    let mut buffer = LineEditBuffer::new(&self.filter_term, self.filter_term.len());
-                    buffer.kill_text(Movement::BackwardWord(1), Movement::BackwardWord(1));
-                    self.filter_term = buffer.get_line().to_string();
-                    self.update_filter();
+                    self.kill_filter_text(Movement::BackwardWord(1));
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char('U'),
                     modifiers: Modifiers::CTRL,
                 }) if self.filtering => {
-                    self.filter_term.clear();
-                    self.update_filter();
+                    self.kill_filter_text(Movement::StartOfLine);
                 }
                 InputEvent::Key(KeyEvent {
                     key: KeyCode::Char(c),
-                    ..
+                    modifiers: Modifiers::NONE,
+                })
+                | InputEvent::Key(KeyEvent {
+                    key: KeyCode::Char(c),
+                    modifiers: Modifiers::SHIFT,
                 }) if self.filtering => {
                     self.filter_term.push(c);
                     self.update_filter();

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -627,6 +627,16 @@ impl Modal for CharSelector {
                 self.selection.borrow_mut().clear();
                 self.updated_input();
             }
+            // Handle any other `Char` input as a filter edit action or report as unhandled.
+            // Keep this catch-all last among the `Char` arms.
+            (KeyCode::Char(c), mods) => {
+                let edited = apply_filter_edit(c, mods, self.selection.borrow().as_str());
+                match edited {
+                    Some(new) => *self.selection.borrow_mut() = new,
+                    None => return Ok(false),
+                }
+                self.updated_input();
+            }
             (KeyCode::PageUp, KeyModifiers::NONE) => {
                 self.do_move(Move::PageUp);
             }
@@ -643,16 +653,6 @@ impl Modal for CharSelector {
                 // Backspace to edit the selection
                 let mut selection = self.selection.borrow_mut();
                 selection.pop();
-                self.updated_input();
-            }
-            // `None` = not a filter-edit key; report it unhandled. Keep this
-            // catch-all last among the `Char` arms.
-            (KeyCode::Char(c), mods) => {
-                let edited = apply_filter_edit(c, mods, self.selection.borrow().as_str());
-                match edited {
-                    Some(new) => *self.selection.borrow_mut() = new,
-                    None => return Ok(false),
-                }
                 self.updated_input();
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {

--- a/wezterm-gui/src/termwindow/charselect.rs
+++ b/wezterm-gui/src/termwindow/charselect.rs
@@ -1,4 +1,4 @@
-use crate::overlay::selector::{matcher_pattern, matcher_score};
+use crate::overlay::selector::{apply_filter_edit, matcher_pattern, matcher_score};
 use crate::termwindow::box_model::*;
 use crate::termwindow::modal::Modal;
 use crate::termwindow::render::corners::{
@@ -639,22 +639,20 @@ impl Modal for CharSelector {
             (KeyCode::DownArrow, KeyModifiers::NONE) => {
                 self.do_move(Move::Down(1));
             }
-            (KeyCode::Char(c), KeyModifiers::NONE) | (KeyCode::Char(c), KeyModifiers::SHIFT) => {
-                // Type to add to the selection
-                let mut selection = self.selection.borrow_mut();
-                selection.push(c);
-                self.updated_input();
-            }
             (KeyCode::Backspace, KeyModifiers::NONE) => {
                 // Backspace to edit the selection
                 let mut selection = self.selection.borrow_mut();
                 selection.pop();
                 self.updated_input();
             }
-            (KeyCode::Char('u'), KeyModifiers::CTRL) => {
-                // CTRL-u to clear the selection
-                let mut selection = self.selection.borrow_mut();
-                selection.clear();
+            // `None` = not a filter-edit key; report it unhandled. Keep this
+            // catch-all last among the `Char` arms.
+            (KeyCode::Char(c), mods) => {
+                let edited = apply_filter_edit(c, mods, self.selection.borrow().as_str());
+                match edited {
+                    Some(new) => *self.selection.borrow_mut() = new,
+                    None => return Ok(false),
+                }
                 self.updated_input();
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -1,5 +1,5 @@
 use crate::commands::{CommandDef, ExpandedCommand};
-use crate::overlay::selector::{matcher_pattern, matcher_score};
+use crate::overlay::selector::{apply_filter_edit, matcher_pattern, matcher_score};
 use crate::termwindow::box_model::*;
 use crate::termwindow::modal::Modal;
 use crate::termwindow::render::corners::{
@@ -601,22 +601,20 @@ impl Modal for CommandPalette {
             (KeyCode::DownArrow, KeyModifiers::NONE) | (KeyCode::Char('n'), KeyModifiers::CTRL) => {
                 self.move_down();
             }
-            (KeyCode::Char(c), KeyModifiers::NONE) | (KeyCode::Char(c), KeyModifiers::SHIFT) => {
-                // Type to add to the selection
-                let mut selection = self.selection.borrow_mut();
-                selection.push(c);
-                self.updated_input();
-            }
             (KeyCode::Backspace, KeyModifiers::NONE) => {
                 // Backspace to edit the selection
                 let mut selection = self.selection.borrow_mut();
                 selection.pop();
                 self.updated_input();
             }
-            (KeyCode::Char('u'), KeyModifiers::CTRL) => {
-                // CTRL-u to clear the selection
-                let mut selection = self.selection.borrow_mut();
-                selection.clear();
+            // `None` = not a filter-edit key; report it unhandled. Keep this
+            // catch-all last among the `Char` arms.
+            (KeyCode::Char(c), mods) => {
+                let edited = apply_filter_edit(c, mods, self.selection.borrow().as_str());
+                match edited {
+                    Some(new) => *self.selection.borrow_mut() = new,
+                    None => return Ok(false),
+                }
                 self.updated_input();
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -602,20 +602,20 @@ impl Modal for CommandPalette {
             (KeyCode::DownArrow, KeyModifiers::NONE) | (KeyCode::Char('n'), KeyModifiers::CTRL) => {
                 self.move_down();
             }
-            (KeyCode::Backspace, KeyModifiers::NONE) => {
-                // Backspace to edit the selection
-                let mut selection = self.selection.borrow_mut();
-                selection.pop();
-                self.updated_input();
-            }
-            // `None` = not a filter-edit key; report it unhandled. Keep this
-            // catch-all last among the `Char` arms.
+            // Handle any other `Char` input as a filter edit action or report as unhandled.
+            // Keep this catch-all last among the `Char` arms.
             (KeyCode::Char(c), mods) => {
                 let edited = apply_filter_edit(c, mods, self.selection.borrow().as_str());
                 match edited {
                     Some(new) => *self.selection.borrow_mut() = new,
                     None => return Ok(false),
                 }
+                self.updated_input();
+            }
+            (KeyCode::Backspace, KeyModifiers::NONE) => {
+                // Backspace to edit the selection
+                let mut selection = self.selection.borrow_mut();
+                selection.pop();
                 self.updated_input();
             }
             (KeyCode::Enter, KeyModifiers::NONE) => {


### PR DESCRIPTION
Support the following shortcuts in the `InputSelector` filter:

- `Ctrl-u` clears the filter
- `Ctrl-w` deletes the trailing word, via `LineEditBuffer` so it behaves exactly like `LineEditor`'s Ctrl-w

Also fixes `Ctrl-w`/`Ctrl-u` inserting a literal `W`/`U` into the filter (the catch-all `Char(c)` arm ignores modifiers).

Similar to https://github.com/wezterm/wezterm/pull/8013, but for the `InputSelector` filter.