### PR TITLE
Add mouse and focus accessors to TerminalState

### DIFF
--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -264,6 +264,9 @@ pub struct TerminalState {
     /// If true, writing a character inserts a new cell
     insert: bool,
 
+    /// When set, received chars auto-wrap to the next line when the cursor reaches the right border.
+    /// Otherwise received chars continuously replace the last char on the right.
+    /// note: This is set by default, because it's more useful this way.
     /// https://vt100.net/docs/vt510-rm/DECAWM.html
     dec_auto_wrap: bool,
 
@@ -752,38 +755,62 @@ impl TerminalState {
         self.mouse_tracking || self.button_event_mouse || self.any_event_mouse
     }
 
+    /// Returns true if the alternate screen (secondary screen buffer) is currently active.
+    /// This is useful for the hosting GUI application to decide how best
+    /// to handle operations like scrollback that only apply to the primary screen.
     pub fn is_alt_screen_active(&self) -> bool {
         self.screen.is_alt_screen_active()
     }
 
+    /// Returns true if the associated application has enabled basic mouse
+    /// tracking mode (DEC mode 1000).
+    /// This is useful for the hosting GUI application to decide how best
+    /// to dispatch mouse events to the terminal.
     pub fn mouse_tracking_enabled(&self) -> bool {
         self.mouse_tracking
     }
 
+    /// Returns true if the associated application has enabled button-event mouse
+    /// tracking mode (DEC mode 1002), which reports motion events while a button is held.
+    /// This is useful for the hosting GUI application to decide how best
+    /// to dispatch mouse events to the terminal.
     pub fn button_event_mouse_enabled(&self) -> bool {
         self.button_event_mouse
     }
 
+    /// Returns true if the associated application has enabled any-event mouse
+    /// tracking mode (DEC mode 1003), which reports all motion events regardless of button state.
+    /// This is useful for the hosting GUI application to decide how best
+    /// to dispatch mouse events to the terminal.
     pub fn any_event_mouse_enabled(&self) -> bool {
         self.any_event_mouse
     }
 
+    /// Returns the current mouse reporting encoding selected by the associated application.
     pub fn get_mouse_encoding(&self) -> MouseEncoding {
         self.mouse_encoding
     }
 
+    /// Returns true if the associated application has enabled focus tracking mode
+    /// (DEC mode 1004), which causes focus-in and focus-out events to be reported.
     pub fn focus_tracking_enabled(&self) -> bool {
         self.focus_tracking
     }
 
+    /// Returns true if the associated application has enabled application cursor keys mode
+    /// (DEC mode 1), which causes cursor keys to send application sequences instead of ANSI ones.
     pub fn application_cursor_keys_enabled(&self) -> bool {
         self.application_cursor_keys
     }
 
+    /// Returns true if the associated application has enabled the special encoding of the numeric
+    /// keypad portion of the keyboard.
     pub fn application_keypad_enabled(&self) -> bool {
         self.application_keypad
     }
 
+    /// Returns true if DECAWM auto-wrap mode (DEC mode 7) is enabled, which causes
+    /// the cursor to wrap to the next line when it reaches the right border.
     pub fn dec_auto_wrap_enabled(&self) -> bool {
         self.dec_auto_wrap
     }

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -42,18 +42,25 @@ lazy_static::lazy_static! {
     };
 }
 
+/// Tracks the horizontal tab stops for a terminal screen.
+/// Tab stops are stored as a boolean vector, one entry per column.
 pub(crate) struct TabStop {
     tabs: Vec<bool>,
     tab_width: usize,
 }
 
+/// A character set selectable through the DEC SCS escape sequences.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum CharSet {
+pub enum CharSet {
+    /// The US ASCII character set (`B`).
     Ascii,
+    /// The United Kingdom character set (`A`).
     Uk,
+    /// DEC Special Graphics / line drawing (`0`).
     DecLineDrawing,
 }
 
+/// The mouse reporting encoding negotiated through DEC private mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MouseEncoding {
     X10,
