### PR TITLE
fix(async-ossl): vendor OpenSSL for musl targets

### DIFF
--- a/async_ossl/Cargo.toml
+++ b/async_ossl/Cargo.toml
@@ -11,9 +11,9 @@ publish = false
 [dependencies]
 async-io.workspace = true
 
-[target.'cfg(not(any(windows, target_os="macos")))'.dependencies]
+[target.'cfg(not(any(windows, target_os="macos", target_env="musl")))'.dependencies]
 openssl.workspace = true
 
-[target.'cfg(any(windows, target_os="macos"))'.dependencies]
+[target.'cfg(any(windows, target_os="macos", target_env="musl"))'.dependencies]
 openssl = { workspace = true, features=["vendored"] }
 


### PR DESCRIPTION
Cross-compiling for `*-linux-musl` fails in `openssl-sys`: there is no musl-compatible system OpenSSL to link against. Use the vendored OpenSSL for musl, as already done for Windows and macOS.

Motivation: I'm building a web frontend for the wezterm mux (xterm.js in the browser talking to `wezterm-mux-server`) which I deploy as a static musl binary.

Note: native musl builds (e.g. Alpine #7390) switch from system to vendored OpenSSL with this change.