### PR TITLE
docs: mention Fcitx5 X11 inline preedit setup

### DIFF
--- a/docs/config/lua/config/ime_preedit_rendering.md
+++ b/docs/config/lua/config/ime_preedit_rendering.md
@@ -55,3 +55,8 @@ UseOnTheSpot=True
 ```
 
 Restart Fcitx5, then re-launch WezTerm for the change to take full effect.
+If that is not sufficient, log out of the desktop session and log back in.
+
+For more background on Fcitx5's XIM inline preedit behavior and why this
+option is not enabled by default, see [fcitx/fcitx5#590](https://github.com/fcitx/fcitx5/issues/590)
+and [fcitx/fcitx5#1162](https://github.com/fcitx/fcitx5/issues/1162).

--- a/docs/config/lua/config/ime_preedit_rendering.md
+++ b/docs/config/lua/config/ime_preedit_rendering.md
@@ -40,3 +40,18 @@ Note:
 * Changing `ime_preedit_rendering` usually requires re-launching WezTerm to take full effect.
 * In macOS, `ime_preedit_rendering` has effected nothing yet.
   IME preedit is always rendered by WezTerm itself.
+
+## Fcitx5 on X11
+
+When using Fcitx5 through XIM, `"Builtin"` rendering requires the
+`Use On The Spot Style` option in the Fcitx5 X Input Method Frontend.
+If committed text works but the text being composed appears in a separate
+Fcitx5 input panel instead of at the terminal cursor, enable that option in
+the Fcitx5 configuration tool or set the following root-level option (without
+a section header) in `~/.config/fcitx5/conf/xim.conf`:
+
+```ini
+UseOnTheSpot=True
+```
+
+Restart Fcitx5, then re-launch WezTerm for the change to take full effect.


### PR DESCRIPTION
## Summary

- document the Fcitx5 XIM `Use On The Spot Style` requirement for built-in preedit rendering on X11
- describe the distinctive symptom: committed text works, but the active composition is shown in a separate Fcitx5 panel
- include the exact root-level `xim.conf` setting and restart requirement

WezTerm already requests XIM preedit callbacks for `"Builtin"` rendering. Fcitx5 only advertises the callback style when `UseOnTheSpot` is enabled, so this is a configuration prerequisite rather than a WezTerm rendering bug.

## Verification

Verified on Linux Mint/Cinnamon X11 with WezTerm `20240203-110809-5046fc22`, Fcitx5 `5.1.7`, and Fcitx5 Hangul:

- before: `program:wezterm-gui frontend:xim cap:4000000000`; composition appeared in the Fcitx5 input panel
- after enabling `UseOnTheSpot` and fully restarting Fcitx5: `cap:4000000012`; Korean composition appeared inline at the WezTerm cursor
- `git diff --check` passes

The same symptom was also observed with a native nightly WezTerm build before applying the Fcitx5 setting.
