### PR TITLE
x11: fix OSC 52 clipboard silently doing nothing

### DIFF
--- a/window/src/os/x11/window.rs
+++ b/window/src/os/x11/window.rs
@@ -923,10 +923,11 @@ impl XWindowInner {
                         but we don't: tell it to clear it"
             );
             // We don't have a selection but X thinks we do; disown it!
+            // See the note about CURRENT_TIME in the assert branch below.
             conn.send_request_no_reply(&xcb::x::SetSelectionOwner {
                 owner: xcb::x::Window::none(),
                 selection,
-                time: self.copy_and_paste.time,
+                time: xcb::x::CURRENT_TIME,
             })?;
         } else if we_own_it {
             log::trace!(
@@ -934,10 +935,19 @@ impl XWindowInner {
                  {current_owner:?}, tell X we now own it"
             );
             // We have the selection but X doesn't think we do; assert it!
+            //
+            // We deliberately use CURRENT_TIME rather than
+            // self.copy_and_paste.time here. That field only advances on key
+            // and button events delivered to *this* window, so for a window
+            // that hasn't been interacted with recently it lags behind the
+            // selection's lastTimeChanged. The X server silently ignores
+            // SetSelectionOwner whose time predates lastTimeChanged, which
+            // made OSC 52 a no-op whenever another window had copied more
+            // recently. CURRENT_TIME is always accepted.
             conn.send_request_no_reply(&xcb::x::SetSelectionOwner {
                 owner: self.window_id,
                 selection,
-                time: self.copy_and_paste.time,
+                time: xcb::x::CURRENT_TIME,
             })?;
         } else {
             log::trace!(


### PR DESCRIPTION
On X11, OSC 52 frequently had no effect at all: the clipboard kept its previous contents, with no error and nothing in the log.

Reproduced with multiple windows open by mouse-copying in one window and then emitting OSC 52 from a pane in another:

```
printf '\033]52;c;%s\033\\' "$(printf 'hello' | base64)"
```

Two independent bugs combine to cause this, so this PR is split into one commit each.

### 1. `SetSelectionOwner` used a stale timestamp

`update_selection_owner` asserted ownership using `self.copy_and_paste.time`. That field only advances on key and button events delivered to *that particular window*, so a window the user has not touched recently carries a timestamp that predates the selection's `lastTimeChanged`. Per ICCCM the X server silently ignores `SetSelectionOwner` in that case — no error, nothing logged, the assertion is simply dropped.

Switched to `CURRENT_TIME`, which is always accepted, for both the assert and the disown path. This mirrors what `focus()` already does, and for the same underlying reason.

This is the bug that makes OSC 52 look intermittent: it works until some other window takes the selection, and appears to "fix itself" after a restart because a fresh window's timestamps win again until the next copy elsewhere.

### 2. The clipboard went to the wrong window

`MuxNotification::AssignClipboard` picked the target window with `fe.known_windows.borrow().keys().next()`. `known_windows` is a `BTreeMap` keyed by the window handle, so this is the lowest handle — the oldest window — regardless of which pane actually emitted the sequence. With more than one window open, OSC 52 from a pane in a newer window set the clipboard by way of an unrelated window.

Now resolves the pane to its mux window and uses the window that owns it, falling back to the previous behaviour if the lookup fails.

### Testing

Built and run on X11 (MATE, single X server, multiple windows and panes). Before: OSC 52 silently no-ops once another window has copied. After: the sequence sets the clipboard reliably from any pane in any window, verified by pasting into other X clients.

I have not tested Wayland or macOS. Change 1 is X11-only; change 2 is in the shared frontend but only alters *which* window receives an already-correct assignment.

Possibly related: #5917 (X11, OSC 52 silently stops working). I can't confirm it's the same root cause — that report attributes the trigger to the presence of a config file, which this doesn't explain — but the symptom matches.