@@ -284,6 +291,9 @@ pub struct TerminalState {
 
     /// The scroll region
     top_and_bottom_margins: Range<VisibleRowIndex>,
+    /// The inner horizontal region between DECSLRM left/right margins.
+    /// `start` is the left margin column, `end` is one past the right margin column.
+    /// Only effective when `left_and_right_margin_mode` is enabled.
     left_and_right_margins: Range<usize>,
     left_and_right_margin_mode: bool,
 
@@ -810,7 +820,7 @@ impl TerminalState {
     }
 
     /// Returns true if DECAWM auto-wrap mode (DEC mode 7) is enabled, which causes
-    /// the cursor to wrap to the next line when it reaches the right border.
+    /// cursor to wrap to next line when it reaches right border.
     pub fn dec_auto_wrap_enabled(&self) -> bool {
         self.dec_auto_wrap
     }
@@ -820,57 +830,48 @@ impl TerminalState {
         self.top_and_bottom_margins.clone()
     }
 
-    /// The DECSLRM margins. These are only in force when
-    /// [`Self::left_and_right_margin_mode_enabled`] is also true; the range
-    /// keeps its full-width value while the mode is off.
-    pub fn get_left_and_right_margins(&self) -> Range<usize> {
-        self.left_and_right_margins.clone()
-    }
-
+    /// Returns true if DEC left/right margin mode (DECLRMM) is enabled.
+    /// Use [`Self::get_left_and_right_margins`] to get those margin values.
     pub fn left_and_right_margin_mode_enabled(&self) -> bool {
         self.left_and_right_margin_mode
     }
 
+    /// The inner horizontal region between the DECSLRM margins.
+    /// `start` is the left margin column, `end` is one past the right margin column.
+    /// Only effective when [`Self::left_and_right_margin_mode_enabled`] is true.
+    pub fn get_left_and_right_margins(&self) -> Range<usize> {
+        self.left_and_right_margins.clone()
+    }
+
+    /// Returns true if DEC origin mode (DECOM) is enabled.
     pub fn dec_origin_mode_enabled(&self) -> bool {
         self.dec_origin_mode
     }
 
+    /// Returns true if insert mode (IRM) is enabled.
     pub fn insert_mode_enabled(&self) -> bool {
         self.insert
     }
 
+    /// Returns true if shift-out is enabled: G1 charset is active for display.
+    /// Reset by shift-in, which restores G0 charset.
     pub fn shift_out_enabled(&self) -> bool {
         self.shift_out
     }
 
-    /// The SCS final byte designating G0: `b'B'` ASCII, `b'A'` UK, `b'0'` DEC
-    /// line drawing. Emit as `ESC ( <byte>`.
-    ///
-    /// Returns the designator rather than `CharSet` because `CharSet` is
-    /// `pub(crate)`: a getter returning it would widen an existing item, and
-    /// this crate already carries one such widening. The byte is what a caller
-    /// reconstructing terminal state needs anyway, so nothing is lost.
-    pub fn g0_charset_designator(&self) -> u8 {
-        match self.g0_charset {
-            CharSet::Ascii => b'B',
-            CharSet::Uk => b'A',
-            CharSet::DecLineDrawing => b'0',
-        }
+    /// The Character Set Selection (SCS) charset designated for G0.
+    pub fn g0_charset(&self) -> CharSet {
+        self.g0_charset
     }
 
-    /// The SCS final byte designating G1. See
-    /// [`Self::g0_charset_designator`]; emit as `ESC ) <byte>`.
-    pub fn g1_charset_designator(&self) -> u8 {
-        match self.g1_charset {
-            CharSet::Ascii => b'B',
-            CharSet::Uk => b'A',
-            CharSet::DecLineDrawing => b'0',
-        }
+    /// The Character Set Selection (SCS) charset designated for G1.
+    pub fn g1_charset(&self) -> CharSet {
+        self.g1_charset
     }
 
-    /// Tab stops by column: `true` where a stop is set. Length tracks the screen
-    /// width, so index is column.
-    pub fn tab_stops(&self) -> Vec<bool> {
+    /// Tab stops by column: `true` where a stop is set.
+    /// Length tracks the screen width, so index is the column.
+    pub fn tab_stops_by_column(&self) -> Vec<bool> {
         self.tabs.tabs.clone()
     }
 

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -55,7 +55,7 @@ pub(crate) enum CharSet {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum MouseEncoding {
+pub enum MouseEncoding {
     X10,
     Utf8,
     SGR,
@@ -754,6 +754,38 @@ impl TerminalState {
 
     pub fn is_alt_screen_active(&self) -> bool {
         self.screen.is_alt_screen_active()
+    }
+
+    pub fn mouse_tracking_enabled(&self) -> bool {
+        self.mouse_tracking
+    }
+
+    pub fn button_event_mouse_enabled(&self) -> bool {
+        self.button_event_mouse
+    }
+
+    pub fn any_event_mouse_enabled(&self) -> bool {
+        self.any_event_mouse
+    }
+
+    pub fn get_mouse_encoding(&self) -> MouseEncoding {
+        self.mouse_encoding
+    }
+
+    pub fn focus_tracking_enabled(&self) -> bool {
+        self.focus_tracking
+    }
+
+    pub fn application_cursor_keys_enabled(&self) -> bool {
+        self.application_cursor_keys
+    }
+
+    pub fn application_keypad_enabled(&self) -> bool {
+        self.application_keypad
+    }
+
+    pub fn dec_auto_wrap_enabled(&self) -> bool {
+        self.dec_auto_wrap
     }
 
     /// Returns true if the associated application has enabled

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -788,6 +788,65 @@ impl TerminalState {
         self.dec_auto_wrap
     }
 
+        /// The DECSTBM scroll region, as inclusive-start/exclusive-end visible rows.
+    pub fn get_top_and_bottom_margins(&self) -> Range<VisibleRowIndex> {
+        self.top_and_bottom_margins.clone()
+    }
+
+    /// The DECSLRM margins. These are only in force when
+    /// [`Self::left_and_right_margin_mode_enabled`] is also true; the range
+    /// keeps its full-width value while the mode is off.
+    pub fn get_left_and_right_margins(&self) -> Range<usize> {
+        self.left_and_right_margins.clone()
+    }
+
+    pub fn left_and_right_margin_mode_enabled(&self) -> bool {
+        self.left_and_right_margin_mode
+    }
+
+    pub fn dec_origin_mode_enabled(&self) -> bool {
+        self.dec_origin_mode
+    }
+
+    pub fn insert_mode_enabled(&self) -> bool {
+        self.insert
+    }
+
+    pub fn shift_out_enabled(&self) -> bool {
+        self.shift_out
+    }
+
+    /// The SCS final byte designating G0: `b'B'` ASCII, `b'A'` UK, `b'0'` DEC
+    /// line drawing. Emit as `ESC ( <byte>`.
+    ///
+    /// Returns the designator rather than `CharSet` because `CharSet` is
+    /// `pub(crate)`: a getter returning it would widen an existing item, and
+    /// this crate already carries one such widening. The byte is what a caller
+    /// reconstructing terminal state needs anyway, so nothing is lost.
+    pub fn g0_charset_designator(&self) -> u8 {
+        match self.g0_charset {
+            CharSet::Ascii => b'B',
+            CharSet::Uk => b'A',
+            CharSet::DecLineDrawing => b'0',
+        }
+    }
+
+    /// The SCS final byte designating G1. See
+    /// [`Self::g0_charset_designator`]; emit as `ESC ) <byte>`.
+    pub fn g1_charset_designator(&self) -> u8 {
+        match self.g1_charset {
+            CharSet::Ascii => b'B',
+            CharSet::Uk => b'A',
+            CharSet::DecLineDrawing => b'0',
+        }
+    }
+
+    /// Tab stops by column: `true` where a stop is set. Length tracks the screen
+    /// width, so index is column.
+    pub fn tab_stops(&self) -> Vec<bool> {
+        self.tabs.tabs.clone()
+    }
+
     /// Returns true if the associated application has enabled
     /// bracketed paste mode, which can be helpful to the hosting
     /// GUI application to decide about fragmenting a large paste.

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -788,7 +788,7 @@ impl TerminalState {
         self.dec_auto_wrap
     }
 
-        /// The DECSTBM scroll region, as inclusive-start/exclusive-end visible rows.
+    /// The DECSTBM scroll region, as inclusive-start/exclusive-end visible rows.
     pub fn get_top_and_bottom_margins(&self) -> Range<VisibleRowIndex> {
         self.top_and_bottom_margins.clone()
     }

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -756,6 +756,38 @@ impl TerminalState {
         self.screen.is_alt_screen_active()
     }
 
+    pub fn mouse_tracking_enabled(&self) -> bool {
+        self.mouse_tracking
+    }
+
+    pub fn button_event_mouse_enabled(&self) -> bool {
+        self.button_event_mouse
+    }
+
+    pub fn any_event_mouse_enabled(&self) -> bool {
+        self.any_event_mouse
+    }
+
+    pub fn get_mouse_encoding(&self) -> MouseEncoding {
+        self.mouse_encoding
+    }
+
+    pub fn focus_tracking_enabled(&self) -> bool {
+        self.focus_tracking
+    }
+
+    pub fn application_cursor_keys_enabled(&self) -> bool {
+        self.application_cursor_keys
+    }
+
+    pub fn application_keypad_enabled(&self) -> bool {
+        self.application_keypad
+    }
+
+    pub fn dec_auto_wrap_enabled(&self) -> bool {
+        self.dec_auto_wrap
+    }
+
     /// Returns true if the associated application has enabled
     /// bracketed paste mode, which can be helpful to the hosting
     /// GUI application to decide about fragmenting a large paste.


### PR DESCRIPTION
I'm embedding wezterm-term in a terminal where the emulator runs in a separate process from the UI, so the frontend has to reproduce the mode state rather than just react to it locally. Most of that state is parsed but isn't reachable from outside the crate.