### PR TITLE
config: cache Config->lua conversion for event dispatch

### DIFF
--- a/config/src/lib.rs
+++ b/config/src/lib.rs
@@ -814,6 +814,82 @@ impl std::ops::Deref for ConfigHandle {
     }
 }
 
+thread_local! {
+    static CONFIG_LUA_CACHE: RefCell<Option<(Rc<Lua>, Arc<Config>, mlua::RegistryKey)>> =
+        RefCell::new(None);
+}
+
+/// Convert a ConfigHandle to a lua value, re-using the cached conversion
+/// when the lua state and the config Arc are both unchanged.
+///
+/// Events such as format-tab-title receive the config on every invocation,
+/// and converting the whole Config each time is expensive: when many windows
+/// are created at once (for example while re-attaching a client domain),
+/// the repeated conversion monopolizes the main thread for minutes.
+///
+/// The cache holds strong refs to the lua state and the config Arc, so the
+/// pointers it compares cannot be recycled while an entry is live.
+///
+/// Must be called from the main thread, same as
+/// run_immediate_with_lua_config.
+pub fn config_handle_to_lua<'lua>(
+    lua: &'lua Rc<Lua>,
+    config: &ConfigHandle,
+) -> mlua::Result<mlua::Value<'lua>> {
+    let cached = CONFIG_LUA_CACHE.with(|cache| -> Option<mlua::Value<'lua>> {
+        let cache = cache.borrow();
+        match &*cache {
+            Some((cached_lua, cached_config, key))
+                if Rc::ptr_eq(cached_lua, lua) && Arc::ptr_eq(cached_config, &config.config) =>
+            {
+                lua.registry_value(key).ok()
+            }
+            _ => None,
+        }
+    });
+    if let Some(value) = cached {
+        return Ok(value);
+    }
+    let value = luahelper::to_lua(lua, (*config.config).clone())?;
+    let key = lua.create_registry_value(&value)?;
+    CONFIG_LUA_CACHE.with(|cache| {
+        cache
+            .borrow_mut()
+            .replace((Rc::clone(lua), Arc::clone(&config.config), key));
+    });
+    Ok(value)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn config_handle_to_lua_caches_per_config_arc() {
+        let lua = Rc::new(Lua::new());
+        let handle = ConfigHandle::default_config();
+
+        let first = config_handle_to_lua(&lua, &handle).unwrap();
+        let second = config_handle_to_lua(&lua, &handle).unwrap();
+        assert!(matches!(first, mlua::Value::Table(_)));
+        assert_eq!(
+            first, second,
+            "same config Arc and lua state must re-use the cached table"
+        );
+
+        // A different config Arc (per-window overrides, or a reload)
+        // must not hit the cache
+        let other = ConfigHandle::default_config();
+        let third = config_handle_to_lua(&lua, &other).unwrap();
+        assert_ne!(first, third);
+
+        // A different lua state must not hit the cache either
+        let other_lua = Rc::new(Lua::new());
+        let fourth = config_handle_to_lua(&other_lua, &handle).unwrap();
+        assert!(matches!(fourth, mlua::Value::Table(_)));
+    }
+}
+
 pub struct LoadedConfig {
     pub config: anyhow::Result<Config>,
     pub file_name: Option<PathBuf>,

--- a/wezterm-gui/src/tabbar.rs
+++ b/wezterm-gui/src/tabbar.rs
@@ -63,19 +63,13 @@ fn call_format_tab_title(
         if let Some(lua) = lua {
             let tabs = lua.create_sequence_from(tab_info.iter().cloned())?;
             let panes = lua.create_sequence_from(pane_info.iter().cloned())?;
+            let config_value = config::config_handle_to_lua(&lua, config)?;
 
             let v = config::lua::emit_sync_callback(
                 &*lua,
                 (
                     "format-tab-title".to_string(),
-                    (
-                        tab.clone(),
-                        tabs,
-                        panes,
-                        (**config).clone(),
-                        hover,
-                        tab_max_width,
-                    ),
+                    (tab.clone(), tabs, panes, config_value, hover, tab_max_width),
                 ),
             )?;
             match &v {


### PR DESCRIPTION

`format-tab-title` receives the whole Config on every call, and every call
converted it to a lua value from scratch (`to_lua<Config>` ->
`dynamic_to_lua_value`). When many windows are created at once the cost
multiplies: a client domain re-attach after a network blip re-creates every
window, each `new_window` rebuilds `TabBarState`, and each tab title
re-converts the entire Config. On a loaded host this monopolizes the main
thread for minutes. The UI freezes and mux cli queries starve behind the
busy frontend.

Observed in the wild twice on macOS: GUI wedge during SSHMUX re-attach.
Main-thread samples show >90% of samples inside one `new_window` spawn,
bottoming out in `dynamic_to_lua_value` recursion under
`call_format_tab_title`.

The fix adds `config::config_handle_to_lua`: it caches the converted table
per (lua state, config Arc) pair in a main-thread thread_local, and
`format-tab-title` dispatch uses it. The cache holds strong refs to both,
so the pointers it compares cannot be recycled while an entry is live. A
config reload or a per-window overridden config allocates a fresh Arc and
misses the cache naturally. The lua state is replaced on reload too, and
the pair key covers it.

## Test plan

New unit test in the config crate: same-Arc reuse returns the identical
table, a different config Arc misses, a different lua state misses.

- `cargo test -p config`: green.
- Live check on macOS with the mux host at load 20: three `cli spawn` window
  creations plus a `cli list` complete in 0.34s and the GUI stays
  responsive. Before the fix, samples show a single window creation holding
  the main thread for over a second during re-attach, with cli queries
  timing out behind it.
