### PR TITLE
Fix macOS transparent window composition

### DIFF
--- a/window/src/os/macos/connection.rs
+++ b/window/src/os/macos/connection.rs
@@ -12,7 +12,7 @@ use crate::Appearance;
 use cocoa::appkit::{NSApp, NSApplication, NSApplicationActivationPolicyRegular, NSScreen};
 use cocoa::base::{id, nil};
 use cocoa::foundation::{NSArray, NSInteger};
-use objc::runtime::{Object};
+use objc::runtime::Object;
 use objc::*;
 use serde::Deserialize;
 use std::cell::RefCell;

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -58,6 +58,17 @@ const NSViewLayerContentsPlacementTopLeft: NSInteger = 11;
 #[allow(non_upper_case_globals)]
 const NSViewLayerContentsRedrawDuringViewResize: NSInteger = 2;
 
+unsafe fn window_background_color(is_opaque: bool) -> id {
+    let clear_color = cocoa::appkit::NSColor::clearColor(nil);
+    if is_opaque {
+        clear_color
+    } else {
+        // Alpha zero tells WindowServer that this may be an irregularly shaped
+        // window, which destabilizes native shadow/edge composition.
+        msg_send![clear_color, colorWithAlphaComponent: 0.01f64]
+    }
+}
+
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
     fn CGSMainConnectionID() -> id;
@@ -524,7 +535,9 @@ impl Window {
             let _: () = msg_send![*window, setRestorable: NO];
 
             window.setReleasedWhenClosed_(NO);
-            window.setBackgroundColor_(cocoa::appkit::NSColor::clearColor(nil));
+            window.setBackgroundColor_(window_background_color(
+                config.window_background_opacity >= 1.0,
+            ));
 
             // Tell Cocoa that we output in sRGB, so it handles color space
             // conversion for non-sRGB displays.
@@ -1107,6 +1120,9 @@ impl WindowInner {
                 is_opaque
             };
             self.window.setHasShadow_(shadow);
+
+            self.window
+                .setBackgroundColor_(window_background_color(is_opaque));
         }
     }
 

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -541,9 +541,8 @@ impl Window {
             let _: () = msg_send![*window, setRestorable: NO];
 
             window.setReleasedWhenClosed_(NO);
-            window.setBackgroundColor_(window_background_color(
-                config.window_background_opacity >= 1.0,
-            ));
+            let is_opaque = self.config.window_background_opacity >= 1.0;
+            window.setBackgroundColor_(window_background_color(is_opaque));
 
             // Tell Cocoa that we output in sRGB, so it handles color space
             // conversion for non-sRGB displays.

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -541,7 +541,7 @@ impl Window {
             let _: () = msg_send![*window, setRestorable: NO];
 
             window.setReleasedWhenClosed_(NO);
-            let is_opaque = self.config.window_background_opacity >= 1.0;
+            let is_opaque = config.window_background_opacity >= 1.0;
             window.setBackgroundColor_(window_background_color(is_opaque));
 
             // Tell Cocoa that we output in sRGB, so it handles color space

--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -58,13 +58,19 @@ const NSViewLayerContentsPlacementTopLeft: NSInteger = 11;
 #[allow(non_upper_case_globals)]
 const NSViewLayerContentsRedrawDuringViewResize: NSInteger = 2;
 
+/// Returns the background color to use for the window.
 unsafe fn window_background_color(is_opaque: bool) -> id {
     let clear_color = cocoa::appkit::NSColor::clearColor(nil);
     if is_opaque {
         clear_color
     } else {
-        // Alpha zero tells WindowServer that this may be an irregularly shaped
-        // window, which destabilizes native shadow/edge composition.
+        // An alpha of zero puts NSWindow into a special mode for irregularly
+        // shaped windows, where shadows are generated from the window contents.
+        // A nearly transparent color avoids that mode while preserving transparency.
+        // See:
+        // <https://notes.yvt.jp/Desktop-Apps/Enabling-Backdrop-Blur/#cgssetwindowbackgroundblurradius>
+        // iTerm2 uses the same workaround:
+        // <https://github.com/gnachman/iTerm2/commit/d5ebd6a00e3522399a47b1a9a739581f69247ccd>
         msg_send![clear_color, colorWithAlphaComponent: 0.01f64]
     }
 }


### PR DESCRIPTION
Use a nearly transparent `NSWindow` background color (alpha `0.01`) instead of a fully clear color when the window is non-opaque.

An exactly transparent window background seems to cause WindowServer to behave differently for window shape and shadow composition. iTerm2 works around the same behaviour by using an alpha of 0.01 rather than 0:

[alpha change](https://github.com/gnachman/iTerm2/blob/3ec57866cd9bcf932f2675f7ca47183793a37b79/sources/TerminalView/PseudoTerminal.m#L8239)

The iTerm2 commit adding the workaround gives a bit more context:

[iTerm2 commit](https://github.com/gnachman/iTerm2/commit/d5ebd6a00e3522399a47b1a9a739581f69247ccd)

This also updates the background color when opacity changes through a config reload.

Tested on macOS with transparency, background blur, `RESIZE`, and
`MACOS_FORCE_ENABLE_SHADOW`. Repeated continuous Mission Control and Stage Manager
transitions no longer produced partial shadows, incorrect borders/corners,
or composition flickering.

`cargo test --all` and the native macOS release build pass.

Likely fixes #5158.

Some reference images for the visual abnormalities I was dealing with.

<img width="933" height="506" alt="partial-zoomed-corner" src="https://github.com/user-attachments/assets/399b18a6-e8e0-4ce3-8292-485add88860c" />
<img width="983" height="574" alt="correct-zoomed-corner" src="https://github.com/user-attachments/assets/081f1652-cfad-4c1a-929d-ae115770bbca" />
<img width="600" height="448" alt="sub-rectangle-fault-zoomed-middle" src="https://github.com/user-attachments/assets/e608d4e9-34c2-4213-bf6f-09a61cf622bb" />
<img width="842" height="602" alt="partial" src="https://github.com/user-attachments/assets/6608bbbf-5b95-4b38-9703-9f15562b2183" />
<img width="867" height="624" alt="sub-rectangle-fault" src="https://github.com/user-attachments/assets/3a7e69ed-b1b8-4b61-bd36-f08c233b08c1" />
<img width="1668" height="1203" alt="correct" src="https://github.com/user-attachments/assets/2c3c5181-4cca-457c-9b4a-f6c312440bcb" />

