### PR TITLE
dynamic: Add fallback="OtherType" container attribute

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -1990,12 +1990,21 @@ pub enum VerticalWindowContentAlignment {
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, PartialEq, Eq)]
+#[dynamic(fallback = "bool")]
 pub enum NewlineCanon {
-    // FIXME: also allow deserialziing from bool
     None,
     LineFeed,
     CarriageReturn,
     CarriageReturnAndLineFeed,
+}
+
+impl From<bool> for NewlineCanon {
+    fn from(value: bool) -> Self {
+        match value {
+            true => NewlineCanon::CarriageReturnAndLineFeed,
+            false => NewlineCanon::None,
+        }
+    }
 }
 
 #[derive(FromDynamic, ToDynamic, Clone, Copy, Debug, Default)]

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -2113,7 +2113,8 @@ fn default_line_to_ele_shape_cache_size() -> usize {
     1024
 }
 
-#[derive(Debug, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, FromDynamic, ToDynamic, Clone, Copy, PartialEq, Eq, Default)]
+#[dynamic(fallback = "bool")]
 pub enum BoldBrightening {
     /// Bold doesn't influence palette selection
     No,
@@ -2124,25 +2125,11 @@ pub enum BoldBrightening {
     BrightOnly,
 }
 
-impl FromDynamic for BoldBrightening {
-    fn from_dynamic(
-        value: &wezterm_dynamic::Value,
-        options: wezterm_dynamic::FromDynamicOptions,
-    ) -> Result<Self, wezterm_dynamic::Error> {
-        match String::from_dynamic(value, options) {
-            Ok(s) => match s.as_str() {
-                "No" => Ok(Self::No),
-                "BrightAndBold" => Ok(Self::BrightAndBold),
-                "BrightOnly" => Ok(Self::BrightOnly),
-                s => Err(wezterm_dynamic::Error::Message(format!(
-                    "`{s}` is not valid, use one of `No`, `BrightAndBold` or `BrightOnly`"
-                ))),
-            },
-            Err(err) => match bool::from_dynamic(value, options) {
-                Ok(true) => Ok(Self::BrightAndBold),
-                Ok(false) => Ok(Self::No),
-                Err(_) => Err(err),
-            },
+impl From<bool> for BoldBrightening {
+    fn from(value: bool) -> Self {
+        match value {
+            true => Self::BrightAndBold,
+            false => Self::No,
         }
     }
 }

--- a/wezterm-dynamic/README.md
+++ b/wezterm-dynamic/README.md
@@ -88,6 +88,7 @@ Attributes are placed on struct/enum definitions or individual fields.
 | `#[dynamic(debug)]` | Print the generated token stream to stderr at compile time |
 | `#[dynamic(try_from = "OtherType")]` | Deserialize into `OtherType` then construct `Self` via `TryFrom<OtherType>` |
 | `#[dynamic(into = "OtherType")]` | Convert `self` into `OtherType` via `Into`, then serialize `OtherType` |
+| `#[dynamic(fallback = "OtherType")]` | Try `Self` deserialization first; on failure retry deserialization with `OtherType` and convert to `Self` via `From<OtherType>`. Mutually exclusive with `try_from`. |
 
 ### Field-level
 

--- a/wezterm-dynamic/derive/src/attr.rs
+++ b/wezterm-dynamic/derive/src/attr.rs
@@ -5,12 +5,14 @@ use syn::{Attribute, Error, Field, Lit, Meta, NestedMeta, Path, Result};
 pub struct ContainerInfo {
     pub into: Option<Path>,
     pub try_from: Option<Path>,
+    pub fallback: Option<Path>,
     pub debug: bool,
 }
 
 pub fn container_info(attrs: &[Attribute]) -> Result<ContainerInfo> {
     let mut into = None;
     let mut try_from = None;
+    let mut fallback = None;
     let mut debug = false;
 
     for attr in attrs {
@@ -44,6 +46,12 @@ pub fn container_info(attrs: &[Attribute]) -> Result<ContainerInfo> {
                             continue;
                         }
                     }
+                    if value.path.is_ident("fallback") {
+                        if let Lit::Str(s) = &value.lit {
+                            fallback = Some(s.parse()?);
+                            continue;
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -51,9 +59,17 @@ pub fn container_info(attrs: &[Attribute]) -> Result<ContainerInfo> {
         }
     }
 
+    if try_from.is_some() && fallback.is_some() {
+        return Err(Error::new(
+            proc_macro2::Span::call_site(),
+            "`try_from` and `fallback` are mutually exclusive",
+        ));
+    }
+
     Ok(ContainerInfo {
         into,
         try_from,
+        fallback,
         debug,
     })
 }

--- a/wezterm-dynamic/derive/src/fromdynamic.rs
+++ b/wezterm-dynamic/derive/src/fromdynamic.rs
@@ -90,7 +90,7 @@ fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenStrea
         )
     };
 
-    let from_dynamic = match info.try_from {
+    let primary_body = match info.try_from {
         Some(try_from) => {
             quote!(
                 use core::convert::TryFrom;
@@ -112,6 +112,27 @@ fn derive_struct(input: &DeriveInput, fields: &FieldsNamed) -> Result<TokenStrea
                 }
             )
         }
+    };
+
+    let from_dynamic = match info.fallback {
+        Some(fallback) => quote!(
+            let primary_result = (|| -> core::result::Result<Self, wezterm_dynamic::Error> {
+                #primary_body
+            })();
+            match primary_result {
+                Ok(v) => Ok(v),
+                Err(primary_err) => {
+                    match <#fallback as wezterm_dynamic::FromDynamic>::from_dynamic(value, options) {
+                        Ok(legacy) => Ok(<#ident as core::convert::From<#fallback>>::from(legacy)),
+                        Err(fallback_err) => Err(wezterm_dynamic::Error::FallbackFailed {
+                            primary_error: Box::new(primary_err),
+                            fallback_error: Box::new(fallback_err),
+                        }),
+                    }
+                }
+            }
+        ),
+        None => primary_body,
     };
 
     let tokens = quote! {
@@ -154,7 +175,7 @@ fn derive_enum(input: &DeriveInput, enumeration: &DataEnum) -> Result<TokenStrea
         .map(|variant| variant.ident.to_string())
         .collect::<Vec<_>>();
 
-    let from_dynamic = match info.try_from {
+    let primary_body = match info.try_from {
         Some(try_from) => {
             quote!(
                 use core::convert::TryFrom;
@@ -307,6 +328,27 @@ fn derive_enum(input: &DeriveInput, enumeration: &DataEnum) -> Result<TokenStrea
                     }
             )
         }
+    };
+
+    let from_dynamic = match info.fallback {
+        Some(fallback) => quote!(
+            let primary_result = (|| -> core::result::Result<Self, wezterm_dynamic::Error> {
+                #primary_body
+            })();
+            match primary_result {
+                Ok(v) => Ok(v),
+                Err(primary_err) => {
+                    match <#fallback as wezterm_dynamic::FromDynamic>::from_dynamic(value, options) {
+                        Ok(legacy) => Ok(<#ident as core::convert::From<#fallback>>::from(legacy)),
+                        Err(fallback_err) => Err(wezterm_dynamic::Error::FallbackFailed {
+                            primary_error: Box::new(primary_err),
+                            fallback_error: Box::new(fallback_err),
+                        }),
+                    }
+                }
+            }
+        ),
+        None => primary_body,
     };
 
     let tokens = quote! {

--- a/wezterm-dynamic/src/error.rs
+++ b/wezterm-dynamic/src/error.rs
@@ -10,6 +10,7 @@ use thiserror::Error;
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
@@ -77,6 +78,11 @@ pub enum Error {
         type_name: &'static str,
         field_name: &'static str,
         reason: &'static str,
+    },
+    #[error("{}\n  also tried fallback type: {}", .primary_error, .fallback_error)]
+    FallbackFailed {
+        primary_error: Box<Error>,
+        fallback_error: Box<Error>,
     },
 }
 

--- a/wezterm-dynamic/tests/fromdynamic.rs
+++ b/wezterm-dynamic/tests/fromdynamic.rs
@@ -313,7 +313,10 @@ fn fallback_struct_primary_succeeds() {
         .into(),
     );
     assert_eq!(
-        StructWithSimplerFallback { field: "hello".to_string(), other: 99 },
+        StructWithSimplerFallback {
+            field: "hello".to_string(),
+            other: 99
+        },
         StructWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
     );
 }
@@ -324,7 +327,10 @@ fn fallback_struct_simpler_string_used() {
     // converts it into the primary type.
     let val = Value::String("simpler-value".to_string());
     assert_eq!(
-        StructWithSimplerFallback { field: "simpler-value".to_string(), other: 0 },
+        StructWithSimplerFallback {
+            field: "simpler-value".to_string(),
+            other: 0
+        },
         StructWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
     );
 }
@@ -335,11 +341,17 @@ fn fallback_struct_both_fail_returns_fallback_failed() {
     // both errors are returned.
     let val = Value::U64(999); // not an Object and not a String
     let err = StructWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap_err();
-    let Error::FallbackFailed { primary_error, fallback_error } = err else {
+    let Error::FallbackFailed {
+        primary_error,
+        fallback_error,
+    } = err
+    else {
         panic!("expected FallbackFailed, got: {err:?}");
     };
     assert!(
-        primary_error.to_string().contains("StructWithSimplerFallback"),
+        primary_error
+            .to_string()
+            .contains("StructWithSimplerFallback"),
         "primary error should mention the primary type name, got: {primary_error}",
     );
     assert!(
@@ -377,7 +389,9 @@ fn fallback_enum_primary_succeeds() {
         .into(),
     );
     assert_eq!(
-        EnumWithSimplerFallback::Complex { field: "yes".to_string() },
+        EnumWithSimplerFallback::Complex {
+            field: "yes".to_string()
+        },
         EnumWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
     );
 }
@@ -387,7 +401,9 @@ fn fallback_enum_simpler_string_used() {
     // When input is a bare string, fallback path runs.
     let val = Value::String("simpler-enum".to_string());
     assert_eq!(
-        EnumWithSimplerFallback::Complex { field: "simpler-enum".to_string() },
+        EnumWithSimplerFallback::Complex {
+            field: "simpler-enum".to_string()
+        },
         EnumWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
     );
 }
@@ -398,11 +414,17 @@ fn fallback_enum_both_fail_returns_fallback_failed() {
     // both errors are returned.
     let val = Value::U64(42); // not a valid enum Object, not a String
     let err = EnumWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap_err();
-    let Error::FallbackFailed { primary_error, fallback_error } = err else {
+    let Error::FallbackFailed {
+        primary_error,
+        fallback_error,
+    } = err
+    else {
         panic!("expected FallbackFailed, got: {err:?}");
     };
     assert!(
-        primary_error.to_string().contains("EnumWithSimplerFallback"),
+        primary_error
+            .to_string()
+            .contains("EnumWithSimplerFallback"),
         "primary error should mention the primary type name, got: {primary_error}",
     );
     assert!(

--- a/wezterm-dynamic/tests/fromdynamic.rs
+++ b/wezterm-dynamic/tests/fromdynamic.rs
@@ -1,6 +1,6 @@
 use maplit::btreemap;
 use ordered_float::OrderedFloat;
-use wezterm_dynamic::{FromDynamic, Object, ToDynamic, Value};
+use wezterm_dynamic::{Error, FromDynamic, Object, ToDynamic, Value};
 
 #[derive(FromDynamic, Debug, PartialEq)]
 struct SimpleStruct {
@@ -286,5 +286,127 @@ fn enum_into() {
     assert_eq!(
         EnumInto::Age(42),
         EnumInto::from_dynamic(&Value::String("age:42".to_string()), Default::default()).unwrap()
+    );
+}
+
+// Struct: primary is a named-field struct; simpler format is a plain string.
+#[derive(FromDynamic, ToDynamic, Debug, PartialEq)]
+#[dynamic(fallback = "String")]
+struct StructWithSimplerFallback {
+    field: String,
+    other: u32,
+}
+impl From<String> for StructWithSimplerFallback {
+    fn from(s: String) -> Self {
+        StructWithSimplerFallback { field: s, other: 0 }
+    }
+}
+
+#[test]
+fn fallback_struct_primary_succeeds() {
+    // When input matches primary struct format, it is used directly.
+    let val = Value::Object(
+        btreemap! {
+            "field".to_dynamic() => Value::String("hello".to_string()),
+            "other".to_dynamic() => Value::U64(99),
+        }
+        .into(),
+    );
+    assert_eq!(
+        StructWithSimplerFallback { field: "hello".to_string(), other: 99 },
+        StructWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
+    );
+}
+
+#[test]
+fn fallback_struct_simpler_string_used() {
+    // When input is a bare string (simpler format), fallback path runs and From<String>
+    // converts it into the primary type.
+    let val = Value::String("simpler-value".to_string());
+    assert_eq!(
+        StructWithSimplerFallback { field: "simpler-value".to_string(), other: 0 },
+        StructWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
+    );
+}
+
+#[test]
+fn fallback_struct_both_fail_returns_fallback_failed() {
+    // When neither primary nor fallback types can deserialize the value,
+    // both errors are returned.
+    let val = Value::U64(999); // not an Object and not a String
+    let err = StructWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap_err();
+    let Error::FallbackFailed { primary_error, fallback_error } = err else {
+        panic!("expected FallbackFailed, got: {err:?}");
+    };
+    assert!(
+        primary_error.to_string().contains("StructWithSimplerFallback"),
+        "primary error should mention the primary type name, got: {primary_error}",
+    );
+    assert!(
+        fallback_error.to_string().contains("String"),
+        "fallback error should mention the fallback type name, got: {fallback_error}",
+    );
+}
+
+// Enum: primary is a named-variant enum; simpler format is a plain string.
+#[derive(FromDynamic, ToDynamic, Debug, PartialEq)]
+#[dynamic(fallback = "String")]
+enum EnumWithSimplerFallback {
+    Complex { field: String },
+    Other,
+}
+
+impl From<String> for EnumWithSimplerFallback {
+    fn from(s: String) -> Self {
+        EnumWithSimplerFallback::Complex { field: s }
+    }
+}
+
+#[test]
+fn fallback_enum_primary_succeeds() {
+    // When input matches the primary enum format, it is used directly.
+    let val = Value::Object(
+        btreemap! {
+            "Complex".to_dynamic() => Value::Object(
+                btreemap! {
+                    "field".to_dynamic() => Value::String("yes".to_string()),
+                }
+                .into(),
+            ),
+        }
+        .into(),
+    );
+    assert_eq!(
+        EnumWithSimplerFallback::Complex { field: "yes".to_string() },
+        EnumWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
+    );
+}
+
+#[test]
+fn fallback_enum_simpler_string_used() {
+    // When input is a bare string, fallback path runs.
+    let val = Value::String("simpler-enum".to_string());
+    assert_eq!(
+        EnumWithSimplerFallback::Complex { field: "simpler-enum".to_string() },
+        EnumWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap(),
+    );
+}
+
+#[test]
+fn fallback_enum_both_fail_returns_fallback_failed() {
+    // When neither primary nor fallback types can deserialize the value,
+    // both errors are returned.
+    let val = Value::U64(42); // not a valid enum Object, not a String
+    let err = EnumWithSimplerFallback::from_dynamic(&val, Default::default()).unwrap_err();
+    let Error::FallbackFailed { primary_error, fallback_error } = err else {
+        panic!("expected FallbackFailed, got: {err:?}");
+    };
+    assert!(
+        primary_error.to_string().contains("EnumWithSimplerFallback"),
+        "primary error should mention the primary type name, got: {primary_error}",
+    );
+    assert!(
+        fallback_error.to_string().contains("String"),
+        "fallback error should mention the fallback type name, got: {fallback_error}",
     );
 }


### PR DESCRIPTION
Allows a struct or enum to transparently accept an older/simpler format.
The derived from_dynamic first attempts the primary type; on failure it retries with OtherType and converts it to primary type. When both fail, both errors are surfaced to the user.

The fallback attribute is mutually exclusive with try_from.
ToDynamic is unaffected.

(NOTE: I'll merge them separately, not squashed!)
👉 https://github.com/wezterm/wezterm/pull/8039/changes/11dc8b6ca9de2d467f2f485d77c39cbb6ab88845 Restored bool parsing for `NewlineCanon`, which had been _broken_ since https://github.com/wezterm/wezterm/commit/f587cac145868320937a3cd28c426126d83c0257 in 2022 👀
👉 https://github.com/wezterm/wezterm/pull/8039/changes/53ac24b673adc99ee0f3bea883f46f682a31fc4a Simplifies BoldBrightening bool value parsing

> [!NOTE]
> I also added a README for the crate, just before (no PR), to better understand what's going on here: https://github.com/wezterm/wezterm/commit/ad5abbaf21676fb44c6a65f7deb09c979ce34596


---

This is an enabler to be able to transparently migrate old actions/configs from a legacy/simpler format to a more structured one.
For example: https://github.com/wezterm/wezterm/pull/6999#issuecomment-3694491298

Alternatively we could offer simpler ways to set configs, like:
```lua
config.window_alignment = "Center"
-- vs
config.window_alignment = {
  horizontal = "Center",
  vertical = "Center",
}
```
