### PR TITLE
mux: fix 100% CPU hang when a split is shrunk below its minimum size

### DIFF
--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -337,6 +337,20 @@ fn compute_min_size(tree: &mut Tree) -> (usize, usize) {
 
 fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &TerminalSize) {
     let (min_x, _) = compute_min_size(tree);
+    // A child cannot give up columns that its own splits need. These minimums
+    // depend only on the shape of the tree, which does not change while sizes
+    // are redistributed, so compute them once rather than on every pass.
+    let (first_min_x, second_min_x) = match tree {
+        Tree::Node {
+            left,
+            right,
+            data: Some(_),
+        } => (
+            compute_min_size(&mut *left).0,
+            compute_min_size(&mut *right).0,
+        ),
+        _ => (1, 1),
+    };
     while x_adjust != 0 {
         match tree {
             Tree::Empty | Tree::Leaf(_) => return,
@@ -385,14 +399,14 @@ fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &Termina
                     SplitDirection::Horizontal => {
                         // x_adjust is negative
                         let before = x_adjust;
-                        if data.first.cols > 1 {
+                        if data.first.cols > first_min_x {
                             adjust_x_size(&mut *left, -1, cell_dimensions);
                             data.first.cols -= 1;
                             data.first.pixel_width =
                                 data.first.cols.saturating_mul(cell_dimensions.pixel_width);
                             x_adjust += 1;
                         }
-                        if x_adjust < 0 && data.second.cols > 1 {
+                        if x_adjust < 0 && data.second.cols > second_min_x {
                             adjust_x_size(&mut *right, -1, cell_dimensions);
                             data.second.cols -= 1;
                             data.second.pixel_width =
@@ -400,8 +414,8 @@ fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &Termina
                             x_adjust += 1;
                         }
                         if x_adjust == before {
-                            // Both children are already at the one-column
-                            // minimum, so there is nothing left to take and
+                            // Neither child can give up a column without
+                            // dropping below what its own splits require, so
                             // the remaining adjustment is unsatisfiable.
                             // Give up instead of spinning in the enclosing
                             // `while x_adjust != 0` loop forever.
@@ -416,6 +430,20 @@ fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &Termina
 
 fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &TerminalSize) {
     let (_, min_y) = compute_min_size(tree);
+    // A child cannot give up rows that its own splits need. These minimums
+    // depend only on the shape of the tree, which does not change while sizes
+    // are redistributed, so compute them once rather than on every pass.
+    let (first_min_y, second_min_y) = match tree {
+        Tree::Node {
+            left,
+            right,
+            data: Some(_),
+        } => (
+            compute_min_size(&mut *left).1,
+            compute_min_size(&mut *right).1,
+        ),
+        _ => (1, 1),
+    };
     while y_adjust != 0 {
         match tree {
             Tree::Empty | Tree::Leaf(_) => return,
@@ -465,14 +493,14 @@ fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &Termina
                     SplitDirection::Vertical => {
                         // y_adjust is negative
                         let before = y_adjust;
-                        if data.first.rows > 1 {
+                        if data.first.rows > first_min_y {
                             adjust_y_size(&mut *left, -1, cell_dimensions);
                             data.first.rows -= 1;
                             data.first.pixel_height =
                                 data.first.rows.saturating_mul(cell_dimensions.pixel_height);
                             y_adjust += 1;
                         }
-                        if y_adjust < 0 && data.second.rows > 1 {
+                        if y_adjust < 0 && data.second.rows > second_min_y {
                             adjust_y_size(&mut *right, -1, cell_dimensions);
                             data.second.rows -= 1;
                             data.second.pixel_height = data
@@ -482,8 +510,8 @@ fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &Termina
                             y_adjust += 1;
                         }
                         if y_adjust == before {
-                            // Both children are already at the one-row
-                            // minimum, so there is nothing left to take and
+                            // Neither child can give up a row without
+                            // dropping below what its own splits require, so
                             // the remaining adjustment is unsatisfiable.
                             // Give up instead of spinning in the enclosing
                             // `while y_adjust != 0` loop forever.
@@ -2620,12 +2648,18 @@ mod test {
         assert_eq!(data.second.rows, 1, "second child shrank below the minimum");
     }
 
-    /// The shape seen in a real hang: the outer split still has a row it can
-    /// give up, so it recurses into a subtree that is already fully collapsed.
-    /// The outer level makes progress while the inner level cannot, so a guard
-    /// that only considered the top level would still spin down here.
+    /// A tree that is already inconsistent, which is the shape a real hang was
+    /// caught in: the outer node records 2 rows for a first child whose own
+    /// splits need 3. Trees reach this state in the wild because the
+    /// interactive divider-drag path clamps to 1 without consulting subtree
+    /// minimums.
+    ///
+    /// Nothing here can legitimately shrink, so this exercises the termination
+    /// guard directly -- without it `y_adjust` never changes and the loop
+    /// spins. Correct behaviour is to return without making the existing
+    /// inconsistency any worse.
     #[test]
-    fn adjust_y_size_terminates_when_only_a_nested_subtree_is_at_minimum() {
+    fn adjust_y_size_terminates_without_worsening_an_inconsistent_tree() {
         let at_min = TerminalSize {
             rows: 1,
             cols: 1,
@@ -2651,7 +2685,10 @@ mod test {
         });
 
         let data = split_data(tree);
-        assert_eq!(data.first.rows, 1, "first child shrank below the minimum");
+        assert_eq!(
+            data.first.rows, 2,
+            "shrank a child that was already below its subtree minimum"
+        );
         assert_eq!(data.second.rows, 1, "second child shrank below the minimum");
     }
 
@@ -2668,5 +2705,90 @@ mod test {
         let data = split_data(tree);
         assert_eq!(data.first.cols, 1, "first child shrank below the minimum");
         assert_eq!(data.second.cols, 1, "second child shrank below the minimum");
+    }
+
+    /// An outer split whose first child is itself a fully collapsed split.
+    /// The child's subtree structurally needs 3 cells along the split axis
+    /// (two leaves plus a divider), while the outer node records only a single
+    /// number for it -- so the outer node can be told to shrink it further than
+    /// its own contents allow.
+    fn nested_at_minimum(direction: SplitDirection, first: usize) -> Tree {
+        let at_min = TerminalSize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 8,
+            pixel_height: 18,
+            dpi: 96,
+        };
+        let first = match direction {
+            SplitDirection::Vertical => TerminalSize {
+                rows: first,
+                ..at_min
+            },
+            SplitDirection::Horizontal => TerminalSize {
+                cols: first,
+                ..at_min
+            },
+        };
+        Tree::Node {
+            left: Box::new(node_at_minimum(direction)),
+            right: Box::new(Tree::Empty),
+            data: Some(SplitDirectionAndSize {
+                direction,
+                first,
+                second: at_min,
+            }),
+        }
+    }
+
+    #[test]
+    fn adjust_y_size_leaves_a_child_alone_when_its_subtree_is_already_minimal() {
+        let mut tree = nested_at_minimum(SplitDirection::Vertical, 3);
+        let dims = cell_dims();
+
+        let tree = run_with_timeout(5, "adjust_y_size(-1) on a minimal subtree", move || {
+            adjust_y_size(&mut tree, -1, &dims);
+            tree
+        });
+
+        let data = split_data(tree);
+        assert_eq!(
+            data.first.rows, 3,
+            "shrank a child below its subtree minimum of 3 rows"
+        );
+    }
+
+    #[test]
+    fn adjust_y_size_shrinks_a_child_only_down_to_its_subtree_minimum() {
+        let mut tree = nested_at_minimum(SplitDirection::Vertical, 5);
+        let dims = cell_dims();
+
+        let tree = run_with_timeout(5, "adjust_y_size(-3) past available slack", move || {
+            adjust_y_size(&mut tree, -3, &dims);
+            tree
+        });
+
+        let data = split_data(tree);
+        assert_eq!(
+            data.first.rows, 3,
+            "shrank a child below its subtree minimum of 3 rows"
+        );
+    }
+
+    #[test]
+    fn adjust_x_size_shrinks_a_child_only_down_to_its_subtree_minimum() {
+        let mut tree = nested_at_minimum(SplitDirection::Horizontal, 5);
+        let dims = cell_dims();
+
+        let tree = run_with_timeout(5, "adjust_x_size(-3) past available slack", move || {
+            adjust_x_size(&mut tree, -3, &dims);
+            tree
+        });
+
+        let data = split_data(tree);
+        assert_eq!(
+            data.first.cols, 3,
+            "shrank a child below its subtree minimum of 3 cols"
+        );
     }
 }

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -384,6 +384,7 @@ fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &Termina
                     }
                     SplitDirection::Horizontal => {
                         // x_adjust is negative
+                        let before = x_adjust;
                         if data.first.cols > 1 {
                             adjust_x_size(&mut *left, -1, cell_dimensions);
                             data.first.cols -= 1;
@@ -397,6 +398,14 @@ fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &Termina
                             data.second.pixel_width =
                                 data.second.cols.saturating_mul(cell_dimensions.pixel_width);
                             x_adjust += 1;
+                        }
+                        if x_adjust == before {
+                            // Both children are already at the one-column
+                            // minimum, so there is nothing left to take and
+                            // the remaining adjustment is unsatisfiable.
+                            // Give up instead of spinning in the enclosing
+                            // `while x_adjust != 0` loop forever.
+                            return;
                         }
                     }
                 }
@@ -455,6 +464,7 @@ fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &Termina
                     }
                     SplitDirection::Vertical => {
                         // y_adjust is negative
+                        let before = y_adjust;
                         if data.first.rows > 1 {
                             adjust_y_size(&mut *left, -1, cell_dimensions);
                             data.first.rows -= 1;
@@ -470,6 +480,14 @@ fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &Termina
                                 .rows
                                 .saturating_mul(cell_dimensions.pixel_height);
                             y_adjust += 1;
+                        }
+                        if y_adjust == before {
+                            // Both children are already at the one-row
+                            // minimum, so there is nothing left to take and
+                            // the remaining adjustment is unsatisfiable.
+                            // Give up instead of spinning in the enclosing
+                            // `while y_adjust != 0` loop forever.
+                            return;
                         }
                     }
                 }
@@ -2524,5 +2542,131 @@ mod test {
     #[test]
     fn tab_is_send_and_sync() {
         assert!(is_send_and_sync::<Tab>());
+    }
+
+    /// Runs `f` on a worker thread and fails the test if it doesn't finish in
+    /// time, returning its value otherwise.
+    ///
+    /// The bug these tests cover is a non-termination bug: a tight userspace
+    /// loop that issues no syscalls and mutates nothing. Calling the function
+    /// directly would wedge the whole test run rather than reporting a failure.
+    fn run_with_timeout<T: Send + 'static>(
+        secs: u64,
+        what: &str,
+        f: impl FnOnce() -> T + Send + 'static,
+    ) -> T {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(f());
+        });
+        match rx.recv_timeout(std::time::Duration::from_secs(secs)) {
+            Ok(value) => value,
+            Err(_) => panic!("{} failed to terminate within {}s", what, secs),
+        }
+    }
+
+    fn cell_dims() -> TerminalSize {
+        TerminalSize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 8,
+            pixel_height: 18,
+            dpi: 96,
+        }
+    }
+
+    /// A split node whose two children are both already down at the one-cell
+    /// minimum along the split axis, so neither can give anything up.
+    fn node_at_minimum(direction: SplitDirection) -> Tree {
+        let at_min = TerminalSize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 8,
+            pixel_height: 18,
+            dpi: 96,
+        };
+        Tree::Node {
+            left: Box::new(Tree::Empty),
+            right: Box::new(Tree::Empty),
+            data: Some(SplitDirectionAndSize {
+                direction,
+                first: at_min,
+                second: at_min,
+            }),
+        }
+    }
+
+    fn split_data(tree: Tree) -> SplitDirectionAndSize {
+        match tree {
+            Tree::Node {
+                data: Some(data), ..
+            } => data,
+            _ => unreachable!("expected a split node"),
+        }
+    }
+
+    #[test]
+    fn adjust_y_size_gives_up_when_both_children_are_at_minimum_height() {
+        let mut tree = node_at_minimum(SplitDirection::Vertical);
+        let dims = cell_dims();
+
+        let tree = run_with_timeout(5, "adjust_y_size(-1) at minimum height", move || {
+            adjust_y_size(&mut tree, -1, &dims);
+            tree
+        });
+
+        let data = split_data(tree);
+        assert_eq!(data.first.rows, 1, "first child shrank below the minimum");
+        assert_eq!(data.second.rows, 1, "second child shrank below the minimum");
+    }
+
+    /// The shape seen in a real hang: the outer split still has a row it can
+    /// give up, so it recurses into a subtree that is already fully collapsed.
+    /// The outer level makes progress while the inner level cannot, so a guard
+    /// that only considered the top level would still spin down here.
+    #[test]
+    fn adjust_y_size_terminates_when_only_a_nested_subtree_is_at_minimum() {
+        let at_min = TerminalSize {
+            rows: 1,
+            cols: 1,
+            pixel_width: 8,
+            pixel_height: 18,
+            dpi: 96,
+        };
+        let inner = node_at_minimum(SplitDirection::Vertical);
+        let mut tree = Tree::Node {
+            left: Box::new(inner),
+            right: Box::new(Tree::Empty),
+            data: Some(SplitDirectionAndSize {
+                direction: SplitDirection::Vertical,
+                first: TerminalSize { rows: 2, ..at_min },
+                second: at_min,
+            }),
+        };
+        let dims = cell_dims();
+
+        let tree = run_with_timeout(5, "adjust_y_size(-2) with collapsed subtree", move || {
+            adjust_y_size(&mut tree, -2, &dims);
+            tree
+        });
+
+        let data = split_data(tree);
+        assert_eq!(data.first.rows, 1, "first child shrank below the minimum");
+        assert_eq!(data.second.rows, 1, "second child shrank below the minimum");
+    }
+
+    #[test]
+    fn adjust_x_size_gives_up_when_both_children_are_at_minimum_width() {
+        let mut tree = node_at_minimum(SplitDirection::Horizontal);
+        let dims = cell_dims();
+
+        let tree = run_with_timeout(5, "adjust_x_size(-1) at minimum width", move || {
+            adjust_x_size(&mut tree, -1, &dims);
+            tree
+        });
+
+        let data = split_data(tree);
+        assert_eq!(data.first.cols, 1, "first child shrank below the minimum");
+        assert_eq!(data.second.cols, 1, "second child shrank below the minimum");
     }
 }

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -316,7 +316,7 @@ where
 
 /// Computes the minimum (x, y) size based on the panes in this portion
 /// of the tree.
-fn compute_min_size(tree: &mut Tree) -> (usize, usize) {
+fn compute_min_size(tree: &Tree) -> (usize, usize) {
     match tree {
         Tree::Node { data: None, .. } | Tree::Empty => (1, 1),
         Tree::Node {
@@ -324,8 +324,8 @@ fn compute_min_size(tree: &mut Tree) -> (usize, usize) {
             right,
             data: Some(data),
         } => {
-            let (left_x, left_y) = compute_min_size(&mut *left);
-            let (right_x, right_y) = compute_min_size(&mut *right);
+            let (left_x, left_y) = compute_min_size(left);
+            let (right_x, right_y) = compute_min_size(right);
             match data.direction {
                 SplitDirection::Vertical => (left_x.max(right_x), left_y + right_y + 1),
                 SplitDirection::Horizontal => (left_x + right_x + 1, left_y.max(right_y)),
@@ -345,10 +345,7 @@ fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &Termina
             left,
             right,
             data: Some(_),
-        } => (
-            compute_min_size(&mut *left).0,
-            compute_min_size(&mut *right).0,
-        ),
+        } => (compute_min_size(left).0, compute_min_size(right).0),
         _ => (1, 1),
     };
     while x_adjust != 0 {
@@ -438,10 +435,7 @@ fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &Termina
             left,
             right,
             data: Some(_),
-        } => (
-            compute_min_size(&mut *left).1,
-            compute_min_size(&mut *right).1,
-        ),
+        } => (compute_min_size(left).1, compute_min_size(right).1),
         _ => (1, 1),
     };
     while y_adjust != 0 {
@@ -1237,6 +1231,14 @@ impl TabInner {
             .pixel_height
             .checked_div(pane_size.rows)
             .unwrap_or(1);
+        // Holding the first child at its current size is only safe while the
+        // second child still has room for its own splits. Once the space runs
+        // out the first child has to yield, or the subtraction below floors the
+        // second child at zero and its panes vanish.
+        let (first_min, second_min) = match cursor.subtree() {
+            Tree::Node { left, right, .. } => (compute_min_size(left), compute_min_size(right)),
+            _ => ((1, 1), (1, 1)),
+        };
         if let Ok(Some(node)) = cursor.node_mut() {
             // Adjust the size of the node; we preserve the size of the first
             // child and adjust the second, so if we are split down the middle
@@ -1246,12 +1248,22 @@ impl TabInner {
                 node.first.rows = pane_size.rows;
                 node.second.rows = pane_size.rows;
 
-                node.second.cols = pane_size.cols.saturating_sub(1 + node.first.cols);
+                let first_max = pane_size.cols.saturating_sub(1 + second_min.0);
+                node.first.cols = node.first.cols.min(first_max).max(first_min.0);
+                node.second.cols = pane_size
+                    .cols
+                    .saturating_sub(1 + node.first.cols)
+                    .max(second_min.0);
             } else {
                 node.first.cols = pane_size.cols;
                 node.second.cols = pane_size.cols;
 
-                node.second.rows = pane_size.rows.saturating_sub(1 + node.first.rows);
+                let first_max = pane_size.rows.saturating_sub(1 + second_min.1);
+                node.first.rows = node.first.rows.min(first_max).max(first_min.1);
+                node.second.rows = pane_size
+                    .rows
+                    .saturating_sub(1 + node.first.rows)
+                    .max(second_min.1);
             }
             node.first.pixel_width = node.first.cols * cell_width;
             node.first.pixel_height = node.first.rows * cell_height;
@@ -1339,41 +1351,57 @@ impl TabInner {
 
     fn adjust_node_at_cursor(&mut self, cursor: &mut Cursor, delta: isize) {
         let cell_dimensions = self.cell_dimensions();
+        // Neither side can be dragged smaller than its own splits require, so
+        // bound the divider by each subtree's minimum rather than reserving a
+        // single cell for the immediate child.
+        let (first_min, second_min) = match cursor.subtree() {
+            Tree::Node { left, right, .. } => (compute_min_size(left), compute_min_size(right)),
+            _ => ((1, 1), (1, 1)),
+        };
         if let Ok(Some(node)) = cursor.node_mut() {
             match node.direction {
                 SplitDirection::Horizontal => {
                     let width = node.width();
+                    let lowest = first_min.0 as isize;
+                    let highest = (width as isize) - 1 - (second_min.0 as isize);
 
-                    let mut cols = node.first.cols as isize;
-                    cols = cols
-                        .saturating_add(delta)
-                        .max(1)
-                        .min((width as isize).saturating_sub(2));
-                    node.first.cols = cols as usize;
-                    node.first.pixel_width =
-                        node.first.cols.saturating_mul(cell_dimensions.pixel_width);
+                    // When the node is already too narrow to satisfy both
+                    // subtrees there is no valid divider position, and moving it
+                    // could only make the overlap worse. Leave it alone.
+                    if highest >= lowest {
+                        let cols = (node.first.cols as isize)
+                            .saturating_add(delta)
+                            .max(lowest)
+                            .min(highest);
+                        node.first.cols = cols as usize;
+                        node.first.pixel_width =
+                            node.first.cols.saturating_mul(cell_dimensions.pixel_width);
 
-                    node.second.cols = width.saturating_sub(node.first.cols.saturating_add(1));
-                    node.second.pixel_width =
-                        node.second.cols.saturating_mul(cell_dimensions.pixel_width);
+                        node.second.cols = width.saturating_sub(node.first.cols.saturating_add(1));
+                        node.second.pixel_width =
+                            node.second.cols.saturating_mul(cell_dimensions.pixel_width);
+                    }
                 }
                 SplitDirection::Vertical => {
                     let height = node.height();
+                    let lowest = first_min.1 as isize;
+                    let highest = (height as isize) - 1 - (second_min.1 as isize);
 
-                    let mut rows = node.first.rows as isize;
-                    rows = rows
-                        .saturating_add(delta)
-                        .max(1)
-                        .min((height as isize).saturating_sub(2));
-                    node.first.rows = rows as usize;
-                    node.first.pixel_height =
-                        node.first.rows.saturating_mul(cell_dimensions.pixel_height);
+                    if highest >= lowest {
+                        let rows = (node.first.rows as isize)
+                            .saturating_add(delta)
+                            .max(lowest)
+                            .min(highest);
+                        node.first.rows = rows as usize;
+                        node.first.pixel_height =
+                            node.first.rows.saturating_mul(cell_dimensions.pixel_height);
 
-                    node.second.rows = height.saturating_sub(node.first.rows.saturating_add(1));
-                    node.second.pixel_height = node
-                        .second
-                        .rows
-                        .saturating_mul(cell_dimensions.pixel_height);
+                        node.second.rows = height.saturating_sub(node.first.rows.saturating_add(1));
+                        node.second.pixel_height = node
+                            .second
+                            .rows
+                            .saturating_mul(cell_dimensions.pixel_height);
+                    }
                 }
             }
         }
@@ -2790,5 +2818,102 @@ mod test {
             data.first.cols, 3,
             "shrank a child below its subtree minimum of 3 cols"
         );
+    }
+
+    /// Dragging a divider must respect what the subtree on either side needs,
+    /// not just leave a single cell for the immediate child. Squeezing a nested
+    /// split down to one row leaves its own children nothing, and the shortfall
+    /// surfaces as a pane sized zero once the sizes cascade down.
+    #[test]
+    fn dragging_a_divider_cannot_collapse_a_nested_split() {
+        let size = TerminalSize {
+            rows: 24,
+            cols: 80,
+            pixel_width: 800,
+            pixel_height: 600,
+            dpi: 96,
+        };
+        let tab = Tab::new(&size);
+        tab.assign_pane(&FakePane::new(1, size));
+
+        // Split the tab in two vertically, then split the top half again, so
+        // the root's first child is itself a split and structurally needs three
+        // rows: two leaves plus the divider between them.
+        let outer = tab
+            .compute_split_size(
+                0,
+                SplitRequest {
+                    direction: SplitDirection::Vertical,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        tab.split_and_insert(
+            0,
+            SplitRequest {
+                direction: SplitDirection::Vertical,
+                ..Default::default()
+            },
+            FakePane::new(2, outer.second),
+        )
+        .unwrap();
+
+        let inner = tab
+            .compute_split_size(
+                0,
+                SplitRequest {
+                    direction: SplitDirection::Vertical,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        tab.split_and_insert(
+            0,
+            SplitRequest {
+                direction: SplitDirection::Vertical,
+                ..Default::default()
+            },
+            FakePane::new(3, inner.second),
+        )
+        .unwrap();
+
+        assert_eq!(tab.iter_panes().len(), 3);
+
+        // Drag the outermost divider as far up as it will go.
+        tab.resize_split_by(0, -100);
+
+        let panes = tab.iter_panes();
+        for pane in &panes {
+            assert!(
+                pane.height >= 1 && pane.width >= 1,
+                "pane {} collapsed to {}x{}",
+                pane.index,
+                pane.width,
+                pane.height
+            );
+        }
+        // Stopping the divider short is only half the job: if it is allowed
+        // past the subtree minimum the contents no longer fit in the region
+        // they were given, and panes end up drawn on top of each other.
+        for (i, a) in panes.iter().enumerate() {
+            for b in &panes[i + 1..] {
+                let rows_overlap = a.top < b.top + b.height && b.top < a.top + a.height;
+                let cols_overlap = a.left < b.left + b.width && b.left < a.left + a.width;
+                assert!(
+                    !(rows_overlap && cols_overlap),
+                    "panes {} (top={} left={} {}x{}) and {} (top={} left={} {}x{}) overlap",
+                    a.index,
+                    a.top,
+                    a.left,
+                    a.width,
+                    a.height,
+                    b.index,
+                    b.top,
+                    b.left,
+                    b.width,
+                    b.height
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## The problem

`wezterm-gui` can wedge permanently with one thread pinned at 100% CPU after un-maximizing a window that contains many splits. The window stops repainting and stops responding to input, while every pane subprocess stays alive and healthy — so the session looks recoverable but isn't.

I caught this on a live instance (`20240203-110809-5046fc22`, X11, ~35 panes) and traced it to `mux/src/tab.rs`. The signature is distinctive:

- the GUI thread sits in state `R`, with `/proc/<pid>/task/<tid>/syscall` reading `running`
- `strace -p <tid>` records **zero syscalls** while that thread burns 100% CPU
- perf samples land on ten instructions, all within one function, and never on a call site

It's a pure userspace infinite loop that writes no memory and makes no calls, so no signal breaks it out and `SIGSTOP`/`SIGCONT` just resumes the same instruction. Recovery is a debugger or killing the process.

## Root cause

The negative-adjustment arm of `adjust_y_size()` (`SplitDirection::Vertical`, and symmetrically `adjust_x_size()`/`Horizontal`) reads:

```rust
if data.first.rows > 1 {
    ...
    y_adjust += 1;
}
if y_adjust < 0 && data.second.rows > 1 {
    ...
    y_adjust += 1;
}
```

When both children are already at 1 row, neither block runs, `y_adjust` is never incremented, and control falls back into the enclosing `while y_adjust != 0`. State is unchanged, so it spins forever.

From the hung process, the innermost frame was exactly that: `y_adjust = -1`, `first.rows = 1`, `second.rows = 1`.

The same backtrace showed a second, deeper problem. The frame above it had `first.rows = 2` for a child whose own splits require 3 rows (two leaves plus a divider). The guards compare the child's *recorded* size against a hardcoded `1`, which says nothing about whether that child's subtree can absorb the loss. `compute_min_size()` already knows the answer — a stack of N panes needs 2N-1 rows — but it is only consulted in the perpendicular arm, via `.max(min_y as isize)`, and never in the arm that loops. So a parent can shrink a child below what its contents need, after which `height()` (derived as `first + second + 1`) disagrees with what `apply_sizes_from_splits()` actually pushes down, since that ignores the parent's figure for interior nodes.

The same hardcoded floor of 1 appears on the interactive divider-drag path, which is the likely reason trees end up containing 1-row panes to begin with.

## The fixes

Three commits, meant to land in order:

1. **`mux: fix infinite loop when shrinking a split below its minimum`** — give up when a pass cannot make progress. This alone stops the hang.
2. **`mux: floor split shrinking at each child's own subtree minimum`** — consult `compute_min_size()` per child instead of the constant 1. Computed once per call, since tree *shape* is invariant while sizes are redistributed.
3. **`mux: respect subtree minimums when dragging a divider`** — the same defect on the `resize_split_by` path, in two places: `adjust_node_at_cursor` (`.max(1).min(width - 2)`), and `apply_pane_size`, which held `first` at its current size and saturating-subtracted the remainder into `second` — flooring it at zero so its panes vanished.

**The ordering matters.** Commit 2 raises the floors, which makes *more* shrink requests unsatisfiable and therefore makes commit 1's guard more load-bearing, not less: with commit 2 but not commit 1, all six `adjust_*` tests hang. Commit 2 on its own would make the hang *more* likely, so please don't take it without commit 1.

## Tests

Seven new tests in `mux/src/tab.rs`.

- `cargo test --all` — 398 passed, 0 failed, 1 ignored across 133 suites
- `cargo fmt --all -- --check` — clean
- verified on rustc 1.97.1, x86_64 Linux

Each new test was watched failing before the corresponding fix went in, and for commits 2 and 3 I checked that each half of the change is independently load-bearing by reverting it in isolation:

| Reverted | Resulting failure |
| --- | --- |
| termination guard | 6 tests hang (caught by watchdog) |
| subtree floors | `left: 2, right: 3` — child shrunk below its minimum |
| divider bound | `panes 1 (top=2 80x1) and 2 (top=2 80x22) overlap` |
| `apply_pane_size` | `pane 1 collapsed to 80x0` |

The tests run the call on a worker thread with a timeout rather than calling it directly: the bug is non-termination with no syscalls, so a direct call wedges the entire test run instead of reporting a failure.

## Notes for review

- `compute_min_size()` now takes `&Tree` rather than `&mut Tree`. It never mutated anything, and `Cursor::subtree()` hands out a shared reference.
- Commit 3 is a **user-visible behavior change**: dividers now stop earlier when the far side contains splits, and window shrinks stop earlier too. It's isolated in its own commit for that reason, and it's the one to revisit if the new bounds feel too strict.
- `tab_splitting`, which asserts exact pane geometry, passes untouched — ordinary splitting and growing are unaffected. The new bounds are also identical to the old ones whenever both children are leaves (`first_min = second_min = 1`), so only nested splits see a difference.
- Possibly related, though I have **not** confirmed any of them are this same defect: #5745 and #4084 (resize freezes), and #3921 (`attempt to divide by zero while resizing pane` — worth noting the old `.max(1).min(width - 2)` could invert when a node was narrower than 3 cells and store `0`, and `SplitDirectionAndSize::size()` divides by `first.cols`/`first.rows`).
