### PR TITLE
term: don't duplicate image attachments when placing kitty images

### DIFF
--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -408,6 +408,18 @@ impl Screen {
         line.set_cell(x, cell.clone(), seqno);
     }
 
+    pub fn set_cell_clearing_image_placements(
+        &mut self,
+        x: usize,
+        y: VisibleRowIndex,
+        cell: &Cell,
+        seqno: SequenceNo,
+    ) {
+        let line_idx = self.phys_row(y);
+        let line = self.line_mut(line_idx);
+        line.set_cell_clearing_image_placements(x, cell.clone(), seqno);
+    }
+
     pub fn set_cell_grapheme(
         &mut self,
         x: usize,

--- a/term/src/terminalstate/image.rs
+++ b/term/src/terminalstate/image.rs
@@ -235,14 +235,21 @@ impl TerminalState {
                     params.placement_id,
                 ));
                 match params.style {
-                    ImageAttachStyle::Kitty => cell.attrs_mut().attach_image(img),
+                    ImageAttachStyle::Kitty => {
+                        cell.attrs_mut().attach_image(img);
+                        self.screen_mut().set_cell_clearing_image_placements(
+                            cursor_x + x,
+                            cursor_y,
+                            &cell,
+                            seqno,
+                        );
+                    }
                     ImageAttachStyle::Sixel | ImageAttachStyle::Iterm => {
-                        cell.attrs_mut().set_image(img)
+                        cell.attrs_mut().set_image(img);
+                        self.screen_mut()
+                            .set_cell(cursor_x + x, cursor_y, &cell, seqno);
                     }
                 };
-
-                self.screen_mut()
-                    .set_cell(cursor_x + x, cursor_y, &cell, seqno);
                 xpos += x_delta;
             }
             ypos += y_delta;

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -2,6 +2,160 @@
 
 use super::*;
 
