### PR TITLE
fix the bug by adding update title to update immediately

### DIFF
--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3553,6 +3553,7 @@ impl TermWindow {
         if let Some(overlay) = self.tab_state(tab_id).overlay.take() {
             Mux::get().remove_pane(overlay.pane.pane_id());
         }
+        self.update_title();
         if let Some(window) = self.window.as_ref() {
             window.invalidate();
         }
@@ -3572,6 +3573,7 @@ impl TermWindow {
                 Mux::get().remove_pane(overlay.pane.pane_id());
             }
         }
+        self.update_title();
         if let Some(window) = self.window.as_ref() {
             window.invalidate();
         }


### PR DESCRIPTION
Hi @bew, 

## The problem ( #8020 )
as I understand, WezTerm has a model on these layered: **Pane, Tab, Window, and Mux**. There is mechanical called **Overlay** that shown a temporary pane. 

So when we activate the **Overlay**, and choose the current active tab, the `update_title()` get called. However, the temporary pane still the current pane, and as a result, `update_title()` recomputed as **Tab Navigator** again.

## The fix
I added `update_title()` for both `cancel_overlay_for_tab()` and `cancel_overlay_for_pane()` so that when an overlay tab/pane removed, its title will compute correctly

What do you think about this?