+/// Minimal base64 encoder so that the tests below can synthesize kitty
+/// direct-transmission payloads without adding a dependency.
+fn base64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    for chunk in data.chunks(3) {
+        let b = [
+            chunk[0],
+            chunk.get(1).copied().unwrap_or(0),
+            chunk.get(2).copied().unwrap_or(0),
+        ];
+        let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+        out.push(ALPHABET[(n >> 18) as usize & 0x3f] as char);
+        out.push(ALPHABET[(n >> 12) as usize & 0x3f] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[(n >> 6) as usize & 0x3f] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[n as usize & 0x3f] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+/// Aggregate per-cell image attachment statistics over the visible screen:
+/// (cells with images, total attachments, max attachments on a single cell,
+/// number of distinct (image_id, placement_id) pairs).
+fn image_attachment_stats(term: &mut TestTerm) -> (usize, usize, usize, usize) {
+    let screen = term.screen_mut();
+    let phys_rows = screen.physical_rows;
+    let top = screen.visible_row_to_stable_row(0);
+    let range = screen.stable_range(&(top..top + phys_rows as crate::StableRowIndex));
+    let mut cells = 0;
+    let mut total = 0;
+    let mut max = 0;
+    let mut pairs = std::collections::HashSet::new();
+    for idx in range {
+        let line = screen.line_mut(idx);
+        for cell in line.visible_cells() {
+            if let Some(images) = cell.attrs().images() {
+                cells += 1;
+                total += images.len();
+                max = max.max(images.len());
+                for im in &images {
+                    pairs.insert((im.image_id(), im.placement_id()));
+                }
+            }
+        }
+    }
+    (cells, total, max, pairs.len())
+}
+
+/// Repeatedly placing a kitty image over cells that are already covered by
+/// another image must not accumulate per-cell image attachments: the
+/// attachment count must reflect the set of live placements, not the number
+/// of placement commands ever issued.
+/// See <https://github.com/wezterm/wezterm/issues/7953>.
+#[test]
+fn kitty_overlapping_placement_reissue_does_not_accumulate() {
+    let mut term = TestTerm::new(6, 10, 0);
+
+    // Two 32x16 RGBA images: at the 8x16 cell size of TestTerm they span
+    // 4 columns and 1 row; we scale them to 4 columns x 2 rows via c=/r=.
+    let rgba: Vec<u8> = std::iter::repeat([0x80u8, 0x80, 0x80, 0xff])
+        .take(32 * 16)
+        .flatten()
+        .collect();
+    let payload = base64_encode(&rgba);
+
+    // Transmit base (i=1) and overlay (i=2) once each. q=2: quiet.
+    term.print(format!(
+        "\x1b_Ga=t,t=d,f=32,q=2,s=32,v=16,i=1;{}\x1b\\",
+        payload
+    ));
+    term.print(format!(
+        "\x1b_Ga=t,t=d,f=32,q=2,s=32,v=16,i=2;{}\x1b\\",
+        payload
+    ));
+
+    // Base placement: 4 cols x 2 rows at the home position, under the text.
+    term.print("\x1b[H\x1b_Ga=p,q=2,C=1,i=1,p=1,c=4,r=2,z=-2\x1b\\");
+
+    let (cells, total, max, pairs) = image_attachment_stats(&mut term);
+    k9::assert_equal!(
+        (cells, total, max, pairs),
+        (8, 8, 1, 1),
+        "base placement covers 8 cells with one attachment each"
+    );
+
+    // Re-issue the same overlay placement over those same cells many times,
+    // as a client animating an overlay does. Each re-issue replaces the
+    // previous placement (same image id and placement id).
+    for _ in 0..20 {
+        term.print("\x1b[H\x1b_Ga=p,q=2,C=1,i=2,p=2,c=4,r=2,z=-1\x1b\\");
+    }
+
+    let (cells, total, max, pairs) = image_attachment_stats(&mut term);
+    k9::assert_equal!(
+        (cells, total, max, pairs),
+        (8, 16, 2, 2),
+        "after any number of overlay re-issues each cell holds exactly \
+         the base attachment and one overlay attachment"
+    );
+
+    term.print("\x1b_Ga=d,d=i,q=2,i=2,p=2\x1b\\");
+    let (cells, total, max, pairs) = image_attachment_stats(&mut term);
+    k9::assert_equal!(
+        (cells, total, max, pairs),
+        (8, 8, 1, 1),
+        "deleting the overlay restores the base-only attachment state"
+    );
+
+    term.print("\x1b_Ga=d,d=A,q=2\x1b\\");
+    let (cells, total, max, pairs) = image_attachment_stats(&mut term);
+    k9::assert_equal!(
+        (cells, total, max, pairs),
+        (0, 0, 0, 0),
+        "deleting all placements scrubs every attachment"
+    );
+}
+
+/// Printing text over a cell that carries kitty image placements must
+/// continue to preserve those placements.
+#[test]
+fn text_over_kitty_placement_preserves_placement() {
+    let mut term = TestTerm::new(6, 10, 0);
+
+    let rgba: Vec<u8> = std::iter::repeat([0x80u8, 0x80, 0x80, 0xff])
+        .take(32 * 16)
+        .flatten()
+        .collect();
+    let payload = base64_encode(&rgba);
+
+    term.print(format!(
+        "\x1b_Ga=t,t=d,f=32,q=2,s=32,v=16,i=1;{}\x1b\\",
+        payload
+    ));
+    term.print("\x1b[H\x1b_Ga=p,q=2,C=1,i=1,p=1,c=4,r=2,z=-2\x1b\\");
+
+    // Overwrite the first row of the image with text.
+    term.print("\x1b[Hxyzw");
+
+    let (cells, total, max, pairs) = image_attachment_stats(&mut term);
+    k9::assert_equal!(
+        (cells, total, max, pairs),
+        (8, 8, 1, 1),
+        "text written over the placement leaves the attachments in place"
+    );
+}
+
 /// A tiny but valid 11x11 PNG, base64 encoded.
 /// Taken from the reproduction in <https://github.com/wezterm/wezterm/issues/6344>.
 const TINY_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAACXBIWXMAAAGKAAABigEzlzBYAAAAOUlEQVQYlZXOwQ0AMAzCQEdi7yaT0xWAN7JuDCac2PQKYxflycOoICOKtPIuqFCg4/LzKxiz6xjyAYh9DR1sLUN1AAAAAElFTkSuQmCC";


### PR DESCRIPTION
## Problem

Repeated Kitty image placements over cells that already contain image attachments can duplicate those attachments on every update.

`assign_image_to_cells` clones the existing cell with its current attachments, then writes it through `Line::set_cell`, which merges the previous attachments back in again.
Repeating this causes attachment counts (renderer quads) — to grow rapidly causing WezTerm to crash.

This explains the quad-count growth seen in #7953 

## Fix

Use `set_cell_clearing_image_placements` for Kitty placement writes, where the updated cell already contains the complete attachment set.

The existing merging behavior remains unchanged for text, sixel, and iTerm2 images, where it is still required.

## Tests

Added regression coverage for:

- repeated overlapping Kitty placements without accumulating attachments
- preserving Kitty placements when text is written over them

Verified with:

- `cargo nextest run --all --no-fail-fast` — 387/387 passing
- `cargo +nightly fmt --all -- --check` — clean

The overlapping-placement repro previously grew from ~120 MB to >500 MB in 15 updates; with this change it remained around 125 MB over 40 updates.