### PR TITLE
mux: run WSL domain discovery off the startup path (#7782)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3550,6 +3550,7 @@ name = "mux"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-io",
  "async-trait",
  "base64",
  "bintree",

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -943,11 +943,35 @@ impl Config {
         }
     }
 
+    /// Returns the WSL domain list for this config.
+    ///
+    /// **This can block the calling thread**, potentially for tens of seconds, if `wsl_domains`
+    /// isn't configured explicitly: it falls through to `WslDomain::default_domains()`, which shells
+    /// out to `wsl.exe -l -v` (or waits for another in-flight invocation of it) on a cache miss.
+    /// Nothing in this crate calls this method anymore -- prefer `wsl_domains_cached()`, the
+    /// non-blocking accessor used everywhere latency matters, and treat a `None` result as "not
+    /// discovered yet" rather than triggering discovery yourself.
     pub fn wsl_domains(&self) -> Vec<WslDomain> {
         if let Some(domains) = &self.wsl_domains {
             domains.clone()
         } else {
             WslDomain::default_domains()
+        }
+    }
+
+    /// Like `wsl_domains()`, but returns a non-blocking result for the
+    /// auto-discovery case: if `wsl_domains` is not configured, returns
+    /// `Some(cached list)` once discovery has populated it, or `None` while
+    /// discovery hasn't completed yet. Callers must treat `None` differently
+    /// from `Some(vec![])` ("discovery finished and found nothing") -- see
+    /// `LocalDomain::resolve_wsl_domain` for why. Never shells out to
+    /// `wsl.exe`. Use this on latency-sensitive paths (like pane spawn) to
+    /// avoid blocking.
+    pub fn wsl_domains_cached(&self) -> Option<Vec<WslDomain>> {
+        if let Some(domains) = &self.wsl_domains {
+            Some(domains.clone())
+        } else {
+            WslDomain::cached_default_domains()
         }
     }
 

--- a/config/src/lua.rs
+++ b/config/src/lua.rs
@@ -333,7 +333,13 @@ end
 
         wezterm_mod.set(
             "default_wsl_domains",
-            lua.create_function(|_, ()| Ok(crate::WslDomain::default_domains()))?,
+            // Deliberately calls the uncached compute_default_domains(),
+            // not default_domains() (used internally by discovery/spawn
+            // paths that shouldn't repeatedly shell out): this function
+            // is documented to reflect what's currently installed, and a
+            // caller invoking it directly is opting into paying the
+            // `wsl.exe` cost for a live answer.
+            lua.create_function(|_, ()| Ok(crate::WslDomain::compute_default_domains()))?,
         )?;
 
         wezterm_mod.set("font", lua.create_function(font)?)?;

--- a/config/src/wsl.rs
+++ b/config/src/wsl.rs
@@ -2,9 +2,11 @@ use crate::config::validate_domain_name;
 use crate::*;
 use luahelper::impl_lua_conversion_dynamic;
 use std::collections::HashMap;
+use std::sync::{Condvar, Mutex};
+use std::time::{Duration, Instant};
 use wezterm_dynamic::{FromDynamic, ToDynamic};
 
-#[derive(Default, Debug, Clone, FromDynamic, ToDynamic)]
+#[derive(Default, Debug, Clone, PartialEq, FromDynamic, ToDynamic)]
 pub struct WslDomain {
     #[dynamic(validate = "validate_domain_name")]
     pub name: String,
@@ -15,25 +17,405 @@ pub struct WslDomain {
 }
 impl_lua_conversion_dynamic!(WslDomain);
 
-impl WslDomain {
-    pub fn default_domains() -> Vec<WslDomain> {
-        #[allow(unused_mut)]
-        let mut domains = vec![];
+lazy_static::lazy_static! {
+    /// Caches the result of `discover_wsl_domains()` for the lifetime of
+    /// the process, used internally by `default_domains()` (see its doc
+    /// comment). Deliberately *not* consulted by the public
+    /// `wezterm.default_wsl_domains()` Lua API / `compute_default_domains()`,
+    /// which is documented to reflect what's currently installed --
+    /// callers who invoke it directly are opting into paying the
+    /// discovery cost for a live answer, same as on `main` before this
+    /// cache existed.
+    ///
+    /// Only ever locked for the brief "check/publish the cached value"
+    /// steps, never while `wsl.exe` itself is running: holding it across
+    /// the subprocess call would mean any concurrent caller blocks for
+    /// the same duration a hung/slow `wsl.exe` does, with no bound.
+    ///
+    /// Exposed as `pub(crate)` for test access.
+    pub(crate) static ref DEFAULT_DOMAINS_CACHE: Mutex<Option<Vec<WslDomain>>> = Mutex::new(None);
 
-        #[cfg(windows)]
-        if let Ok(distros) = WslDistro::load_distro_list() {
-            for distro in distros {
-                domains.push(WslDomain {
-                    name: format!("WSL:{}", distro.name),
-                    distribution: Some(distro.name.clone()),
-                    username: None,
-                    default_cwd: Some("~".into()),
-                    default_prog: None,
-                });
+    /// Tracks the timestamp when the currently-in-flight discovery started.
+    /// `None` means no discovery is running. This is accessed together with
+    /// `DEFAULT_DOMAINS_CACHE`'s mutex, so there's no race between checking
+    /// the flag and reading/writing the cache.
+    ///
+    /// Exposed as `pub(crate)` for test access.
+    pub(crate) static ref DISCOVERY_CLAIM_START: Mutex<Option<Instant>> = Mutex::new(None);
+
+    /// Signalled unconditionally whenever any `DiscoveryGuard` is dropped
+    /// -- whether or not that guard actually still owned the claim it
+    /// clears (see the `Drop` impl for why a guard whose claim was stolen
+    /// by an abandonment-takeover clears nothing). A parked waiter always
+    /// has to re-check the cache and claim state from scratch after being
+    /// woken regardless of which guard woke it, so a spurious wakeup here
+    /// costs nothing: the alternative (only notifying when a claim was
+    /// actually cleared) would leave a waiter parked on a stolen claim's
+    /// original owner asleep until its own deadline even after the result
+    /// it's waiting for has already been published to the cache by the
+    /// guard that stole it. Paired with `DEFAULT_DOMAINS_CACHE`'s mutex.
+    pub(crate) static ref DISCOVERY_FINISHED: Condvar = Condvar::new();
+}
+
+/// How long `try_default_domains` will wait for an already-in-flight
+/// discovery to finish before giving up and reporting failure. Generous,
+/// because the thing being waited on is a `wsl.exe` that can legitimately
+/// take many seconds on a cold WSL start, and the caller (a background
+/// discovery thread) has nothing better to do meanwhile; bounded, because
+/// a genuinely hung `wsl.exe` must not pin this thread for the life of the
+/// process.
+const DISCOVERY_BUSY_WAIT_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Shells out to `wsl.exe -l -v` and parses its output into `WslDomain`s.
+/// Always live; no caching here. Split out from `WslDomain::default_domains`/
+/// `WslDomain::compute_default_domains` so both can share it while
+/// differing only in whether they consult `DEFAULT_DOMAINS_CACHE`.
+#[cfg(windows)]
+fn discover_wsl_domains() -> anyhow::Result<Vec<WslDomain>> {
+    Ok(WslDistro::load_distro_list()?
+        .into_iter()
+        .map(|distro| WslDomain {
+            name: format!("WSL:{}", distro.name),
+            distribution: Some(distro.name.clone()),
+            username: None,
+            default_cwd: Some("~".into()),
+            default_prog: None,
+        })
+        .collect())
+}
+#[cfg(not(windows))]
+fn discover_wsl_domains() -> anyhow::Result<Vec<WslDomain>> {
+    Ok(vec![])
+}
+
+/// RAII guard that clears the `DISCOVERY_CLAIM_START` timestamp on drop.
+/// Carries the `Instant` it claimed so `Drop` can tell whether the claim it
+/// would clear is still *its own* claim (see the `Drop` impl below for why
+/// that matters). Exposed as `pub(crate)` for test access.
+pub(crate) struct DiscoveryGuard(Instant);
+
+impl DiscoveryGuard {
+    fn new() -> Option<Self> {
+        // Try to claim the discovery flag. Returns None if another
+        // discovery is already in flight.
+        //
+        // Claimed and released under `DEFAULT_DOMAINS_CACHE`'s lock so
+        // that a caller which loses the race can inspect the flag and
+        // park on `DISCOVERY_FINISHED` atomically, without the winner
+        // finishing and signalling in the gap between those two steps.
+        let _cache = DEFAULT_DOMAINS_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut claim_start = DISCOVERY_CLAIM_START
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if claim_start.is_some() {
+            None
+        } else {
+            let start = Instant::now();
+            *claim_start = Some(start);
+            Some(DiscoveryGuard(start))
+        }
+    }
+}
+
+impl Drop for DiscoveryGuard {
+    fn drop(&mut self) {
+        // Compare-and-clear, not unconditional-clear: only clear
+        // `DISCOVERY_CLAIM_START` if it still holds *this* guard's own
+        // claim.
+        //
+        // Without this check, a guard whose `wsl.exe` call has been running
+        // long enough that a waiter in `try_default_domains_with` declared
+        // it abandoned and stole the claim for itself would, once its own
+        // (still-running) `wsl.exe` finally returns, unconditionally set
+        // `DISCOVERY_CLAIM_START` back to `None` -- clobbering the new
+        // claim the waiter installed, which by then is live and backing an
+        // actual in-progress `wsl.exe` invocation of its own. A third
+        // caller would then see no claim held and start a third concurrent
+        // `wsl.exe`, violating the "at most one concurrent enumeration"
+        // invariant this whole mechanism exists to guarantee. Comparing
+        // against the exact `Instant` this guard stored when it claimed
+        // (rather than merely checking `is_some()`) ensures this guard only
+        // ever clears a claim it actually owns; a stale guard whose claim
+        // was already stolen simply leaves the current claim alone, since
+        // whoever holds it now is responsible for their own cleanup.
+        {
+            let _cache = DEFAULT_DOMAINS_CACHE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let mut claim_start = DISCOVERY_CLAIM_START
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if *claim_start == Some(self.0) {
+                *claim_start = None;
             }
         }
+        // Notified unconditionally, regardless of whether this guard's
+        // claim was still current above -- see `DISCOVERY_FINISHED`'s own
+        // doc comment for why a spurious wakeup here is harmless while
+        // suppressing it is not: a stolen claim's original owner (this
+        // guard) may still be the one that ends up publishing the result
+        // a parked waiter needs (eg. it "won" the race to actually finish
+        // `discover()` first, even though it lost the claim), and that
+        // waiter must not be left asleep until its own deadline just
+        // because the guard that published the result wasn't the one
+        // holding the claim it's watching.
+        DISCOVERY_FINISHED.notify_all();
+    }
+}
 
-        domains
+impl WslDomain {
+    /// Returns the currently-cached auto-discovered WSL domain list, if any
+    /// discovery has completed and populated the cache yet. Never shells out to
+    /// `wsl.exe` -- returns `None` on a cache miss instead of blocking. Callers
+    /// on a latency-sensitive path (like resolving an already-registered
+    /// domain's live settings during pane spawn) should use this instead of
+    /// `default_domains()`, and treat `None` as "not discovered yet" rather than
+    /// triggering discovery themselves.
+    pub fn cached_default_domains() -> Option<Vec<WslDomain>> {
+        let cache = DEFAULT_DOMAINS_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        cache.clone()
+    }
+
+    /// Computes the current list of installed WSL distros by shelling
+    /// out to `wsl.exe -l -v` every time this is called -- no caching.
+    /// This is what the public `wezterm.default_wsl_domains()` Lua API
+    /// calls, per its documented contract of reflecting what's currently
+    /// installed. On error, logs a warning and returns an empty list.
+    pub fn compute_default_domains() -> Vec<WslDomain> {
+        discover_wsl_domains().unwrap_or_else(|err| {
+            log::warn!("failed to enumerate WSL distros: {:#}", err);
+            vec![]
+        })
+    }
+
+    /// Like `default_domains()`, but preserves a discovery failure as an
+    /// `Err` instead of silently converting it to an empty, successfully-cached
+    /// list. Still caches only on `Ok`; still runs with the cache lock
+    /// released across the actual `wsl.exe` call, same as `default_domains()`.
+    /// Also guarded by `DISCOVERY_CLAIM_START` to prevent concurrent enumerations.
+    ///
+    /// If another discovery is already in flight, this *waits* for it (up
+    /// to `DISCOVERY_BUSY_WAIT_TIMEOUT`) and returns its result, rather
+    /// than reporting failure immediately. Reporting failure would be
+    /// wrong in a way that loses domains outright: the caller treats a
+    /// failed run as terminal and resets to "not started", while the run
+    /// actually in flight is typically one that's already been superseded
+    /// (a config reload away and back cancels it), so nothing would ever
+    /// publish the list it eventually produces -- leaving a populated
+    /// cache and no registered domains until some later reload happened
+    /// to come along.
+    fn try_default_domains_with(
+        discover: impl FnOnce() -> anyhow::Result<Vec<WslDomain>>,
+    ) -> anyhow::Result<Vec<WslDomain>> {
+        let deadline = Instant::now() + DISCOVERY_BUSY_WAIT_TIMEOUT;
+
+        let _guard = loop {
+            // Hold the cache lock continuously from this check through the
+            // `wait_timeout` call below: `DiscoveryGuard::new`/`Drop` both
+            // take this same lock first (nested: cache outer, claim inner),
+            // so as long as we never release it in between, a discovery
+            // that's finishing up (populating the cache and/or clearing its
+            // claim, then notifying) cannot complete "in the gap" between
+            // our decision to wait and the point where we actually start
+            // waiting -- it simply blocks on this same lock until we've
+            // called `wait_timeout`, which is the only thing that releases
+            // it while parked. Releasing this lock between the claim check
+            // and the wait (as an earlier version of this function did)
+            // reopens exactly that gap: a discovery could finish, clear its
+            // claim under this lock, and `notify_all()` before we ever
+            // start waiting on the condvar, and a `notify_all()` that runs
+            // before `wait_timeout` is called is not queued -- it's simply
+            // missed, and we'd block for the full remaining deadline
+            // instead of noticing immediately.
+            let cache = DEFAULT_DOMAINS_CACHE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            if let Some(domains) = &*cache {
+                return Ok(domains.clone());
+            }
+
+            // Check the claim state while still holding the cache lock.
+            // Keeps the claimed-at `Instant` (not just a bool) so the
+            // `wait_timeout` call below can clamp its sleep to when this
+            // specific claim would go stale, rather than only to this
+            // waiter's own overall deadline; see the comment there.
+            let (is_claimed, is_abandoned, claimed_at) = {
+                let claim_start = DISCOVERY_CLAIM_START
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                match *claim_start {
+                    None => (false, false, None),
+                    Some(start) => (
+                        true,
+                        Instant::now().duration_since(start) >= DISCOVERY_BUSY_WAIT_TIMEOUT,
+                        Some(start),
+                    ),
+                }
+            };
+
+            if !is_claimed || is_abandoned {
+                // Nothing running, or the in-flight discovery is abandoned.
+                if is_abandoned {
+                    log::warn!(
+                        "a previous WSL domain discovery has been running for over {:?} without \
+                         finishing; treating it as stuck and starting a new attempt",
+                        DISCOVERY_BUSY_WAIT_TIMEOUT
+                    );
+                    // Still holding the cache lock here, so this can't race
+                    // a concurrent `DiscoveryGuard::new`/`Drop` (both take
+                    // the cache lock first too).
+                    let mut claim_start = DISCOVERY_CLAIM_START
+                        .lock()
+                        .unwrap_or_else(|poisoned| poisoned.into_inner());
+                    *claim_start = None;
+                }
+                // `DiscoveryGuard::new` takes this same cache lock, so it
+                // has to be released first; losing a race to claim it here
+                // just sends us around the loop again.
+                drop(cache);
+                if let Some(guard) = DiscoveryGuard::new() {
+                    break guard;
+                }
+                continue;
+            }
+
+            // The in-flight discovery is still within the timeout. Wait for
+            // it. `wait_timeout` atomically releases `cache` and parks, so
+            // there's no window between our checks above and actually
+            // waiting where a finishing discovery's notify could be missed.
+            let now = Instant::now();
+            if now >= deadline {
+                anyhow::bail!(
+                    "timed out after {:?} waiting for an already-in-flight WSL \
+                     discovery to finish",
+                    DISCOVERY_BUSY_WAIT_TIMEOUT
+                );
+            }
+            // Clamp the sleep to the sooner of (a) this waiter's own
+            // overall deadline, and (b) when the claim we're currently
+            // watching would itself be considered abandoned. Without (b),
+            // a waiter that parks here sleeps until its own deadline or
+            // `DISCOVERY_FINISHED` fires -- neither of which necessarily
+            // happens promptly if the claim we're watching started well
+            // before we arrived: it could go stale seconds (or, in the
+            // pathological case, tens of seconds) before our own deadline
+            // does, and we'd have no chance to notice and steal it until
+            // some other, unrelated wakeup. Waking up right as `claimed_at`
+            // crosses the abandonment threshold lets the loop immediately
+            // re-check `is_abandoned` and steal the claim if it's still
+            // stuck, instead of sleeping longer than necessary. This is
+            // purely about waking up earlier when useful -- it never
+            // extends `deadline - now`, only shortens the sleep.
+            let wait_for = match claimed_at {
+                Some(start) => {
+                    let abandoned_at = start + DISCOVERY_BUSY_WAIT_TIMEOUT;
+                    (deadline - now).min(abandoned_at.saturating_duration_since(now))
+                }
+                None => deadline - now,
+            };
+            let (_cache, _timeout) = DISCOVERY_FINISHED
+                .wait_timeout(cache, wait_for)
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+        };
+
+        // Deliberately runs with the cache lock released: `wsl.exe` can
+        // take many seconds (or hang outright), and nothing else that
+        // touches `DEFAULT_DOMAINS_CACHE` should have to wait behind
+        // that. Note the error is *not* propagated with `?` here: it has
+        // to be held until after the cache has been re-checked below.
+        let result = discover();
+
+        // Note this drops before `_guard` does (reverse declaration
+        // order), which matters because `DiscoveryGuard::drop` takes this
+        // same lock.
+        let mut cache = DEFAULT_DOMAINS_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        // Whatever is already in the cache wins, and our own result is
+        // discarded -- *including* when ours succeeded and theirs is
+        // arguably staler, and including when ours failed outright.
+        //
+        // The cache can only be non-empty here if a concurrent run
+        // published while `discover()` was running, which in turn can only
+        // happen via the abandonment-takeover path above (a run whose
+        // claim we stole, or which stole ours, finishing in the meantime).
+        // Returning our own list in that case silently breaks the
+        // invariant that the mux domain registry and this cache describe
+        // the same set of WSL distros: `Mux` would register the domains
+        // *we* returned, while `LocalDomain::resolve_wsl_domain` looks up
+        // each domain's live settings in this *cache*. A domain present
+        // only in our list would then resolve to `None`, and
+        // `fixup_command` would take its "not a WSL domain at all" branch
+        // and run the command directly on the Windows host instead of
+        // inside WSL -- silently wrong, not merely slow, which is exactly
+        // the failure mode `resolve_wsl_domain`'s own doc comment calls
+        // out as the thing to never allow.
+        //
+        // Preferring the published value over a fresher local one is the
+        // right trade: the cache is process-lifetime, so the published
+        // value is what every later spawn resolves against no matter what
+        // we do here. Adopting it makes the registry agree with it. Being
+        // slightly stale merely means a distro is missing (which every
+        // consumer already handles); disagreeing means running commands
+        // on the wrong machine.
+        //
+        // Adopting it on our *error* path matters for the same reason,
+        // and additionally avoids throwing away a perfectly good answer:
+        // the caller treats an `Err` as a failed run and resets to "not
+        // started" without registering anything, even though a usable
+        // list is sitting right here.
+        if let Some(published) = &*cache {
+            return Ok(published.clone());
+        }
+
+        let domains = result?;
+        *cache = Some(domains.clone());
+        Ok(domains)
+    }
+
+    pub fn try_default_domains() -> anyhow::Result<Vec<WslDomain>> {
+        Self::try_default_domains_with(discover_wsl_domains)
+    }
+
+    /// Like `compute_default_domains`, but memoized for the lifetime of
+    /// the process after the first successful call. Discovery shells out
+    /// to `wsl.exe -l -v`, which can take many seconds (starting the
+    /// LxssManager service and/or booting the WSL2 utility VM) the first
+    /// time it runs; this used to be re-run on every call, including
+    /// once per pane spawn via `LocalDomain::resolve_wsl_domain`, so a
+    /// config that leaves `wsl_domains` unset paid that cost repeatedly
+    /// instead of just once. `resolve_wsl_domain` has since moved to the
+    /// non-blocking `config.wsl_domains_cached()` and no longer calls this
+    /// (or anything that shells out) on that path -- see its own doc
+    /// comment. The remaining internal consumer is the background
+    /// domain-discovery thread: the WSL-specific `discover` closure built
+    /// in `wezterm-mux-server-impl`'s `update_mux_domains_impl` calls
+    /// `try_default_domains()` (this function's fallible sibling, sharing
+    /// the same memoized cache) from inside the closure passed to
+    /// `Mux::begin_domain_discovery`/`begin_domain_discovery_with_default_filter`,
+    /// so that cost is paid at most once per process even though the
+    /// closure can in principle run again on a later config reload -- see
+    /// `compute_default_domains` for the always-live public API.
+    ///
+    /// Distros added/removed after the first successful call won't be
+    /// picked up here until the process restarts; that's the accepted
+    /// trade-off for not paying the discovery cost repeatedly. A
+    /// *failed* discovery is deliberately not cached, so the next call
+    /// gets another chance instead of being stuck with an empty list for
+    /// the rest of the process's life.
+    pub fn default_domains() -> Vec<WslDomain> {
+        Self::try_default_domains().unwrap_or_else(|err| {
+            log::warn!(
+                "failed to enumerate WSL distros, will retry next time: {:#}",
+                err
+            );
+            vec![]
+        })
     }
 }
 
@@ -208,4 +590,571 @@ fn test_parse_wsl_distro_list() {
             },
         ]
     );
+}
+
+#[cfg(test)]
+mod try_default_domains_tests {
+    use crate::wsl::{
+        DiscoveryGuard, DEFAULT_DOMAINS_CACHE, DISCOVERY_BUSY_WAIT_TIMEOUT, DISCOVERY_CLAIM_START,
+        DISCOVERY_FINISHED,
+    };
+    use crate::WslDomain;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    /// Every test in this module reads and writes the process-global
+    /// `DEFAULT_DOMAINS_CACHE`/`DISCOVERY_CLAIM_START` statics directly, so
+    /// they can't run concurrently with each other without racing (one
+    /// test's "set the flag" step landing between another test's own
+    /// check-and-clear steps). `cargo test`'s default parallel test runner
+    /// would otherwise make this module flaky/reliably-failing depending
+    /// on scheduling -- verified: every one of these tests failed
+    /// intermittently under the default (parallel) test runner before this
+    /// mutex was added. Each test acquires this for its entire body,
+    /// serializing them against each other while leaving every other test
+    /// in the crate free to run in parallel as normal.
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// Sets the process-global cache, returning the previous value.
+    fn set_cache(value: Option<Vec<WslDomain>>) -> Option<Vec<WslDomain>> {
+        let mut cache = DEFAULT_DOMAINS_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        std::mem::replace(&mut *cache, value)
+    }
+
+    fn read_cache() -> Option<Vec<WslDomain>> {
+        DEFAULT_DOMAINS_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    fn clear_claim_start() {
+        let mut claim_start = DISCOVERY_CLAIM_START
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *claim_start = None;
+    }
+
+    fn is_claimed() -> bool {
+        let claim_start = DISCOVERY_CLAIM_START
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        claim_start.is_some()
+    }
+
+    fn domain_named(name: &str) -> WslDomain {
+        WslDomain {
+            name: name.to_string(),
+            distribution: Some(name.to_string()),
+            username: None,
+            default_cwd: None,
+            default_prog: None,
+        }
+    }
+
+    /// `cached_default_domains()` must never block or shell out: on a cache
+    /// miss it reports the miss rather than triggering discovery.
+    ///
+    /// Lives in this module (rather than one of its own) precisely so it
+    /// can clear the shared cache under `TEST_MUTEX` and actually assert
+    /// `None`, instead of merely asserting that the call was fast -- which
+    /// a cache *hit* would satisfy just as well, making the assertion
+    /// vacuous.
+    #[test]
+    fn cached_default_domains_returns_none_when_cache_empty() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+
+        let start = Instant::now();
+        let result = WslDomain::cached_default_domains();
+        let elapsed = start.elapsed();
+
+        assert!(
+            result.is_none(),
+            "a cache miss must read as None, not trigger discovery"
+        );
+        assert!(
+            elapsed < Duration::from_millis(100),
+            "cached_default_domains() must not block (took {:?})",
+            elapsed
+        );
+    }
+
+    /// The other half of the contract: once populated, the cached list is
+    /// what comes back, still without shelling out.
+    #[test]
+    fn cached_default_domains_returns_the_cached_list_once_populated() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let expected = vec![domain_named("WSL:Cached")];
+        set_cache(Some(expected.clone()));
+
+        assert_eq!(WslDomain::cached_default_domains(), Some(expected));
+
+        set_cache(None);
+    }
+
+    /// A caller that finds a discovery already in flight must wait for it
+    /// and adopt its result, rather than reporting failure.
+    ///
+    /// Reporting failure is what the previous implementation did, and it
+    /// lost domains outright: the mux treats a failed run as terminal
+    /// (resetting to "not started"), while the run actually in flight is
+    /// typically one that has already been superseded by a config reload,
+    /// so nothing would ever publish the list it eventually produced.
+    #[test]
+    fn try_default_domains_waits_for_an_in_flight_discovery_and_adopts_its_result() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        let expected = vec![domain_named("WSL:Discovered-by-the-other-run")];
+
+        // Stand in for the in-flight discovery: hold a real guard (so the
+        // waiter observes the flag exactly the way it would in
+        // production), publish a result, then release.
+        let (claimed_tx, claimed_rx) = std::sync::mpsc::channel::<()>();
+        let expected_for_thread = expected.clone();
+        let in_flight = thread::spawn(move || {
+            let guard = DiscoveryGuard::new().expect("flag must be free at the start of this test");
+            claimed_tx.send(()).expect("main thread is still waiting");
+            // Long enough that the waiter is parked on the condvar rather
+            // than racing past it, but not part of the assertion: the test
+            // asserts on the *result*, not on timing.
+            thread::sleep(Duration::from_millis(150));
+            set_cache(Some(expected_for_thread));
+            drop(guard);
+        });
+
+        claimed_rx
+            .recv()
+            .expect("the in-flight thread must claim the flag");
+
+        // Must block until the in-flight run publishes, then return its
+        // list. Note this also proves no second discovery ran: a second
+        // one would have overwritten nothing (the cache is write-once) but
+        // would have had to return its own, different, list.
+        let result = WslDomain::try_default_domains().expect("waiting must not report failure");
+        assert_eq!(result, expected);
+
+        in_flight.join().expect("in-flight thread must not panic");
+        assert!(
+            !is_claimed(),
+            "the flag must be clear once the in-flight run released it"
+        );
+
+        set_cache(None);
+    }
+
+    /// If the in-flight run finishes *without* publishing anything (ie. it
+    /// failed), the waiter must pick the work up itself rather than
+    /// returning an empty answer, or a transient failure in one run would
+    /// silently become "there are no WSL domains" for the next one.
+    #[test]
+    fn try_default_domains_runs_discovery_itself_if_the_in_flight_one_published_nothing() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        let (claimed_tx, claimed_rx) = std::sync::mpsc::channel::<()>();
+        let in_flight = thread::spawn(move || {
+            let guard = DiscoveryGuard::new().expect("flag must be free at the start of this test");
+            claimed_tx.send(()).expect("main thread is still waiting");
+            thread::sleep(Duration::from_millis(100));
+            // Releases without ever populating the cache: a failed run.
+            drop(guard);
+        });
+
+        claimed_rx
+            .recv()
+            .expect("the in-flight thread must claim the flag");
+
+        // Waits for the failed run, finds no published result, and so
+        // claims the flag and discovers for itself. Uses a stub closure
+        // to avoid shelling out to the real wsl.exe on Windows CI.
+        let expected = vec![domain_named("WSL:Stub")];
+        let result = WslDomain::try_default_domains_with(|| Ok(expected.clone()))
+            .expect("a failed in-flight run must not make this one fail too");
+
+        in_flight.join().expect("in-flight thread must not panic");
+
+        assert_eq!(result, expected, "must run discovery itself with the stub");
+        assert_eq!(read_cache().as_ref(), Some(&result));
+        assert!(!is_claimed());
+
+        set_cache(None);
+    }
+
+    /// Regression test: when a concurrent run publishes to the cache while
+    /// our own `discover()` is still running, we must adopt the published
+    /// list rather than returning our own divergent one. `Mux` registers
+    /// whatever this returns, but `LocalDomain::resolve_wsl_domain` looks
+    /// domains up in the *cache* -- so returning a list the cache doesn't
+    /// contain leaves a registered domain that resolves to `None`, and
+    /// `fixup_command` then runs its command on the Windows host instead
+    /// of inside WSL.
+    ///
+    /// Only reachable via the abandonment-takeover path (which the
+    /// mux-level 90s stuck-supersede made live), so the ordering is forced
+    /// explicitly here rather than waiting on a real timeout: our stub
+    /// `discover` blocks until the "other" run has published, guaranteeing
+    /// the cache is already populated by the time we reach the publish
+    /// step.
+    #[test]
+    fn a_concurrently_published_cache_wins_over_our_own_result() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        let published = vec![domain_named("WSL:Published-by-the-other-run")];
+        let ours = vec![domain_named("WSL:Ours")];
+
+        // Our `discover` publishes the *other* run's result partway
+        // through, standing in for a stolen-from run finishing while ours
+        // is still shelling out.
+        let published_for_stub = published.clone();
+        let ours_for_stub = ours.clone();
+        let result = WslDomain::try_default_domains_with(move || {
+            set_cache(Some(published_for_stub));
+            Ok(ours_for_stub)
+        })
+        .expect("must succeed by adopting the published list");
+
+        assert_eq!(
+            result, published,
+            "must return the list already published to the cache, not our own"
+        );
+        assert_eq!(
+            read_cache().as_ref(),
+            Some(&published),
+            "must not overwrite the already-published cache"
+        );
+        assert_ne!(result, ours, "our own divergent list must not win");
+
+        // Same requirement on the error path: a published list is a usable
+        // answer, so our own failure must not be reported as one (which
+        // would make the caller reset to "not started" and register
+        // nothing, despite a good list being right there).
+        set_cache(None);
+        clear_claim_start();
+        let published_for_err = published.clone();
+        let result = WslDomain::try_default_domains_with(move || {
+            set_cache(Some(published_for_err));
+            anyhow::bail!("simulated wsl.exe failure")
+        })
+        .expect("a published list must be adopted even when our own run failed");
+        assert_eq!(result, published);
+
+        set_cache(None);
+    }
+
+    /// A successful result is cached; a subsequent call is served from the
+    /// cache rather than shelling out again.
+    #[test]
+    fn try_default_domains_caches_a_successful_result() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        let expected = vec![domain_named("WSL:Stub")];
+        let runs = Arc::new(AtomicUsize::new(0));
+
+        let runs_first = Arc::clone(&runs);
+        let expected_first = expected.clone();
+        let first = WslDomain::try_default_domains_with(move || {
+            runs_first.fetch_add(1, Ordering::SeqCst);
+            Ok(expected_first)
+        })
+        .expect("discovery must succeed");
+        assert_eq!(
+            read_cache().as_ref(),
+            Some(&first),
+            "a successful result must be cached"
+        );
+        assert_eq!(first, expected, "must return the stub value");
+        assert_eq!(
+            runs.load(Ordering::SeqCst),
+            1,
+            "the first call must discover"
+        );
+
+        // The second closure counts its own invocations rather than just
+        // returning the same value again: without a negative control here,
+        // deleting the cache fast path entirely would still leave this
+        // test green, since both closures would produce identical output.
+        let runs_second = Arc::clone(&runs);
+        let second = WslDomain::try_default_domains_with(move || {
+            runs_second.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![domain_named("WSL:Should-never-be-reached")])
+        })
+        .expect("the cached call must succeed");
+        assert_eq!(first, second);
+        assert_eq!(
+            runs.load(Ordering::SeqCst),
+            1,
+            "the second call must be served from the cache without invoking discovery again"
+        );
+
+        set_cache(None);
+    }
+
+    /// Verify that the `DISCOVERY_CLAIM_START` flag is correctly
+    /// cleared after a successful discovery, so later calls can proceed.
+    ///
+    /// Also regression-tests that a *successful* discovery finding zero
+    /// distributions caches `Some(vec![])`, not `None`: the two are not
+    /// interchangeable to `resolve_wsl_domain`, which reads `None` as
+    /// "discovery hasn't finished yet" (fall back to the domain's
+    /// construction-time snapshot) and `Some(vec![])` as "discovery
+    /// finished and there is nothing" (a real "no longer a WSL domain").
+    /// Caching `None` here -- eg. a future "don't bother caching an empty
+    /// result" change -- would leave every WSL domain permanently on the
+    /// fallback path instead of correctly resolving to `None` once removed
+    /// from the config.
+    #[test]
+    fn discovery_flag_cleared_after_success() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        let result = WslDomain::try_default_domains_with(|| Ok(vec![]));
+        assert!(result.is_ok());
+
+        // Verify flag is cleared after success.
+        assert!(!is_claimed());
+        assert_eq!(
+            read_cache(),
+            Some(vec![]),
+            "a successful discovery that found zero distributions must cache Some(vec![]), \
+             not leave the cache empty"
+        );
+
+        set_cache(None);
+    }
+
+    /// Regression test: verify that a discovery failure is propagated
+    /// correctly and does not populate the cache or leave the flag set.
+    #[test]
+    fn try_default_domains_with_propagates_a_real_discovery_failure() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        let result =
+            WslDomain::try_default_domains_with(|| anyhow::bail!("simulated wsl.exe failure"));
+
+        assert!(result.is_err());
+        assert!(
+            read_cache().is_none(),
+            "a failed discovery must not populate the cache"
+        );
+        assert!(!is_claimed(), "the flag must be cleared after a failure");
+
+        set_cache(None);
+    }
+
+    /// Verify that the RAII guard correctly clears the flag
+    /// even if the guard is dropped explicitly (simulating a panic recovery
+    /// scenario where the guard's Drop is called).
+    #[test]
+    fn discovery_guard_clears_flag_on_drop() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        // Create a guard manually (this is what happens inside try_default_domains).
+        let guard = DiscoveryGuard::new();
+        assert!(guard.is_some());
+        assert!(is_claimed());
+
+        // A second claim while the first is live must fail: that's the
+        // whole point of the flag.
+        assert!(
+            DiscoveryGuard::new().is_none(),
+            "only one discovery may hold the flag at a time"
+        );
+
+        // Drop the guard explicitly.
+        drop(guard);
+
+        // Verify flag is cleared after drop.
+        assert!(!is_claimed());
+    }
+
+    /// Regression test: dropping a
+    /// `DiscoveryGuard` whose claim was already stolen by an
+    /// abandonment-takeover (its compare-and-clear is a no-op) must still
+    /// notify `DISCOVERY_FINISHED` unconditionally. An earlier version of
+    /// the fix for "DiscoveryGuard has no owner" made the notify
+    /// conditional on the clear actually happening, which meant a waiter
+    /// parked behind the *new* owner's claim could sleep for its full
+    /// timeout even after the stolen-from guard published a result to the
+    /// cache on its way out.
+    #[test]
+    fn dropping_a_superseded_guard_still_notifies_finished() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        // Run A claims first.
+        let guard_a = DiscoveryGuard::new().expect("flag must be free at the start of this test");
+
+        // Run B steals A's claim, standing in for the abandonment-takeover
+        // path in `try_default_domains_with` (which does exactly these
+        // two steps once it observes A's claim as stale). B is left
+        // "still running" for the rest of this test (its guard is simply
+        // never dropped).
+        clear_claim_start();
+        let guard_b = DiscoveryGuard::new().expect("flag must be free once cleared");
+
+        // A waiter parks on `DISCOVERY_FINISHED`, holding the cache lock
+        // exactly like `try_default_domains_with`'s wait loop does.
+        let timed_out = Arc::new(AtomicBool::new(false));
+        let timed_out2 = Arc::clone(&timed_out);
+        let (parked_tx, parked_rx) = std::sync::mpsc::channel::<()>();
+        let waiter = thread::spawn(move || {
+            let cache = DEFAULT_DOMAINS_CACHE
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            parked_tx.send(()).expect("main thread is still waiting");
+            let (_cache, timeout) = DISCOVERY_FINISHED
+                .wait_timeout(cache, Duration::from_secs(5))
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            timed_out2.store(timeout.timed_out(), Ordering::SeqCst);
+        });
+
+        // "Signalled right before calling `wait_timeout`" is not quite the
+        // same as "actually parked on the condvar" -- there's a small gap
+        // between the channel send returning and `wait_timeout` itself
+        // starting to block, with no lock or syscall in between to hang a
+        // more precise handoff on. Give it a moment; this is the same
+        // technique, and the same caveat, as
+        // `mux::domain_discovery_tests::cancel_domain_discovery_defers_sync_wakeup_until_notify_is_called`
+        // -- it only affects how long the handshake takes, never whether
+        // the assertion below is valid once it completes.
+        parked_rx
+            .recv()
+            .expect("waiter thread must have started parking");
+        thread::sleep(Duration::from_millis(50));
+
+        // A's stale guard (its claim was already stolen by B, which is
+        // still "running") drops now, simulating A's long-hung `wsl.exe`
+        // finally returning. This must notify `DISCOVERY_FINISHED` even
+        // though A's own compare-and-clear is a no-op -- otherwise the
+        // waiter sleeps for its full timeout instead of waking promptly.
+        drop(guard_a);
+
+        waiter.join().expect("waiter thread must not panic");
+        assert!(
+            !timed_out.load(Ordering::SeqCst),
+            "dropping a guard whose claim was already stolen must still notify \
+             DISCOVERY_FINISHED, not silently do nothing"
+        );
+
+        drop(guard_b);
+        set_cache(None);
+    }
+
+    /// `default_domains()` is the infallible wrapper, and it inherits the
+    /// waiting behaviour: it also adopts an in-flight run's result rather
+    /// than reporting the emptiness that its error path would produce.
+    #[test]
+    fn default_domains_adopts_an_in_flight_discoverys_result() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        let expected = vec![domain_named("WSL:From-the-other-run")];
+
+        let (claimed_tx, claimed_rx) = std::sync::mpsc::channel::<()>();
+        let expected_for_thread = expected.clone();
+        let in_flight = thread::spawn(move || {
+            let guard = DiscoveryGuard::new().expect("flag must be free at the start of this test");
+            claimed_tx.send(()).expect("main thread is still waiting");
+            thread::sleep(Duration::from_millis(150));
+            set_cache(Some(expected_for_thread));
+            drop(guard);
+        });
+
+        claimed_rx
+            .recv()
+            .expect("the in-flight thread must claim the flag");
+
+        assert_eq!(WslDomain::default_domains(), expected);
+
+        in_flight.join().expect("in-flight thread must not panic");
+        set_cache(None);
+    }
+
+    /// Regression test: verify that an abandoned discovery (one that's
+    /// been running longer than the timeout) is treated as stuck and a new
+    /// discovery is started instead of waiting indefinitely.
+    #[test]
+    fn abandoned_discovery_triggers_new_attempt() {
+        let _guard = TEST_MUTEX
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        set_cache(None);
+        clear_claim_start();
+
+        // Manually set the claim timestamp to a time that's older than the timeout.
+        // This simulates a hung discovery without actually waiting 60 seconds.
+        let mut claim_start = DISCOVERY_CLAIM_START
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *claim_start = Some(
+            // checked_sub avoids a panic on underflow on a host whose
+            // monotonic clock hasn't reached DISCOVERY_BUSY_WAIT_TIMEOUT +
+            // 1s of uptime yet (very early boot, some CI/container clock
+            // sources). Falling back to Instant::now() means the claim
+            // won't actually read as abandoned in that edge case, which is
+            // an acceptable trade-off for a test that cannot meaningfully
+            // run on a host with under a minute of uptime anyway -- the
+            // point is just that this must not panic.
+            Instant::now()
+                .checked_sub(DISCOVERY_BUSY_WAIT_TIMEOUT + Duration::from_secs(1))
+                .unwrap_or_else(Instant::now),
+        );
+        drop(claim_start);
+
+        // Verify that the flag is set.
+        assert!(is_claimed());
+
+        // This should trigger the abandonment path and start a new discovery,
+        // returning successfully without waiting for the stuck one.
+        let expected = vec![domain_named("WSL:Abandoned")];
+        let result = WslDomain::try_default_domains_with(|| Ok(expected.clone()))
+            .expect("abandoned discovery must not block");
+
+        assert_eq!(result, expected, "must run discovery with the stub");
+        assert_eq!(read_cache().as_ref(), Some(&result));
+        assert!(!is_claimed(), "the old claim must be cleared");
+
+        set_cache(None);
+    }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,12 @@ usually the best available version.
 As features stabilize some brief notes about them will accumulate here.
 
 #### Changed
+* WSL domains are now more strictly identified: a `wsl_domains` entry whose
+  `name` happens to match a domain that was NOT itself created as a WSL domain
+  (for example, the built-in `local` domain) no longer causes that domain to be
+  treated as a WSL domain. Only domains actually registered via WSL discovery
+  or an explicit `wsl_domains` entry that creates a new domain get WSL treatment
+  now. #7782
 * DECRQCRA is now disabled by default to prevent silent screen scraping.
   Set `enable_checksum_rectangular_area = true` to re-enable it.
   Thanks to @jquast! #7701
@@ -152,6 +158,17 @@ As features stabilize some brief notes about them will accumulate here.
   search matching. Thanks to @mrdziuban! #7385
 
 #### Fixed
+* Windows: startup (and, separately, the first pane spawn) could take 15-50+
+  seconds when `wsl_domains` wasn't explicitly configured, because discovering
+  the default list of WSL domains shelled out to `wsl.exe -l -v` synchronously
+  on the startup path, and again on every pane spawn. WSL domain discovery now
+  runs on a background thread instead of blocking startup, and its result is
+  cached for the life of the process. One consequence: a long-lived process
+  (in particular `wezterm-mux-server`) won't notice a WSL distro installed or
+  removed after it started until it's restarted; see
+  [wsl_domains](config/lua/config/wsl_domains.md) and
+  [wezterm.default_wsl_domains()](config/lua/wezterm/default_wsl_domains.md)
+  for the details and the workaround. #7782
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program
   that left it enabled and exited uncleanly could leave ctrl keys emitting
   escape sequences that the shell doesn't expect. RIS now also resets the

--- a/docs/config/lua/config/wsl_domains.md
+++ b/docs/config/lua/config/wsl_domains.md
@@ -14,3 +14,30 @@ This option accepts a list of [WslDomain](../WslDomain.md) objects.
 The default is a list derived from parsing the output of `wsl -l -v`.  See
 [wezterm.default_wsl_domains()](../wezterm/default_wsl_domains.md) for more
 about that list, and on how to override it.
+
+!!! note
+    When left unconfigured, that default list is discovered in the
+    background rather than blocking startup on `wsl -l -v`, so it (and the
+    corresponding domains) may not be immediately available in the first
+    moment or two after wezterm starts. A `default_domain`,
+    `default_mux_server_domain` or `--domain` naming one of them waits for
+    discovery to finish rather than failing, however long that takes --
+    in the instance that is starting up. `wezterm start --domain` handed
+    off to an *already running* instance is an ordinary by-name spawn
+    over there, and so gets the brief wait described next; if that
+    instance is itself only a few seconds old and hasn't finished
+    discovering yet, the hand-off is declined and you get a new window
+    from a new process instead of a tab in the existing one.
+    Spawning into one by name from anywhere else -- a key assignment, or
+    `wezterm.mux.spawn_window{domain=...}` -- also waits, but only briefly,
+    and reports the name as invalid if discovery hasn't found it by then;
+    if you need a specific WSL domain guaranteed available that early, set
+    `wsl_domains` explicitly rather than relying on auto-discovery. The
+    discovered list is also cached for the lifetime of the process: WSL
+    distributions installed or removed after that first discovery won't be
+    picked up until wezterm is restarted. If you want newly installed
+    distributions to be picked up on a config reload instead, set
+    `wsl_domains = wezterm.default_wsl_domains()`, which enumerates them
+    afresh every time your config is evaluated; see
+    [wezterm.default_wsl_domains()](../wezterm/default_wsl_domains.md) for
+    what that costs, and for why removed distributions still don't go away.

--- a/docs/config/lua/wezterm.mux/all_domains.md
+++ b/docs/config/lua/wezterm.mux/all_domains.md
@@ -4,3 +4,12 @@
 
 Returns an array table holding all of the known
 [MuxDomain](../MuxDomain/index.md) objects.
+
+!!! note
+    This is a snapshot of the domains registered at the moment of the call.
+    On Windows, when [wsl_domains](../config/wsl_domains.md) is left
+    unconfigured, the default WSL domain list is discovered in the
+    background rather than blocking startup, so for the first moment or two
+    after wezterm starts any WSL domain that hasn't been discovered yet is
+    simply absent from this list. If you need a startup event handler to see
+    a specific WSL domain deterministically, set `wsl_domains` explicitly.

--- a/docs/config/lua/wezterm.mux/get_domain.md
+++ b/docs/config/lua/wezterm.mux/get_domain.md
@@ -14,3 +14,14 @@ Resolves `name_or_id` to a domain and returns a
 
 If the name or id don't map to a valid domain, this function will return `nil`.
 
+!!! note
+    This is a snapshot of the domains registered at the moment of the call.
+    On Windows, when [wsl_domains](../config/wsl_domains.md) is left
+    unconfigured, the default WSL domain list is discovered in the
+    background rather than blocking startup, so for the first moment or two
+    after wezterm starts a WSL domain that hasn't been discovered yet will
+    read as `nil` here. Spawning into such a domain by name does wait for
+    discovery, though only briefly, so it is not a reliable substitute; it
+    is only this lookup that doesn't wait at all. If you need a startup
+    event handler to see a specific WSL domain deterministically, set
+    `wsl_domains` explicitly.

--- a/docs/config/lua/wezterm/default_wsl_domains.md
+++ b/docs/config/lua/wezterm/default_wsl_domains.md
@@ -65,3 +65,32 @@ that the default shell if possible, so that you can avoid this additional config
 The `default_cwd` field is now automatically set to `"~"` to make it more
 convenient to launch a WSL instance in the home directory of the configured
 distribution.
+
+!!! note
+    This function always computes a fresh, live list by running `wsl -l -v`,
+    and its result is never cached, so every call pays that cost again --
+    several seconds, and longer on a cold WSL start. If you use the recipe
+    above of calling `wezterm.default_wsl_domains()` directly from your
+    config, that means paying it synchronously every time your config is
+    evaluated, including on every reload. If you don't need a live answer,
+    consider setting `wsl_domains` once with an explicit, hand-written list
+    instead of calling this function from your config.
+
+    This is a different function from the one wezterm itself uses
+    internally to populate the default `wsl_domains` list when it isn't
+    configured explicitly: that internal discovery runs off the startup
+    path in the background and its result is cached for the life of the
+    process, so it doesn't pay this cost on every spawn or every reload the
+    way a config that calls this function directly would. One consequence
+    of that internal caching is that a long-lived process (in particular
+    `wezterm-mux-server`) won't notice a WSL distro installed or removed
+    after it started, even across a config reload, unless it's restarted.
+    If you need that, call `wezterm.default_wsl_domains()` directly from
+    your config (as in the recipe above, or even just `wsl_domains =
+    wezterm.default_wsl_domains()` with no filtering) to get a fresh
+    enumeration on every reload instead. Note that this makes *newly
+    installed* distributions show up, but does not make *removed* ones go
+    away: domains already registered with the multiplexer are never
+    unregistered, so a domain for a since-removed distribution remains
+    listed until the process restarts, and attempting to spawn into it
+    will not do what you want.

--- a/lua-api-crates/mux/src/lib.rs
+++ b/lua-api-crates/mux/src/lib.rs
@@ -121,6 +121,25 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
 
     mux_mod.set(
         "get_domain",
+        // Deliberately a *synchronous* lua function, like all_domains
+        // below. It is reachable from synchronous callbacks
+        // (format-tab-title, format-window-title,
+        // augment-command-palette, mux-is-process-stateful), which
+        // config::lua::emit_sync_callback invokes with a plain
+        // `Function::call`. An mlua async function compiles down to a lua
+        // wrapper that does `coroutine.yield` whenever the underlying
+        // future returns Pending, so waiting for domain discovery in here
+        // would make those callbacks fail outright with "attempt to yield
+        // from outside a coroutine" -- and it would do so precisely
+        // during the post-startup window this whole change introduces.
+        //
+        // So this is a snapshot lookup: while a background discovery is
+        // still in flight, a domain it hasn't registered yet reads as
+        // nil, the same way it does for all_domains. Spawning into a
+        // domain *by name* does wait for discovery, though only up to
+        // mux::DOMAIN_DISCOVERY_TIMEOUT (see Mux::resolve_spawn_tab_domain,
+        // and that constant for why the bound is there and when it can
+        // bite); it's only this accessor that doesn't wait at all.
         lua.create_function(|_, domain: LuaValue| {
             let mux = get_mux()?;
             match domain {
@@ -149,6 +168,18 @@ pub fn register(lua: &Lua) -> anyhow::Result<()> {
     mux_mod.set(
         "all_domains",
         lua.create_function(|_, _: ()| {
+            // This is a snapshot of whatever domains are registered at
+            // the moment of the call. If a background domain discovery
+            // (eg. WSL) is still in flight -- which can be the case for
+            // a few seconds right after startup -- domains it hasn't
+            // found yet won't appear here. Like `mux.get_domain(name)`,
+            // this is a synchronous snapshot that does NOT wait for
+            // discovery. `wezterm.mux.spawn_window{domain=...}` does wait
+            // (via `Mux::resolve_spawn_tab_domain` and
+            // `await_domain_resolution_async`), but only up to
+            // `mux::DOMAIN_DISCOVERY_TIMEOUT` -- a config that needs a
+            // specific WSL domain guaranteed available this early should
+            // set `wsl_domains` explicitly rather than rely on either.
             let mux = get_mux()?;
             Ok(mux
                 .iter_domains()

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
+async-io.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bintree.workspace = true

--- a/mux/src/domain.rs
+++ b/mux/src/domain.rs
@@ -203,6 +203,58 @@ pub struct LocalDomain {
     pty_system: Mutex<Box<dyn PtySystem + Send>>,
     id: DomainId,
     name: String,
+    /// Whether this domain was constructed via `new_wsl` -- ie. it's a WSL
+    /// domain, whether from explicit `wsl_domains` config or from
+    /// background discovery. Used only to short-circuit `resolve_wsl_domain`
+    /// for non-WSL domains without touching global config at all: that
+    /// method used to call `config.wsl_domains()` unconditionally for
+    /// *every* LocalDomain (including plain non-WSL ones like "local"),
+    /// which falls back to `WslDomain::default_domains()` and could shell
+    /// out to `wsl.exe` when `wsl_domains` isn't explicitly configured,
+    /// meaning every pane spawn paid that cost regardless of what kind of
+    /// domain it was spawning into.
+    ///
+    /// Deliberately not a cached snapshot of the `WslDomain` itself:
+    /// `resolve_wsl_domain` always re-reads the live, current
+    /// `config.wsl_domains_cached()` by name instead, matching this
+    /// method's pre-existing (always-live) behavior. Caching a snapshot
+    /// here was tried and reverted -- it made a domain registered under an
+    /// explicit `wsl_domains` entry keep using that entry's settings
+    /// forever even after the entry (or `wsl_domains` entirely) was
+    /// removed from the config on reload, and made a domain registered by
+    /// auto-discovery *not* revert to a plain non-WSL shell when
+    /// `wsl_domains = {}` -- the documented way to disable auto-added WSL
+    /// domains -- was set on reload. `wsl_domains_cached()` is the
+    /// non-blocking variant (see its doc comment): it never shells out to
+    /// `wsl.exe` itself, so the live lookup costs nothing beyond a mutex
+    /// lock once we know this domain is WSL-flavored in the first place.
+    is_wsl_domain: bool,
+    /// Construction-time snapshot of critical WSL domain fields, used as a
+    /// fallback ONLY while `wsl_domains_cached()` returns `None`.
+    ///
+    /// A domain registered *by* auto-discovery can't get here: the ordering in
+    /// `config::WslDomain::try_default_domains()` publishes the cache before
+    /// the domains are registered, so by the time one exists to spawn into, the
+    /// lookup it does has an answer. What does reach it is a domain that
+    /// outlived the config that named it -- registered from an explicit
+    /// `wsl_domains` list, then that list removed on reload, which leaves the
+    /// domain in the mux (domains are never unregistered) and starts a
+    /// discovery whose cache isn't published yet. Every spawn into it until
+    /// that discovery lands takes this path.
+    wsl_fallback: Option<WslDomainFallback>,
+}
+
+/// Snapshot of critical WSL domain fields stored at construction time.
+/// Used ONLY as a fallback for the "cache isn't populated yet" case;
+/// never substitutes for a live cached lookup. See `wsl_fallback` for when
+/// that case actually arises.
+#[derive(Clone, Debug)]
+struct WslDomainFallback {
+    name: String,
+    distribution: Option<String>,
+    username: Option<String>,
+    default_cwd: Option<PathBuf>,
+    default_prog: Option<Vec<String>>,
 }
 
 impl LocalDomain {
@@ -219,11 +271,63 @@ impl LocalDomain {
     }
 
     fn resolve_wsl_domain(&self) -> Option<WslDomain> {
-        config::configuration()
-            .wsl_domains()
-            .iter()
-            .find(|d| d.name == self.name)
-            .cloned()
+        // Short-circuits before touching global config at all for a
+        // non-WSL domain, which is the point: this used to unconditionally
+        // call `config.wsl_domains()` for every domain type, including
+        // plain "local" ones.
+        if !self.is_wsl_domain {
+            return None;
+        }
+        // Use the non-blocking cached accessor: pane-spawn must never
+        // shell out to `wsl.exe`. Two distinct "not found" cases have to be
+        // told apart here:
+        //
+        // - the list is known (explicit config, or auto-discovery already
+        //   completed) but doesn't mention this domain's name -- eg. its
+        //   `wsl_domains` entry was removed on reload, or `wsl_domains = {}`
+        //   was set to disable auto-added WSL domains. That's a real "this
+        //   is no longer a WSL domain" and must resolve to `None`, exactly
+        //   as before (`wsl_domain_with_no_matching_entry_resolves_to_none`
+        //   below locks this in).
+        // - the list isn't known *yet*: most often because this domain came
+        //   from an explicit `wsl_domains` list that a reload has since
+        //   removed, leaving it registered while the discovery that replaced
+        //   it is still running (see `wsl_fallback`). We still know from
+        //   `is_wsl_domain` that this
+        //   domain is WSL-flavored, so we must not let `fixup_command` fall through
+        //   to its "not WSL at all" branch, which runs the command directly on the
+        //   Windows host instead of inside WSL -- silently wrong, not just slow.
+        //   Fall back to a `WslDomain` built from the construction-time snapshot
+        //   stored in `wsl_fallback`, which contains the actual distribution name
+        //   (not just the mux domain name) and any other per-distro overrides
+        //   configured at registration time.
+        self.resolve_wsl_domain_from_cache(config::configuration().wsl_domains_cached().as_deref())
+    }
+
+    /// The config-free core of `resolve_wsl_domain`: takes the cached list
+    /// (or `None` as a defensive guard against future reordering) as a parameter
+    /// rather than reading process-global config, so both branches can be
+    /// unit tested directly. Without this seam a test of the `None` branch
+    /// would have to rely on the global cache happening to be unpopulated
+    /// in the test binary -- true today, but silently broken by the first
+    /// test that ever triggers a real discovery.
+    fn resolve_wsl_domain_from_cache(&self, cached: Option<&[WslDomain]>) -> Option<WslDomain> {
+        match cached {
+            Some(wsl_domains) => Self::resolve_wsl_domain_impl(&self.name, wsl_domains),
+            None => self.wsl_fallback.as_ref().map(|f| WslDomain {
+                name: f.name.clone(),
+                distribution: f.distribution.clone(),
+                username: f.username.clone(),
+                default_cwd: f.default_cwd.clone(),
+                default_prog: f.default_prog.clone(),
+            }),
+        }
+    }
+
+    /// The name-lookup half of `resolve_wsl_domain_from_cache`, split out
+    /// so it can be tested without constructing a `LocalDomain`.
+    fn resolve_wsl_domain_impl(name: &str, wsl_domains: &[WslDomain]) -> Option<WslDomain> {
+        wsl_domains.iter().find(|d| d.name == name).cloned()
     }
 
     pub fn with_pty_system(name: &str, pty_system: Box<dyn PtySystem + Send>) -> Self {
@@ -232,11 +336,22 @@ impl LocalDomain {
             pty_system: Mutex::new(pty_system),
             id,
             name: name.to_string(),
+            is_wsl_domain: false,
+            wsl_fallback: None,
         }
     }
 
     pub fn new_wsl(wsl: WslDomain) -> Result<Self, Error> {
-        Self::new(&wsl.name)
+        let mut domain = Self::new(&wsl.name)?;
+        domain.is_wsl_domain = true;
+        domain.wsl_fallback = Some(WslDomainFallback {
+            name: wsl.name.clone(),
+            distribution: wsl.distribution.clone(),
+            username: wsl.username.clone(),
+            default_cwd: wsl.default_cwd.clone(),
+            default_prog: wsl.default_prog.clone(),
+        });
+        Ok(domain)
     }
 
     pub fn new_exec_domain(exec_domain: ExecDomain) -> anyhow::Result<Self> {
@@ -728,5 +843,146 @@ impl Domain for LocalDomain {
 
     fn state(&self) -> DomainState {
         DomainState::Attached
+    }
+}
+
+#[cfg(test)]
+mod resolve_wsl_domain_tests {
+    use super::*;
+
+    fn wsl_domain(name: &str, default_prog: Option<Vec<&str>>) -> WslDomain {
+        WslDomain {
+            name: name.to_string(),
+            distribution: None,
+            username: None,
+            default_cwd: None,
+            default_prog: default_prog.map(|p| p.into_iter().map(String::from).collect()),
+        }
+    }
+
+    /// A plain (non-WSL) domain must never consult global config to
+    /// resolve WSL settings: this is what keeps a `local` pane spawn from
+    /// ever shelling out to `wsl.exe`, regardless of what background
+    /// discovery is doing concurrently.
+    #[test]
+    fn plain_domain_resolves_to_none_without_touching_config() {
+        let domain = LocalDomain::new("local").expect("LocalDomain::new is infallible in tests");
+        assert!(domain.resolve_wsl_domain().is_none());
+    }
+
+    /// A WSL domain resolves to whatever entry in the current, live
+    /// `config.wsl_domains()` list matches its name -- always live, never
+    /// a value cached at construction time. See the doc comment on
+    /// `LocalDomain::is_wsl_domain` for why: caching used to make a
+    /// domain keep stale settings (or stay WSL-flavored when it shouldn't
+    /// be) across a config reload that changed or removed its
+    /// configuration.
+    #[test]
+    fn wsl_domain_resolves_matching_entry_by_name() {
+        let ubuntu = wsl_domain("WSL:Ubuntu", Some(vec!["bash"]));
+        let debian = wsl_domain("WSL:Debian", Some(vec!["zsh"]));
+
+        let resolved =
+            LocalDomain::resolve_wsl_domain_impl("WSL:Ubuntu", &[ubuntu.clone(), debian]);
+        assert_eq!(resolved.map(|d| d.default_prog), Some(ubuntu.default_prog));
+    }
+
+    /// Regression test: if the current effective
+    /// `wsl_domains` list (explicit or auto-discovered) no longer
+    /// mentions this domain's name -- eg. its `wsl_domains` entry was
+    /// removed on reload, or `wsl_domains = {}` was set to disable
+    /// auto-discovered WSL domains -- resolution must return `None`
+    /// rather than silently keep serving a stale cached value. A cached
+    /// snapshot was tried and reverted specifically because it broke
+    /// this case.
+    #[test]
+    fn wsl_domain_with_no_matching_entry_resolves_to_none() {
+        let debian = wsl_domain("WSL:Debian", Some(vec!["zsh"]));
+        let resolved = LocalDomain::resolve_wsl_domain_impl("WSL:Ubuntu", &[debian]);
+        assert!(resolved.is_none());
+    }
+
+    /// `resolve_wsl_domain_impl` (the pure name-lookup core) resolving
+    /// against an empty-but-known list must return `None` -- this is the
+    /// legitimate "discovery completed and found nothing" / "name genuinely
+    /// absent" case, distinct from "discovery hasn't populated the cache
+    /// yet" (see `resolve_wsl_domain_falls_back_to_minimal_domain_while_cache_is_unpopulated`
+    /// below for that case, which must NOT resolve to `None`).
+    #[test]
+    fn resolve_wsl_domain_impl_with_empty_known_list_resolves_to_none() {
+        let empty: &[WslDomain] = &[];
+        let resolved = LocalDomain::resolve_wsl_domain_impl("WSL:Ubuntu", empty);
+        assert!(
+            resolved.is_none(),
+            "an empty but *known* list (eg. discovery found zero distros) must resolve to None"
+        );
+    }
+
+    /// When the cache is populated (simulating completed discovery),
+    /// `resolve_wsl_domain` must return the matching entry from the cache.
+    #[test]
+    fn resolve_wsl_domain_uses_cached_value_when_available() {
+        let ubuntu = wsl_domain("WSL:Ubuntu", Some(vec!["bash"]));
+        let debian = wsl_domain("WSL:Debian", Some(vec!["zsh"]));
+
+        let cached = vec![ubuntu.clone(), debian];
+        let resolved = LocalDomain::resolve_wsl_domain_impl("WSL:Ubuntu", &cached);
+        assert_eq!(resolved.map(|d| d.default_prog), Some(ubuntu.default_prog));
+    }
+
+    /// Regression test for the explicit -> unset config reload race: while
+    /// auto-discovery hasn't populated the cache yet (`wsl_domains_cached()`
+    /// returns `None`, not `Some(vec![])`), `resolve_wsl_domain` must still
+    /// report this domain as WSL-flavored and must preserve the *actual*
+    /// distribution name from construction time, not the mux domain name.
+    /// `fixup_command` gates its entire `wsl.exe --distribution ...` wrapping
+    /// on `resolve_wsl_domain` returning `Some`, so returning `None` here would
+    /// make a real WSL domain's pane spawn run directly on the Windows host
+    /// instead of inside WSL: silently wrong, not just slow. And if the
+    /// distribution name is wrong, the spawn fails with "distribution not found"
+    /// instead of working.
+    #[test]
+    fn resolve_wsl_domain_uses_fallback_with_correct_distribution() {
+        // Create a domain where the mux name differs from the actual distribution,
+        // simulating `{ name = "WSL:Ubuntu", distribution = "Ubuntu" }` from config.
+        let wsl_config = WslDomain {
+            name: "WSL:Ubuntu".to_string(),
+            distribution: Some("Ubuntu".to_string()),
+            username: Some("ubuntuuser".to_string()),
+            default_cwd: Some("/home/ubuntuuser".into()),
+            default_prog: Some(vec!["bash".to_string()]),
+        };
+
+        let domain = LocalDomain::new_wsl(wsl_config.clone())
+            .expect("LocalDomain::new_wsl is infallible in tests");
+
+        // Passes the "cache not populated yet" state in explicitly rather
+        // than relying on the process-global config cache happening to be
+        // empty in this test binary: that happens to be true today (nothing
+        // here runs a real discovery), but it's an invariant owned by other
+        // tests, and the first one to break it would turn this into a
+        // confusing failure somewhere else.
+        let resolved = domain.resolve_wsl_domain_from_cache(None);
+
+        assert!(
+            resolved.is_some(),
+            "WSL domain must resolve to Some while cache is unpopulated"
+        );
+        let resolved = resolved.unwrap();
+
+        // The critical assertion: distribution must be the actual distro name
+        // from construction, NOT the mux name. This is what prevents the
+        // `wsl.exe --distribution WSL:Ubuntu` bug (correct is `--distribution Ubuntu`).
+        assert_eq!(
+            resolved.distribution,
+            Some("Ubuntu".to_string()),
+            "fallback must preserve the actual distribution name from construction time"
+        );
+
+        // Also verify the other fields are preserved for consistency.
+        assert_eq!(resolved.name, "WSL:Ubuntu");
+        assert_eq!(resolved.username, Some("ubuntuuser".to_string()));
+        assert_eq!(resolved.default_cwd, Some("/home/ubuntuuser".into()));
+        assert_eq!(resolved.default_prog, Some(vec!["bash".to_string()]));
     }
 }

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -13,7 +13,8 @@ use libc::{c_int, SOL_SOCKET, SO_RCVBUF, SO_SNDBUF};
 use log::error;
 use metrics::histogram;
 use parking_lot::{
-    MappedRwLockReadGuard, MappedRwLockWriteGuard, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard,
+    Condvar, MappedRwLockReadGuard, MappedRwLockWriteGuard, Mutex, RwLock, RwLockReadGuard,
+    RwLockWriteGuard,
 };
 use percent_encoding::percent_decode_str;
 use portable_pty::{CommandBuilder, ExitStatus, PtySize};
@@ -22,8 +23,9 @@ use std::convert::TryInto;
 use std::io::{Read, Write};
 #[cfg(windows)]
 use std::os::raw::c_int;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
+use std::task::{Poll, Waker};
 use std::thread;
 use std::time::{Duration, Instant};
 use termwiz::escape::csi::{DecPrivateMode, DecPrivateModeCode, Device, Mode};
@@ -99,6 +101,534 @@ pub enum MuxNotification {
 
 static LAST_SUBSCRIBER_ID: AtomicUsize = AtomicUsize::new(0);
 
+/// How long resolving a domain *by name* will wait for an in-progress
+/// background domain discovery (see `Mux::begin_domain_discovery`) before
+/// giving up and falling back to its usual "domain not found" behavior.
+///
+/// Bounded, unlike the `default_domain`/`default_mux_server_domain`/`--domain`
+/// paths, because the two differ in what a wrong answer costs. Those name the
+/// domain the user has declared they want to start in, so treating "discovery
+/// is still running" as "that domain doesn't exist" fails startup outright;
+/// they wait for as long as discovery takes. An arbitrary later
+/// `SpawnTabDomain::DomainName` -- a key assignment, or
+/// `wezterm.mux.spawn_window{domain=...}` -- is far more likely to name
+/// something that will never appear (a typo, or a distribution since removed),
+/// and blocking it for the whole of a cold `wsl.exe` before saying so is its
+/// own kind of wrong.
+///
+/// The trade-off worth stating plainly: `wsl.exe -l -v` can take longer than
+/// this on exactly the machines this discovery exists to keep off the startup
+/// path, so a by-name spawn issued in the first seconds of a session -- most
+/// plausibly from a `gui-startup`/`mux-startup` handler -- can be told the
+/// name is invalid even though discovery would have found it shortly after. A
+/// config that needs a specific WSL domain available that early should set
+/// `wsl_domains` explicitly instead of relying on auto-discovery.
+pub const DOMAIN_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// How long an `InProgress` discovery run may persist before a later
+/// `begin_domain_discovery`/`begin_domain_discovery_with_default_filter`
+/// call treats it as permanently stuck (eg. a `wsl.exe` that hangs
+/// forever, not just one that's slow) and supersedes it with a fresh run
+/// rather than the usual "already in progress, just refresh the fields
+/// and return" no-op.
+///
+/// Deliberately longer than `config::wsl`'s own 60s
+/// `DISCOVERY_BUSY_WAIT_TIMEOUT` (not exported across the crate boundary,
+/// so not named directly here): that timeout is what lets a *second*
+/// concurrent caller of `WslDomain::try_default_domains` steal an
+/// abandoned claim and make real progress, but nothing here ever makes
+/// that second call while a run is `InProgress` -- `begin_domain_discovery*`
+/// refuses to spawn a competing discovery thread precisely to avoid
+/// running `wsl.exe` twice at once. Without this mux-level check, a
+/// permanently hung first attempt would mean nothing here ever produces
+/// the second caller that the config-layer timeout is waiting to un-stick,
+/// and any unbounded waiter (`await_domain_discovery_unbounded[_async]`)
+/// would block forever with no way out. Set comfortably above the
+/// config-layer timeout so a merely-slow (not hung) first attempt gets a
+/// full chance to finish on its own before this starts a competing one.
+const DOMAIN_DISCOVERY_STUCK_THRESHOLD: Duration = Duration::from_secs(90);
+
+/// Which flavor of discovery wait `Mux::await_domain_resolution_async`
+/// decided is needed for a given `resolve_spawn_tab_domain` target; see
+/// `Mux::domain_resolution_wait_kind`.
+#[derive(Debug, PartialEq, Eq)]
+enum DomainResolutionWaitKind {
+    None,
+    Bounded,
+    Unbounded,
+}
+
+/// Tracks the state of a background domain discovery run kicked off by
+/// `Mux::begin_domain_discovery` (currently used only for WSL domains, but
+/// deliberately not WSL-specific: `Mux` doesn't otherwise know what kind of
+/// domain it's registering). `generation` identifies a particular run and
+/// is compared-and-swapped as a single unit with the rest of this enum
+/// under `Mux::domain_discovery`'s lock -- never read from a separate
+/// atomic outside that lock -- so that starting, cancelling and finishing
+/// a run can't observe or act on a torn combination of "which run" and
+/// "what state that run is in". `pending_default` names the domain (if
+/// any) that should become the mux default domain once discovery
+/// completes, because it was requested (via
+/// `default_domain`/`default_mux_server_domain`) but didn't exist among
+/// the domains known synchronously at startup.
+///
+/// `wakers` stores any async tasks waiting for this discovery to complete.
+/// These are woken when the discovery finishes (successfully or with an
+/// error) or is cancelled.
+///
+/// `default_domain_id_at_start` is the default domain's id as of the most
+/// recent `begin_domain_discovery`/`begin_domain_discovery_with_default_filter`
+/// call for this run -- initially set when the run starts, and refreshed
+/// (along with `pending_default`) on every repeat call that lands while
+/// this run is still `InProgress`, all under the same lock. Living here
+/// (rather than being captured once into `FinishDomainDiscoveryOnDrop` and
+/// never updated again) is what lets a later repeat call's "did the
+/// default change since *I* asked for `pending_default`" guard use *its
+/// own* baseline instead of silently inheriting a stale one from whichever
+/// call happened to be first to actually spawn the discovery thread.
+///
+/// `next_waiter_id` allocates a fresh ID for each async waiter that
+/// registers, used to key `wakers` so individual waiters can be looked up
+/// and removed (or their waker replaced) in O(1).
+///
+/// `accepts_as_default` is the predicate from the most recent
+/// `begin_domain_discovery_with_default_filter` call for this run, refreshed
+/// on every repeat call (same pattern as `pending_default` and
+/// `default_domain_id_at_start`).
+///
+/// `started_at` is set once, when this run's discovery thread is first
+/// spawned, and never refreshed by repeat calls (unlike the other fields
+/// above) -- it exists purely to let `begin_domain_discovery_with_default_filter`
+/// measure how long *this* run has actually been running, so it can tell
+/// a merely-slow run apart from one that's stuck past
+/// `DOMAIN_DISCOVERY_STUCK_THRESHOLD` and needs superseding. See that
+/// function and the constant's own doc comment.
+enum DomainDiscoveryState {
+    NotStarted,
+    InProgress {
+        generation: u64,
+        pending_default: Option<String>,
+        default_domain_id_at_start: Option<DomainId>,
+        wakers: HashMap<u64, Waker>,
+        next_waiter_id: u64,
+        accepts_as_default: Arc<dyn Fn(&Arc<dyn Domain>) -> bool + Send + Sync>,
+        started_at: Instant,
+    },
+    Done {
+        _generation: u64,
+        not_found_pending_default: Option<String>,
+    },
+}
+
+/// Future that waits for domain discovery to complete. Registers itself
+/// in the `DomainDiscoveryState::InProgress::wakers` map and is woken
+/// when discovery finishes or is cancelled. Unlike the old thread-per-waiter
+/// approach, this is zero-cost from a thread perspective and doesn't spawn
+/// additional OS threads.
+///
+/// The future now carries its own independent timer via
+/// `async_io::Timer` when a timeout is configured, so it wakes at the
+/// deadline even if discovery never completes (e.g. a hung `wsl.exe`).
+/// The timer is lazily started on the first poll to avoid creating it
+/// for futures that resolve immediately.
+///
+/// The future tracks its registration as `(generation,
+/// waiter_id)` rather than just `generation`, and implements `Drop` to
+/// unregister its slot from the run's wakers map when dropped. This
+/// allows stale wakers to be cleaned up and enables the `will_wake`
+/// check for updating the stored waker on a later poll.
+pub struct DomainDiscoveryWaitFuture {
+    mux: Arc<Mux>,
+    timeout: Option<Duration>,
+    timer: Option<async_io::Timer>,
+    /// The `generation` of the `InProgress` run (if any) this future has
+    /// already pushed its waker into, so it knows whether it needs to
+    /// (re-)register. Deliberately keyed by generation rather than a plain
+    /// "have we ever registered" bool: a cancelled run's `wakers` are
+    /// drained and woken by `cancel_domain_discovery`/`FinishDomainDiscoveryOnDrop`,
+    /// and if a *new* discovery run starts before this future gets polled
+    /// again, a plain bool would see itself as "already registered" and
+    /// skip joining the new run's (separate, freshly-empty) `wakers` list
+    /// -- leaving it registered nowhere and pending forever. Comparing
+    /// generations means a new run is always detected and re-registered
+    /// against. The `waiter_id` half additionally lets this future find and
+    /// remove or replace its own slot without disturbing anyone else's.
+    registered: Option<(u64, u64)>,
+}
+
+impl DomainDiscoveryWaitFuture {
+    fn new(mux: Arc<Mux>, timeout: Option<Duration>) -> Self {
+        Self {
+            mux,
+            timeout,
+            timer: None,
+            registered: None,
+        }
+    }
+
+    /// Unregister this future's waker from the run's map if
+    /// it's still registered. Called from both Drop and when the future
+    /// resolves via timeout.
+    fn unregister(&self) {
+        if let Some((generation, waiter_id)) = self.registered {
+            let mut state = self.mux.domain_discovery.lock();
+            // Check generation first, then access wakers
+            let is_current_gen = matches!(
+                &*state,
+                DomainDiscoveryState::InProgress { generation: g, .. } if *g == generation
+            );
+            if is_current_gen {
+                if let DomainDiscoveryState::InProgress { wakers, .. } = &mut *state {
+                    wakers.remove(&waiter_id);
+                }
+            }
+        }
+    }
+}
+
+impl Drop for DomainDiscoveryWaitFuture {
+    fn drop(&mut self) {
+        // Clean up our waker registration when dropped
+        self.unregister();
+    }
+}
+
+impl std::future::Future for DomainDiscoveryWaitFuture {
+    type Output = bool; // true if discovery completed, false if timed out
+
+    fn poll(mut self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context) -> Poll<Self::Output> {
+        // Lazily create the timer on the first poll (now that
+        // we have a `Context` to register it against), then -- whether it
+        // was just created or already existed from an earlier poll --
+        // always poll it here. This is not optional: constructing an
+        // `async_io::Timer` without ever polling it never registers a
+        // wake with the reactor at all, so a timer that's created but not
+        // immediately polled once would never fire -- reintroducing
+        // exactly the "nothing wakes this task at the deadline" bug this
+        // timer exists to fix, just one layer deeper.
+        if self.timer.is_none() {
+            if let Some(timeout) = self.timeout {
+                self.timer = Some(async_io::Timer::after(timeout));
+            }
+        }
+        if let Some(timer) = &mut self.timer {
+            if std::pin::Pin::new(timer).poll(cx).is_ready() {
+                // Timer fired: unregister our waker and report timeout.
+                self.unregister();
+                return Poll::Ready(false);
+            }
+        }
+
+        let mut newly_registered = None;
+
+        let result = {
+            let mut state = self.mux.domain_discovery.lock();
+
+            match &mut *state {
+                DomainDiscoveryState::NotStarted => {
+                    // Nothing to wait for
+                    Some(Poll::Ready(true))
+                }
+                DomainDiscoveryState::Done { .. } => {
+                    // Discovery already completed
+                    Some(Poll::Ready(true))
+                }
+                DomainDiscoveryState::InProgress {
+                    generation,
+                    wakers,
+                    next_waiter_id,
+                    ..
+                } => {
+                    // Check if we need to register or update our waker
+                    let waker = cx.waker();
+                    let (current_gen, current_id) = match self.registered {
+                        Some((gen, id)) => (Some(gen), Some(id)),
+                        None => (None, None),
+                    };
+
+                    match (current_gen, current_id) {
+                        // Not yet registered: allocate a new waiter_id
+                        (None, None) => {
+                            let waiter_id = *next_waiter_id;
+                            *next_waiter_id = waiter_id.wrapping_add(1);
+                            wakers.insert(waiter_id, waker.clone());
+                            newly_registered = Some((*generation, waiter_id));
+                            None
+                        }
+                        // Already registered, check if generation matches
+                        (Some(gen), Some(id)) if gen == *generation => {
+                            // Same generation: check if waker needs updating
+                            match wakers.get(&id) {
+                                Some(old_waker) => {
+                                    if !old_waker.will_wake(waker) {
+                                        wakers.insert(id, waker.clone());
+                                    }
+                                }
+                                // Our slot is gone even though the
+                                // generation still matches. No current code
+                                // path does that -- everything that drains
+                                // `wakers` also bumps the generation, and
+                                // `unregister` only runs on terminal paths
+                                // -- but returning Pending here without a
+                                // registered waker would mean nothing ever
+                                // wakes this task again, ie. a spawn hung
+                                // forever. Re-register instead of trusting
+                                // an invariant that lives in other
+                                // functions. `next_waiter_id` never reuses
+                                // ids, so reinstating our own is safe.
+                                None => {
+                                    wakers.insert(id, waker.clone());
+                                }
+                            }
+                            None
+                        }
+                        // Different generation: need to re-register
+                        _ => {
+                            let waiter_id = *next_waiter_id;
+                            *next_waiter_id = waiter_id.wrapping_add(1);
+                            wakers.insert(waiter_id, waker.clone());
+                            newly_registered = Some((*generation, waiter_id));
+                            None
+                        }
+                    }
+                }
+            }
+        };
+
+        // Log after releasing `state`'s lock above: nothing here needs the
+        // lock, and this `poll` runs on the executor thread, so there is no
+        // reason to hold a lock the discovery thread wants across a log
+        // backend of unknown cost. (Elsewhere in this file logging *does*
+        // happen under that lock -- in `FinishDomainDiscoveryOnDrop::drop`
+        // and the supersede paths -- because there the message describes a
+        // decision made from the state being held, and splitting it out
+        // would mean copying that state back out just to format it.)
+        // Gated on `newly_registered` so this
+        // fires once per (future, generation) -- ie. the moment this poll
+        // is genuinely about to return `Pending` for the first time on
+        // this run, meaning a real wait is starting -- rather than on
+        // every re-poll/wake while still waiting. Gated on
+        // `self.timeout.is_none()` so only the unbounded variant
+        // (`await_domain_discovery_unbounded_async`) logs here; the
+        // bounded variant (`await_domain_discovery_async`) shares this
+        // same `poll` but has an explicit, self-describing timeout and
+        // doesn't need this diagnostic.
+        if newly_registered.is_some() && self.timeout.is_none() {
+            log::info!("waiting for WSL domain discovery to finish (unbounded)");
+        }
+
+        if let Some(reg) = newly_registered {
+            self.registered = Some(reg);
+        }
+
+        match result {
+            Some(poll) => {
+                // If we're resolving without timeout, clean up
+                self.unregister();
+                poll
+            }
+            None => Poll::Pending,
+        }
+    }
+}
+
+/// Finalizes a background domain discovery run when dropped: applies
+/// `pending_default` if the named domain was found and the default domain
+/// hasn't changed since discovery started, transitions the state to
+/// `Done` (or `NotStarted` on error), and wakes anything blocked in
+/// `Mux::await_domain_discovery`. Runs on both normal completion and panic
+/// unwind (Drop runs either way), which is the whole point -- see the
+/// comment at its construction site in `Mux::begin_domain_discovery`.
+///
+/// `generation` identifies which run this guard belongs to; it's compared
+/// against the *current* `DomainDiscoveryState`'s own `generation` field
+/// under `Mux::domain_discovery`'s lock (not a separately-read atomic), so
+/// a superseded run's guard can't mistake a newer run's `InProgress` state
+/// for its own and finish it early -- nor can it be fooled into thinking
+/// it's still current by a state transition that happened after it made
+/// an earlier, unlocked check.
+///
+/// `result` holds the outcome of the discover closure: `Ok(domains)` on
+/// success, `Err(err)` on failure. On error, the state transitions to
+/// `NotStarted` (retryable) instead of `Done`, allowing a later config
+/// reload to retry discovery.
+///
+/// Deliberately does *not* carry its own snapshot of `pending_default`'s
+/// "did the default change since I was asked to apply this" baseline
+/// (`default_domain_id_at_start`) or of `pending_default` itself -- both
+/// live in `DomainDiscoveryState::InProgress` instead, refreshed together
+/// by every repeat `begin_domain_discovery`/
+/// `begin_domain_discovery_with_default_filter` call that lands while this
+/// run is still in progress. Reads them out of `state` (already locked
+/// below) when it fires, so a later repeat call's own baseline is what
+/// gets checked, not whichever call happened to be first to actually spawn
+/// the discovery thread this guard belongs to.
+struct FinishDomainDiscoveryOnDrop {
+    mux: Arc<Mux>,
+    generation: u64,
+    /// The outcome of the discover closure, set before this guard is
+    /// dropped. Must be `Some` when dropped.
+    result: Option<anyhow::Result<Vec<Arc<dyn Domain>>>>,
+}
+
+impl Drop for FinishDomainDiscoveryOnDrop {
+    fn drop(&mut self) {
+        let mut state = self.mux.domain_discovery.lock();
+        let is_current = matches!(
+            &*state,
+            DomainDiscoveryState::InProgress { generation, .. } if *generation == self.generation
+        );
+        let mut wakers: Vec<Waker> = vec![];
+        if is_current {
+            if let DomainDiscoveryState::InProgress {
+                wakers: in_flight_wakers,
+                ..
+            } = &mut *state
+            {
+                wakers = std::mem::take(in_flight_wakers)
+                    .drain()
+                    .map(|(_, w)| w)
+                    .collect();
+            }
+
+            // Wrap the pending_default application in catch_unwind.
+            // Even if accepts_as_default or set_default_domain panic, we must
+            // still transition state and wake waiters.
+            let pending_apply_result =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    // Check the result: on error, transition to NotStarted (retryable)
+                    // instead of Done. On success (including panic - see below),
+                    // transition to Done.
+                    let is_success = self.result.as_ref().map(|r| r.is_ok()).unwrap_or(true);
+                    if is_success {
+                        // Determine which pending_default name (if any) we failed to find,
+                        // so the Done shortcut can avoid spawning redundant runs for it.
+                        let not_found_pending_default = if let DomainDiscoveryState::InProgress {
+                            pending_default: Some(name),
+                            ..
+                        } = &*state
+                        {
+                            // The run was asked to find a domain by name. Did we find it?
+                            if self.mux.get_domain_by_name(name).is_none() {
+                                Some(name.clone())
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+
+                        if let DomainDiscoveryState::InProgress {
+                            pending_default: Some(name),
+                            default_domain_id_at_start,
+                            accepts_as_default,
+                            ..
+                        } = &*state
+                        {
+                            // Read accepts_as_default from state (refreshed on repeat calls)
+                            // rather than from the captured field.
+                            // Do the compare and set under a single write lock.
+                            {
+                                let mut default = self.mux.default_domain.write();
+                                let current_default_domain_id =
+                                    default.as_ref().map(|d| d.domain_id());
+                                let default_unchanged =
+                                    current_default_domain_id == *default_domain_id_at_start;
+                                if default_unchanged {
+                                    if let Some(dom) = self.mux.get_domain_by_name(name) {
+                                        if accepts_as_default(&dom) {
+                                            *default = Some(Arc::clone(&dom));
+                                        } else {
+                                            log::error!(
+                                                "pending default domain \"{name}\" is not an \
+                                                 acceptable default here (eg. it resolved to a \
+                                                 client domain where that isn't allowed); not \
+                                                 applying it"
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        DomainDiscoveryState::Done {
+                            _generation: self.generation,
+                            not_found_pending_default,
+                        }
+                    } else {
+                        // Error or explicit failure: transition to NotStarted
+                        // so a later config reload can retry.
+                        //
+                        // Log it on the way past. Distinguishing a real
+                        // failure from "there genuinely are no domains" is
+                        // the entire reason the error is threaded up here
+                        // rather than swallowed at the source, and dropping
+                        // it silently would leave a user whose `wsl.exe -l
+                        // -v` is broken with no diagnostic at all -- just
+                        // domains that never appear.
+                        if let Some(Err(err)) = self.result.as_ref() {
+                            log::warn!(
+                                "background domain discovery failed; no domains were \
+                                 registered from it, and it will be retried on the next \
+                                 config reload: {err:#}"
+                            );
+                        }
+                        DomainDiscoveryState::NotStarted
+                    }
+                }));
+
+            let next_state = match pending_apply_result {
+                Ok(s) => s,
+                Err(_) => {
+                    log::error!(
+                        "panic while applying pending default or checking default unchanged; \
+                         treating discovery as finished"
+                    );
+                    // Treat panic as success (transition to Done) so we don't retry forever.
+                    // The pending default was not applied in this case, but that's acceptable.
+                    // Still determine not_found_pending_default for the Done shortcut.
+                    let not_found_pending_default = if let DomainDiscoveryState::InProgress {
+                        pending_default: Some(name),
+                        ..
+                    } = &*state
+                    {
+                        if self.mux.get_domain_by_name(name).is_none() {
+                            Some(name.clone())
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+                    DomainDiscoveryState::Done {
+                        _generation: self.generation,
+                        not_found_pending_default,
+                    }
+                }
+            };
+
+            *state = next_state;
+        }
+        drop(state);
+        self.mux.domain_discovery_cond.notify_all();
+
+        // Wake all async waiters *after* releasing the lock, matching
+        // `cancel_domain_discovery_and_replace`. Waking under the lock
+        // happens to be safe with the executor actually in use
+        // (`async_task` never polls or drops the woken future inline on
+        // this thread, so `DomainDiscoveryWaitFuture::drop` can't reenter
+        // `domain_discovery`), but that's an implicit dependency on an
+        // executor implementation detail, and it costs nothing to not
+        // depend on it.
+        for waker in wakers {
+            waker.wake();
+        }
+
+        if std::thread::panicking() {
+            log::error!("domain discovery thread panicked; treating discovery as finished");
+        }
+    }
+}
+
 pub struct Mux {
     tabs: RwLock<HashMap<TabId, Arc<Tab>>>,
     panes: RwLock<HashMap<PaneId, Arc<dyn Pane>>>,
@@ -113,6 +643,41 @@ pub struct Mux {
     num_panes_by_workspace: RwLock<HashMap<String, usize>>,
     main_thread_id: std::thread::ThreadId,
     agent: Option<AgentProxy>,
+    domain_discovery: Mutex<DomainDiscoveryState>,
+    domain_discovery_cond: Condvar,
+    /// Allocates a fresh id for each new discovery run started from
+    /// `NotStarted`/`Done`; read only while holding `domain_discovery`'s
+    /// lock (via `fetch_add`, which is itself atomic), never compared
+    /// against a run's captured generation outside that lock.
+    next_domain_discovery_generation: AtomicU64,
+    /// Bumped by every `cancel_domain_discovery`/`cancel_domain_discovery_and_replace`
+    /// call, always while holding `domain_discovery`'s lock, and likewise only
+    /// read under it. Exists so `adopt_orphaned_discovery` can tell a
+    /// `NotStarted` that means "the run that replaced me failed, retry welcome"
+    /// from one that means "the config switched to an explicit `wsl_domains`
+    /// list and no longer wants discovered domains" -- the state itself is the
+    /// same in both cases, but only the former may adopt a late result. Bumped
+    /// even when the cancel turns out to be a no-op, so it errs towards *not*
+    /// adopting.
+    domain_discovery_cancel_epoch: AtomicU64,
+    /// The default-domain request carried by the most recent
+    /// `begin_domain_discovery_with_default_filter` call -- what
+    /// `adopt_orphaned_discovery` consults instead of values captured when
+    /// the adopting run was spawned, so that a config reload which changed
+    /// or dropped `default_domain` while that run was stuck is honoured
+    /// rather than resurrecting the old ask. Overwritten at the top of
+    /// every `begin_*` call; a leaf lock, only ever taken while
+    /// `domain_discovery`'s lock is held, and never held across any other
+    /// lock acquisition.
+    domain_discovery_latest_default: Mutex<Option<DomainDiscoveryDefaultRequest>>,
+}
+
+/// See `Mux::domain_discovery_latest_default`.
+#[derive(Clone)]
+struct DomainDiscoveryDefaultRequest {
+    pending_default: Option<String>,
+    default_domain_id_at_start: Option<DomainId>,
+    accepts_as_default: Arc<dyn Fn(&Arc<dyn Domain>) -> bool + Send + Sync>,
 }
 
 const BUFSIZE: usize = 1024 * 1024;
@@ -423,6 +988,14 @@ impl std::ops::Deref for MuxWindowBuilder {
     }
 }
 
+/// Outcome of `add_discovered_domain` - 3-way result to
+/// distinguish "superseded" from "already present" vs "inserted".
+enum AddDiscoveredDomainOutcome {
+    Inserted,
+    AlreadyPresent,
+    Superseded,
+}
+
 impl Mux {
     pub fn new(default_domain: Option<Arc<dyn Domain>>) -> Self {
         let mut domains = HashMap::new();
@@ -456,6 +1029,11 @@ impl Mux {
             num_panes_by_workspace: RwLock::new(HashMap::new()),
             main_thread_id: std::thread::current().id(),
             agent,
+            domain_discovery: Mutex::new(DomainDiscoveryState::NotStarted),
+            domain_discovery_cond: Condvar::new(),
+            next_domain_discovery_generation: AtomicU64::new(0),
+            domain_discovery_cancel_epoch: AtomicU64::new(0),
+            domain_discovery_latest_default: Mutex::new(None),
         }
     }
 
@@ -743,16 +1321,1060 @@ impl Mux {
         self.domains_by_name.read().get(name).cloned()
     }
 
+    /// Registers `domain` unconditionally. The mux model does not guarantee
+    /// globally-unique domain *names* — only `DomainId`s are unique. Multiple
+    /// domain objects with the same name but different `DomainId`s can be
+    /// registered (e.g., multiple `TermWizTerminalDomain` instances for different
+    /// debug overlay tabs, or concurrent tmux control-mode sessions).
+    ///
+    /// For domain discovery scenarios where deduplication by name is required
+    /// (to prevent a background discovery thread and a synchronous config reload
+    /// from registering the same logical domain twice), use `add_discovered_domain`,
+    /// which checks the name before registering and skips if it's already taken.
     pub fn add_domain(&self, domain: &Arc<dyn Domain>) {
-        if self.default_domain.read().is_none() {
-            *self.default_domain.write() = Some(Arc::clone(domain));
-        }
-        self.domains
-            .write()
-            .insert(domain.domain_id(), Arc::clone(domain));
         self.domains_by_name
             .write()
             .insert(domain.domain_name().to_string(), Arc::clone(domain));
+
+        self.domains
+            .write()
+            .insert(domain.domain_id(), Arc::clone(domain));
+
+        if self.default_domain.read().is_none() {
+            *self.default_domain.write() = Some(Arc::clone(domain));
+        }
+    }
+
+    /// Like `add_domain`, but only registers `domain` if:
+    /// 1. `generation` still identifies the currently active discovery run -- checked and
+    ///    applied while holding `domain_discovery`'s lock for the whole
+    ///    operation, so a `cancel_domain_discovery` or a newer
+    ///    `begin_domain_discovery` call landing between the generation check
+    ///    and the registration can't be missed the way a separate,
+    ///    unlocked check would allow.
+    /// 2. No domain with the same name is already registered. This deduplication is
+    ///    specific to the discovery path to prevent a background discovery thread and
+    ///    a synchronous config reload from both registering the same logical WSL domain.
+    /// Used by the discovery thread spawned in `begin_domain_discovery` to register
+    /// each domain it finds.
+    ///
+    /// The outcome distinguishes "superseded" from "already present" and
+    /// "inserted" so that a single name collision doesn't abort registration of
+    /// every other discovered domain.
+    fn add_discovered_domain(
+        &self,
+        generation: u64,
+        domain: &Arc<dyn Domain>,
+    ) -> AddDiscoveredDomainOutcome {
+        let discovery_state = self.domain_discovery.lock();
+        let is_current = matches!(
+            &*discovery_state,
+            DomainDiscoveryState::InProgress { generation: g, .. } if *g == generation
+        );
+        if !is_current {
+            return AddDiscoveredDomainOutcome::Superseded;
+        }
+        // Still holding domain_discovery's lock: a concurrent
+        // cancel_domain_discovery/begin_domain_discovery call blocks on
+        // the same lock and so cannot supersede this run until the
+        // registration below has completed.
+        self.register_discovered_domain_locked(domain)
+    }
+
+    /// The registration half of `add_discovered_domain`, split out so
+    /// `adopt_orphaned_discovery` can reuse it while already holding
+    /// `domain_discovery`'s lock (re-taking it there would deadlock).
+    ///
+    /// The caller must hold that lock and must already have decided this
+    /// registration is allowed; this performs no generation check of its own.
+    ///
+    /// The by-name check and insert happen under one `domains_by_name`
+    /// write lock (not two separate lock acquisitions) so that a
+    /// same-named `add_domain` call landing from outside discovery (eg.
+    /// explicit `wsl_domains` config registration, which doesn't hold
+    /// `domain_discovery`'s lock) can't sneak in between the check and
+    /// the insert and have its entry silently overwritten by this
+    /// discovery run.
+    fn register_discovered_domain_locked(
+        &self,
+        domain: &Arc<dyn Domain>,
+    ) -> AddDiscoveredDomainOutcome {
+        {
+            let mut by_name = self.domains_by_name.write();
+            if by_name.contains_key(domain.domain_name()) {
+                return AddDiscoveredDomainOutcome::AlreadyPresent;
+            }
+            by_name.insert(domain.domain_name().to_string(), Arc::clone(domain));
+        }
+
+        self.domains
+            .write()
+            .insert(domain.domain_id(), Arc::clone(domain));
+
+        if self.default_domain.read().is_none() {
+            *self.default_domain.write() = Some(Arc::clone(domain));
+        }
+
+        AddDiscoveredDomainOutcome::Inserted
+    }
+
+    /// Salvages the result of a discovery run that succeeded but found itself
+    /// superseded, in the one case where nothing else will ever publish it.
+    ///
+    /// The situation this exists for: a slow run A is superseded by
+    /// `DOMAIN_DISCOVERY_STUCK_THRESHOLD`, the replacement run B fails, and
+    /// only afterwards does A finally succeed. A's `discover` closure has by
+    /// then published its list to `config`'s process-lifetime cache (that
+    /// happens inside the closure, before this code runs and before A learns
+    /// it was superseded), but A's generation is stale, so it registers
+    /// nothing. The result is a populated cache and an empty registry --
+    /// inconsistent, and since spawn resolves a domain's live settings against
+    /// that cache, exactly the kind of divergence the rest of this machinery
+    /// works to avoid.
+    ///
+    /// Adoption is deliberately narrow. It happens only when:
+    ///
+    /// * no cancellation has landed since this run started -- otherwise the
+    ///   config has switched to an explicit `wsl_domains` list that no longer
+    ///   wants discovered domains, and registering them would resurrect
+    ///   entries the user just removed. `NotStarted` alone cannot tell the two
+    ///   apart (a cancel and a failure both produce it), which is why
+    ///   `domain_discovery_cancel_epoch` is consulted rather than the state
+    ///   alone; and
+    /// * the state is `NotStarted`, ie. no newer run is in flight (which would
+    ///   publish its own, fresher answer) and none has completed (`Done`,
+    ///   which already registered one).
+    ///
+    /// Requiring `NotStarted` rather than retrying leaves one gap: a run
+    /// arriving in the window between a replacement deciding to fail (having
+    /// just looked in the config-level cache and found it empty) and that
+    /// replacement's guard actually recording the failure will see
+    /// `InProgress`, decline, and then find the state turn `NotStarted` a
+    /// moment too late -- so the divergence this exists to prevent survives
+    /// until the next reload rather than being repaired now. Closing it means
+    /// re-checking after the replacement settles, which means either blocking
+    /// this thread on the state or a retry loop with no natural bound, to buy
+    /// a window measured in the microseconds between two adjacent statements
+    /// in the run that is failing.
+    ///
+    /// A configured `default_domain` naming a domain only this run can supply
+    /// still has to be honoured here, or it silently stays unapplied until
+    /// some later reload happens along -- `update_mux_domains_impl` already
+    /// tried, before the domain existed, and found nothing. What gets applied
+    /// is `domain_discovery_latest_default` -- the request carried by the most
+    /// recent `begin_*` call -- NOT values captured when this run was spawned.
+    /// The distinction matters precisely in the situation this function exists
+    /// for: this run has been stuck long enough to be superseded, which means
+    /// there has been at least one reload since it started, and that reload
+    /// may have changed or dropped `default_domain`. A spawn-time copy would
+    /// resurrect the old ask (a `default_domain` the config no longer
+    /// contains, applied anyway, and a later reload can't undo it -- a config
+    /// with no `default_domain` has nothing to apply); the slot tracks what
+    /// was asked for last. It is applied with the same compare-and-set guard
+    /// as the other two sites, so a default set deliberately in the meantime
+    /// is not clobbered.
+    fn adopt_orphaned_discovery(&self, cancel_epoch_at_start: u64, domains: &[Arc<dyn Domain>]) {
+        let mut state = self.domain_discovery.lock();
+
+        if self.domain_discovery_cancel_epoch.load(Ordering::SeqCst) != cancel_epoch_at_start {
+            return;
+        }
+        if !matches!(&*state, DomainDiscoveryState::NotStarted) {
+            return;
+        }
+
+        // Clone the latest request out and release the slot's lock
+        // immediately: it is a leaf lock, deliberately never held while
+        // taking `default_domain` (or anything else) below. `None` is
+        // impossible in production -- reaching here means a `begin_*` call
+        // published this run, and every such call writes the slot first --
+        // but a `None` simply means there is no default to apply, which is
+        // also the correct degraded behavior.
+        let request = self.domain_discovery_latest_default.lock().clone();
+
+        let mut adopted = 0usize;
+        for domain in domains {
+            if matches!(
+                self.register_discovered_domain_locked(domain),
+                AddDiscoveredDomainOutcome::Inserted
+            ) {
+                adopted += 1;
+            }
+        }
+
+        log::info!(
+            "a superseded WSL domain discovery finished successfully after the run that \
+             replaced it had already failed; adopting its {adopted} domain(s) rather than \
+             leaving the cache populated with nothing registered against it"
+        );
+
+        // Same shape as the `Done` shortcut and `FinishDomainDiscoveryOnDrop`:
+        // compare and set under a single write guard so a concurrent writer
+        // can't land in the gap, and run the caller-supplied predicate under
+        // `catch_unwind` because it is arbitrary code executing while this
+        // holds both `domain_discovery` and `default_domain`.
+        let mut not_found_pending_default = None;
+        if let Some(request) = &request {
+            if let Some(name) = &request.pending_default {
+                match self.get_domain_by_name(name) {
+                    Some(dom) => {
+                        let mut default = self.default_domain.write();
+                        if default.as_ref().map(|d| d.domain_id())
+                            == request.default_domain_id_at_start
+                        {
+                            match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                (request.accepts_as_default)(&dom)
+                            })) {
+                                Ok(true) => *default = Some(Arc::clone(&dom)),
+                                Ok(false) => {}
+                                Err(_) => {
+                                    log::error!(
+                                        "panic while deciding whether \"{name}\" is an acceptable \
+                                         default domain; not applying it"
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    None => not_found_pending_default = Some(name.to_string()),
+                }
+            }
+        }
+
+        *state = DomainDiscoveryState::Done {
+            _generation: self
+                .next_domain_discovery_generation
+                .fetch_add(1, Ordering::SeqCst),
+            not_found_pending_default,
+        };
+
+        drop(state);
+        self.domain_discovery_cond.notify_all();
+    }
+
+    /// Kicks off a background domain discovery run, using `discover` to
+    /// produce the domains to register (in production, `discover`
+    /// constructs WSL `LocalDomain`s from `config::WslDomain::default_domains`,
+    /// which shells out to `wsl.exe -l -v` and can block for many seconds
+    /// on Windows -- but `Mux` itself has no WSL-specific knowledge here).
+    ///
+    /// The `discover` closure returns `anyhow::Result`: on success, the
+    /// discovered domains are registered and the state transitions to
+    /// `Done`. On error (including panics), the state transitions to
+    /// `NotStarted` instead, allowing a later config reload to retry.
+    ///
+    /// This exists so that callers on the GUI/mux startup path never have
+    /// to block on that discovery: the domains `discover` returns are
+    /// registered directly against this `Mux` from the background thread
+    /// once available. If `pending_default` is set, that domain also
+    /// becomes the mux default domain as soon as it is discovered -- but
+    /// only if the default domain hasn't changed since this call, so an
+    /// intentional later choice (eg. `wezterm connect`/`wezterm ssh`
+    /// setting their own default) isn't clobbered once discovery finally
+    /// finishes; see `FinishDomainDiscoveryOnDrop`.
+    ///
+    /// A second call while discovery is already in progress does not start
+    /// a redundant discovery thread (the caller is expected to gate this
+    /// on there being nothing left to discover; see
+    /// `update_mux_domains_impl`); it always replaces whatever
+    /// `pending_default` the in-flight discovery was going to apply --
+    /// including with `None` -- so a config reload's updated default
+    /// domain (or its explicit choice to no longer want one) isn't
+    /// silently overridden by a stale value from before the reload once
+    /// the first discovery finishes.
+    ///
+    /// Precondition if `pending_default` is used: this `Mux` should
+    /// already have *some* default domain set before calling this (every
+    /// production caller does, seeding one into `Mux::new` before
+    /// `update_mux_domains` ever runs). If it doesn't,
+    /// `FinishDomainDiscoveryOnDrop`'s "the default hasn't changed since
+    /// this call" check compares against `None`; if `discover` finds any
+    /// domain, `add_domain` auto-assigns the first one as the default
+    /// (its own, unrelated fallback for "no default yet"), which then
+    /// reads as "the default changed" and suppresses applying
+    /// `pending_default` -- leaving an arbitrary discovered domain as the
+    /// default instead of the one actually requested.
+    pub fn begin_domain_discovery(
+        self: &Arc<Self>,
+        discover: impl FnOnce() -> anyhow::Result<Vec<Arc<dyn Domain>>> + Send + 'static,
+        pending_default: Option<String>,
+    ) {
+        self.begin_domain_discovery_with_default_filter(discover, pending_default, |_| true)
+    }
+
+    /// Like `begin_domain_discovery`, but `accepts_as_default` gets a say
+    /// in whether the domain `pending_default` names is actually
+    /// acceptable to apply as the mux default once discovery finds it --
+    /// eg. so a standalone mux-server caller can keep enforcing "a client
+    /// domain can't be the mux-server default", the same invariant it
+    /// already enforces synchronously elsewhere, even when that domain is
+    /// only found asynchronously. See `FinishDomainDiscoveryOnDrop`.
+    ///
+    /// `accepts_as_default` is invoked from three places, all while holding
+    /// `domain_discovery`'s lock *and* `default_domain`'s write lock, and
+    /// all wrapping the call in `catch_unwind` so a panic in it can't
+    /// strand the state machine or unwind into a config-reload task:
+    ///
+    /// 1. `FinishDomainDiscoveryOnDrop`'s `Drop` impl, when a background
+    ///    run finishes and applies its `pending_default`;
+    /// 2. the `Done` shortcut in this function, when a previous run already
+    ///    registered the requested domain and no new run is needed;
+    /// 3. `adopt_orphaned_discovery`, when a superseded run turns out to be
+    ///    the only one that ever produced a result. Note that the predicate
+    ///    invoked there is the one from the *most recent* call to this
+    ///    function, not the one passed alongside the run being adopted --
+    ///    it is applied together with that call's `pending_default`, and the
+    ///    two have to agree on which config they came from. See
+    ///    `domain_discovery_latest_default`.
+    ///
+    /// In all three cases it must **not** call back into `Mux`'s
+    /// domain-discovery API (`begin_domain_discovery*`,
+    /// `cancel_domain_discovery_and_replace`, `await_domain_discovery*`,
+    /// etc.), nor take `default_domain`'s lock (eg. via
+    /// `set_default_domain`/`default_domain()`) -- either would deadlock.
+    /// Every current caller passes a trivial predicate (`|_| true`, or a
+    /// plain `downcast`/type check) that satisfies this; keep it that way.
+    pub fn begin_domain_discovery_with_default_filter(
+        self: &Arc<Self>,
+        discover: impl FnOnce() -> anyhow::Result<Vec<Arc<dyn Domain>>> + Send + 'static,
+        pending_default: Option<String>,
+        accepts_as_default: impl Fn(&Arc<dyn Domain>) -> bool + Send + Sync + 'static,
+    ) {
+        let generation;
+        let cancel_epoch_at_start;
+        let accepts_as_default: Arc<dyn Fn(&Arc<dyn Domain>) -> bool + Send + Sync> =
+            Arc::new(accepts_as_default);
+        let mut stuck_wakers: Vec<Waker> = vec![];
+        {
+            let mut state = self.domain_discovery.lock();
+            // Snapshotted *after* acquiring `domain_discovery`'s lock
+            // (rather than before it) so it's consistent with everything
+            // else decided under that lock below. `domain_discovery` is
+            // always the outer lock relative to `default_domain` in this
+            // file (see eg. the `Done`-shortcut branch a few lines down,
+            // which takes `default_domain`'s write lock while still
+            // holding this one), so nesting a `default_domain.read()`
+            // snapshot inside an already-held `domain_discovery` lock here
+            // follows that same established order. Taking the snapshot
+            // before acquiring `domain_discovery` would leave a gap in
+            // which a different in-flight run's `FinishDomainDiscoveryOnDrop`
+            // could apply its own `pending_default` and transition to
+            // `Done`, making this snapshot stale relative to what it's
+            // about to be compared against below.
+            let default_domain_id_at_start =
+                self.default_domain.read().as_ref().map(|d| d.domain_id());
+            // Record this call as the latest word on what should be applied
+            // as the default, unconditionally and before any of the
+            // branching below: `adopt_orphaned_discovery` reads this slot
+            // instead of values captured when the adopting run was spawned,
+            // so a reload landing while a run is stuck updates what a late
+            // adoption will apply even though it can't reach into the
+            // already-running thread. (Written under `domain_discovery`'s
+            // lock so it can't interleave against another `begin_*` call's
+            // state transition; its own lock is a leaf, see the field.)
+            *self.domain_discovery_latest_default.lock() = Some(DomainDiscoveryDefaultRequest {
+                pending_default: pending_default.clone(),
+                default_domain_id_at_start,
+                accepts_as_default: Arc::clone(&accepts_as_default),
+            });
+            if let DomainDiscoveryState::InProgress {
+                pending_default: in_flight_pending_default,
+                default_domain_id_at_start: in_flight_default_domain_id_at_start,
+                accepts_as_default: in_flight_accepts_as_default,
+                wakers: in_flight_wakers,
+                started_at,
+                ..
+            } = &mut *state
+            {
+                if started_at.elapsed() < DOMAIN_DISCOVERY_STUCK_THRESHOLD {
+                    // Refresh `accepts_as_default` together with the other
+                    // fields on every repeat call, following the same pattern as
+                    // `pending_default` and `default_domain_id_at_start`.
+                    *in_flight_pending_default = pending_default;
+                    *in_flight_default_domain_id_at_start = default_domain_id_at_start;
+                    *in_flight_accepts_as_default = accepts_as_default;
+                    return;
+                }
+                // This run has been `InProgress` for longer than
+                // `DOMAIN_DISCOVERY_STUCK_THRESHOLD` without finishing:
+                // treat it as permanently stuck (see that constant's doc
+                // comment for why) and fall through to supersede it with a
+                // fresh run below, instead of the usual no-op refresh.
+                //
+                // Its own discovery thread, if it's still alive, keeps
+                // running in the background and is simply abandoned here,
+                // not cancelled -- there's no way to cancel a blocked
+                // `wsl.exe` subprocess call from here. `add_discovered_domain`
+                // and `FinishDomainDiscoveryOnDrop` both compare against
+                // the *current* generation under this same lock before
+                // doing anything, so whatever that stale thread eventually
+                // produces (including much later, once its `wsl.exe`
+                // finally returns) is silently discarded as superseded the
+                // moment we bump the generation below -- it can never
+                // clobber the fresh run's state or double-register a
+                // domain.
+                log::warn!(
+                    "background WSL domain discovery has been running for over {:?} \
+                     without finishing; treating it as stuck and starting a new attempt",
+                    DOMAIN_DISCOVERY_STUCK_THRESHOLD
+                );
+                stuck_wakers = std::mem::take(in_flight_wakers)
+                    .drain()
+                    .map(|(_, w)| w)
+                    .collect();
+            }
+
+            if matches!(&*state, DomainDiscoveryState::Done { .. }) {
+                // A previous run already completed successfully;
+                // `discover` is expected to be idempotent/cached at the
+                // caller's level (eg. config::WslDomain::default_domains()
+                // memoizes its own result -- see config/src/wsl.rs), so a
+                // domain this run would find has *already* been
+                // registered by the prior run. If there's nothing to
+                // apply as a default, or the requested default is
+                // already known, there's nothing a fresh discovery
+                // thread could add: skip spawning one entirely, rather
+                // than doing that on every single config reload just to
+                // re-derive the same answer.
+                match &pending_default {
+                    None => return,
+                    Some(name) => {
+                        if let Some(dom) = self.get_domain_by_name(name) {
+                            // Same "hasn't the default changed since we
+                            // decided to apply this" guard as
+                            // FinishDomainDiscoveryOnDrop, for the same
+                            // reason: an intentional default set between
+                            // this call starting and reaching this point
+                            // (eg. `wezterm connect` picking its own
+                            // domain) must not be clobbered. Compare and
+                            // set under one write guard (not a `.read()`
+                            // followed by a separately-acquired
+                            // `.write()` inside `set_default_domain`), so
+                            // a concurrent writer can't land in the gap --
+                            // same fix as `FinishDomainDiscoveryOnDrop`.
+                            let mut default = self.default_domain.write();
+                            let current_default_domain_id = default.as_ref().map(|d| d.domain_id());
+                            if current_default_domain_id == default_domain_id_at_start {
+                                // Same `catch_unwind` treatment as the
+                                // `Drop` path: this is caller-supplied
+                                // code running under two of our locks
+                                // (`domain_discovery` *and*
+                                // `default_domain`), and a panic escaping
+                                // here would unwind through
+                                // `update_mux_domains` -- on the GUI, that
+                                // is the main-thread executor. parking_lot
+                                // locks don't poison, so not applying the
+                                // default is the whole of the damage.
+                                let accepted =
+                                    std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                        (*accepts_as_default)(&dom)
+                                    }));
+                                match accepted {
+                                    Ok(true) => {
+                                        *default = Some(Arc::clone(&dom));
+                                    }
+                                    Ok(false) => {}
+                                    Err(_) => {
+                                        log::error!(
+                                            "panic while deciding whether \"{name}\" is an \
+                                             acceptable default domain; not applying it"
+                                        );
+                                    }
+                                }
+                            }
+                            drop(default);
+                            return;
+                        }
+                        // Domain not found. Check if this name was already
+                        // looked for by a previous run and not found.
+                        // If so, skip spawning a new thread that will
+                        // just re-derive the same "not found" answer.
+                        if let DomainDiscoveryState::Done {
+                            not_found_pending_default,
+                            ..
+                        } = &*state
+                        {
+                            if *not_found_pending_default == Some(name.clone()) {
+                                return;
+                            }
+                        }
+                        // Not found yet: fall through and actually
+                        // (re-)run discovery, in case this is a
+                        // genuinely new name discovery hasn't seen
+                        // before.
+                    }
+                }
+            }
+
+            // Only allocated (and only ever compared) while holding this
+            // same lock, so two runs can never share a generation and a
+            // run can never be started with a generation that's already
+            // stale by the time it's published.
+            generation = self
+                .next_domain_discovery_generation
+                .fetch_add(1, Ordering::SeqCst);
+            // Read under the same lock, for the same reason: it's only
+            // meaningful compared against a later read that is also taken
+            // under it. See `adopt_orphaned_discovery`.
+            cancel_epoch_at_start = self.domain_discovery_cancel_epoch.load(Ordering::SeqCst);
+            *state = DomainDiscoveryState::InProgress {
+                generation,
+                pending_default,
+                default_domain_id_at_start,
+                wakers: HashMap::new(),
+                next_waiter_id: 0,
+                accepts_as_default,
+                started_at: Instant::now(),
+            };
+        }
+
+        // Wake anything that was still waiting on a stuck run we just
+        // superseded, after releasing the lock -- matching the
+        // `FinishDomainDiscoveryOnDrop::drop` / `cancel_domain_discovery_and_replace`
+        // convention elsewhere in this file. A no-op (empty vec, harmless
+        // `notify_all` on a condvar nothing is parked on) on the far more
+        // common path where the previous state wasn't a stuck `InProgress`.
+        self.domain_discovery_cond.notify_all();
+        for waker in stuck_wakers {
+            waker.wake();
+        }
+
+        let mux = Arc::clone(self);
+        if std::thread::Builder::new()
+            .name("mux-domain-discovery".to_string())
+            .spawn(move || {
+                // Run the discover closure and capture the result
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| discover()));
+
+                let result = match result {
+                    Ok(domains) => domains,
+                    Err(_) => {
+                        // Panic in discover: treat as error
+                        Err(anyhow!("discover closure panicked"))
+                    }
+                };
+
+                // If discover succeeded, register the domains.
+                // Continue on AlreadyPresent, only abort on Superseded.
+                //
+                // Registration runs *before* the finish guard exists and
+                // under its own `catch_unwind`, so that a panic escaping
+                // any `Domain` method reached from here (`domain_name()`
+                // and friends -- these are trait objects, so this crate
+                // doesn't control what they do) is folded into `result`
+                // as an error rather than unwinding past a guard that's
+                // already holding `Ok(..)`. Getting that wrong is not
+                // just untidy: the guard would publish `Done` despite the
+                // registration having only partially happened, and a
+                // later config reload carrying `pending_default: None`
+                // would then take the `Done` shortcut and never retry
+                // discovery for the rest of the process's life. Failing
+                // to `NotStarted` instead makes that reload re-run it,
+                // which is safe to repeat -- `add_discovered_domain`
+                // reports the already-registered ones as `AlreadyPresent`,
+                // which this loop deliberately tolerates.
+                let result = match result {
+                    Err(err) => Err(err),
+                    Ok(domains) => {
+                        // `false` means "superseded, stop registering",
+                        // distinct from a panic (`Err`) and from running
+                        // to completion (`true`).
+                        let registered =
+                            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                                for domain in &domains {
+                                    match mux.add_discovered_domain(generation, domain) {
+                                        AddDiscoveredDomainOutcome::Inserted => {}
+                                        AddDiscoveredDomainOutcome::AlreadyPresent => {
+                                            // Name collision is expected and should continue.
+                                        }
+                                        AddDiscoveredDomainOutcome::Superseded => {
+                                            // Superseded (cancelled, or a newer discovery run
+                                            // started): generation only ever increases, so
+                                            // once this run is stale it can't become current
+                                            // again, and none of the remaining domains should
+                                            // be registered either.
+                                            return false;
+                                        }
+                                    }
+                                }
+                                true
+                            }));
+                        match registered {
+                            Ok(true) => Ok(domains),
+                            Ok(false) => {
+                                // Superseded: skip the finish guard
+                                // entirely. Constructing it would be a
+                                // no-op anyway (it compares generations
+                                // and finds itself stale), so returning
+                                // here is equivalent and clearer.
+                                //
+                                // First, though: `discover` has by now
+                                // published this list to the config-level
+                                // cache, which no generation check governs.
+                                // If nothing else is going to register it,
+                                // dropping it here would leave that cache
+                                // describing domains the mux doesn't have.
+                                // `adopt_orphaned_discovery` decides whether
+                                // this is that case; it is a no-op otherwise.
+                                mux.adopt_orphaned_discovery(cancel_epoch_at_start, &domains);
+                                return;
+                            }
+                            Err(_) => {
+                                log::error!(
+                                    "panic while registering discovered domains; \
+                                     treating this discovery run as failed so a later \
+                                     config reload retries it"
+                                );
+                                Err(anyhow!("panic while registering discovered domains"))
+                            }
+                        }
+                    }
+                };
+
+                // Guarantees the state transitions and wakes any
+                // waiters even if `discover()` panics (eg. a malformed
+                // `wsl -l -v` output tripping an indexing panic in
+                // parse_wsl_distro_list). Without this, a panic here
+                // would leave `InProgress` in place forever, and every
+                // future domain resolution would silently pay the full
+                // DOMAIN_DISCOVERY_TIMEOUT for the rest of the process's
+                // life.
+                let finish_on_drop = FinishDomainDiscoveryOnDrop {
+                    mux: Arc::clone(&mux),
+                    generation,
+                    result: Some(result),
+                };
+
+                // Keep the guard alive until the end of the scope
+                let _ = finish_on_drop;
+            })
+            .is_err()
+        {
+            // Couldn't spawn the discovery thread: this run never
+            // happened, so reset to `NotStarted` (only if this is still
+            // the run we just published -- an extremely unlikely, but
+            // possible, race against a concurrent cancel/newer `begin`
+            // landing in between) rather than `Done`, so a later call
+            // retries for real instead of being fooled into thinking
+            // discovery already completed. See `cancel_domain_discovery`'s
+            // doc comment for why `Done` and "nothing was ever discovered"
+            // must stay distinguishable.
+            let mut state = self.domain_discovery.lock();
+            let is_current = matches!(
+                &*state,
+                DomainDiscoveryState::InProgress { generation: g, .. } if *g == generation
+            );
+            let mut wakers_to_wake: Vec<Waker> = vec![];
+            if is_current {
+                // Wake any wakers that may have been registered (now a HashMap)
+                if let DomainDiscoveryState::InProgress { wakers, .. } = &mut *state {
+                    wakers_to_wake = wakers.drain().map(|(_, w)| w).collect();
+                }
+                *state = DomainDiscoveryState::NotStarted;
+            }
+            drop(state);
+            self.domain_discovery_cond.notify_all();
+
+            // Wake all async waiters *after* releasing the lock, matching
+            // `FinishDomainDiscoveryOnDrop::drop` and
+            // `cancel_domain_discovery_and_replace`. Waking under the lock
+            // happens to be safe with the executor actually in use
+            // (`async_task` never polls or drops the woken future inline on
+            // this thread, so `DomainDiscoveryWaitFuture::drop` can't reenter
+            // `domain_discovery`), but that's an implicit dependency on an
+            // executor implementation detail, and it costs nothing to not
+            // depend on it.
+            for waker in wakers_to_wake {
+                waker.wake();
+            }
+        }
+    }
+
+    /// Atomically cancels in-flight discovery, runs the replacement
+    /// registration closure while still holding the lock, then publishes.
+    /// This closes the TOCTOU race where a new waiter arriving between
+    /// `cancel_domain_discovery` and `notify_cancelled_domain_discovery_waiters`
+    /// would see `NotStarted` and do its lookup before replacement domains are
+    /// registered.
+    ///
+    /// The `register_replacements` closure runs synchronously under the
+    /// `domain_discovery` lock. It must only do cheap, in-memory work like
+    /// calling `mux.add_domain` for already-known domain objects (no I/O,
+    /// no subprocess calls), and must NOT call back into `Mux`'s discovery API
+    /// (would deadlock on this same lock).
+    ///
+    /// Cancellation semantics are identical to `cancel_domain_discovery`,
+    /// including leaving an already-`Done` state alone: see that function's
+    /// doc comment for why `Done` and "cancelled without ever completing"
+    /// must stay distinguishable.
+    pub fn cancel_domain_discovery_and_replace(
+        &self,
+        register_replacements: impl FnOnce() -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        // Guarantees the "publish" half of this function -- notifying the
+        // condvar and waking the async waiters -- runs on *every* exit
+        // path, including a panic escaping the caller-supplied
+        // `register_replacements` closure below. Without it such a panic
+        // unwinds straight past the notify/wake calls while the wakers
+        // this function has already drained out of the state get dropped,
+        // leaving async waiters parked with their registration gone and
+        // nothing left that could ever wake them: `Pending` for the rest
+        // of the process's life. (Sync waiters survive it, but only
+        // because `await_domain_discovery`/`_unbounded` re-check on a
+        // timer.) The production closure is trivial today, but this is a
+        // public API taking an arbitrary caller closure, and the same
+        // hazard on the discovery-completion path is already handled the
+        // same way by `FinishDomainDiscoveryOnDrop`.
+        //
+        // Declared *before* the state lock below so that it drops *after*
+        // it: locals drop in reverse declaration order, which keeps the
+        // "never wake while holding `domain_discovery`" rule the rest of
+        // this file follows, on the unwind path as well as the normal one.
+        struct NotifyDiscoveryWaitersOnDrop<'a> {
+            mux: &'a Mux,
+            wakers: Vec<Waker>,
+        }
+        impl Drop for NotifyDiscoveryWaitersOnDrop<'_> {
+            fn drop(&mut self) {
+                self.mux.domain_discovery_cond.notify_all();
+                for waker in std::mem::take(&mut self.wakers) {
+                    waker.wake();
+                }
+            }
+        }
+        let mut notify_on_drop = NotifyDiscoveryWaitersOnDrop {
+            mux: self,
+            wakers: vec![],
+        };
+
+        let mut state = self.domain_discovery.lock();
+        // Bumped under the lock, unconditionally: see the field's doc comment.
+        // A superseded-but-successful run that observes a changed epoch must
+        // not adopt its result, because this config no longer wants
+        // auto-discovered domains at all.
+        self.domain_discovery_cancel_epoch
+            .fetch_add(1, Ordering::SeqCst);
+        if let DomainDiscoveryState::InProgress { wakers, .. } = &mut *state {
+            notify_on_drop.wakers = std::mem::take(wakers).drain().map(|(_, w)| w).collect();
+        }
+        // Only an in-flight run gets cancelled. Clobbering `Done` here
+        // would throw away the knowledge that a run already completed, so
+        // a later reload back to auto-discovery would pointlessly spawn a
+        // fresh discovery thread instead of taking `begin_domain_discovery`'s
+        // already-completed shortcut -- and it would diverge from
+        // `cancel_domain_discovery`, which this is otherwise supposed to be
+        // a drop-in, race-free replacement for.
+        if matches!(&*state, DomainDiscoveryState::InProgress { .. }) {
+            *state = DomainDiscoveryState::NotStarted;
+        }
+
+        // Run replacement registration while STILL HOLDING domain_discovery's
+        // lock. This is the crux of the fix: a new waiter (sync via
+        // await_domain_discovery/_unbounded, or async via
+        // DomainDiscoveryWaitFuture::poll) has to acquire this same lock
+        // before it can inspect state at all, so it can't observe the
+        // intermediate "cancelled to NotStarted, but replacements not
+        // registered yet" window -- it simply blocks here until we're done
+        // and release the lock below. `register_replacements` must stay
+        // fast, in-memory work (see the doc comment above) precisely so
+        // that this blocking window stays short, unlike the `wsl.exe`
+        // subprocess call this lock is deliberately never held across.
+        let result = register_replacements();
+
+        // Releases the lock before `notify_on_drop` fires, same as the
+        // unwind path gets for free from drop order.
+        drop(state);
+        result
+    }
+
+    /// Marks any in-progress background domain discovery as no longer
+    /// relevant and immediately unblocks anything waiting on it, resetting
+    /// back to `NotStarted` so a later `begin_domain_discovery` call
+    /// starts a fresh, real discovery run rather than being fooled into
+    /// thinking one already completed. A no-op if nothing is in flight --
+    /// in particular, this deliberately does *not* touch an already-`Done`
+    /// state: if discovery genuinely completed successfully before, the
+    /// domains it found are still registered in the mux (domains are
+    /// never removed on reload), so there is nothing to "cancel" or lose
+    /// by leaving `Done` as `Done`.
+    ///
+    /// Resetting to `NotStarted` here (rather than the `Done` this used to
+    /// transition to) is what fixes a real bug: `Done` and "cancelled
+    /// without ever completing" used to be indistinguishable, so a config
+    /// that started with explicit `wsl_domains` (calling this from
+    /// `NotStarted`, which used to unconditionally land on `Done`), or
+    /// that cancelled a still-running auto-discovery mid-flight, and later
+    /// reloaded back to auto-discovery, would see `Done` and skip
+    /// discovery entirely via `begin_domain_discovery`'s
+    /// already-completed shortcut -- even though nothing had actually
+    /// ever been discovered, silently losing the auto-discovered domains
+    /// until the process restarted.
+    ///
+    /// Called when a config reload moves to an explicit domain list that
+    /// no longer wants discovery: from that point on, a still-running
+    /// discovery thread from before the reload must not be allowed to
+    /// register extra domains or override the default that the explicit
+    /// configuration is about to set synchronously. The discovery thread
+    /// itself, if any, keeps running to completion (it can't be killed
+    /// mid-subprocess-call), but its results are discarded: resetting
+    /// state away from its `InProgress { generation, .. }` here is what
+    /// makes that thread's captured generation stop matching --
+    /// `add_discovered_domain` and `FinishDomainDiscoveryOnDrop` both
+    /// require the state to still be `InProgress` with their generation,
+    /// which is no longer true once this runs.
+    ///
+    /// Deliberately **not** `pub`: `cancel_domain_discovery_and_replace` is
+    /// the supported entry point, and it exists precisely because this
+    /// two-phase split is easy to misuse. The hazard can't be designed out
+    /// while the two halves stay separate -- a caller that drops the
+    /// returned `Waker`s, returns early, or panics between the two calls
+    /// silently parks every async waiter forever, and `#[must_use]` only
+    /// produces a warning. Restricting visibility instead of papering over
+    /// it with more documentation keeps the footgun out of this crate's
+    /// public surface; the tests below still exercise the split directly,
+    /// since that is what `cancel_domain_discovery_and_replace` is built
+    /// on top of.
+    ///
+    /// Returns the list of async waiters (`Waker`s) that were waiting on
+    /// this discovery. Deliberately does **not** wake anything itself --
+    /// neither the returned `Waker`s nor the synchronous `Condvar` that
+    /// `await_domain_discovery`/`await_domain_discovery_unbounded` block
+    /// on (both loop on the state, so notifying either kind of waiter here
+    /// would let it observe "no longer `InProgress`" and return before a
+    /// caller that's about to register replacement domains -- eg. explicit
+    /// `wsl_domains` -- has actually done so, reopening the exact race this
+    /// two-phase cancel/publish split exists to close). Call
+    /// `notify_cancelled_domain_discovery_waiters` once any replacement
+    /// domains are visible, passing the `Waker`s returned here, so every
+    /// waiter -- sync or async -- observes either the pre-cancellation
+    /// state or the fully-registered replacement, never an in-between one.
+    ///
+    /// Dropping the returned `Waker`s instead of passing them on is a
+    /// silent hang: their slots have already been removed from the state,
+    /// so nothing else will ever wake those futures. Hence `#[must_use]`.
+    #[must_use = "the returned Wakers must be passed to \
+                  notify_cancelled_domain_discovery_waiters, or the futures \
+                  waiting on this discovery will never be woken again"]
+    pub(crate) fn cancel_domain_discovery(&self) -> Vec<Waker> {
+        let mut state = self.domain_discovery.lock();
+        // Same unconditional bump as `cancel_domain_discovery_and_replace`;
+        // see `domain_discovery_cancel_epoch`'s doc comment.
+        self.domain_discovery_cancel_epoch
+            .fetch_add(1, Ordering::SeqCst);
+        if matches!(&*state, DomainDiscoveryState::InProgress { .. }) {
+            let wakers = if let DomainDiscoveryState::InProgress { wakers, .. } = &mut *state {
+                std::mem::take(wakers).drain().map(|(_, w)| w).collect()
+            } else {
+                vec![]
+            };
+            *state = DomainDiscoveryState::NotStarted;
+            wakers
+        } else {
+            vec![]
+        }
+    }
+
+    /// Publishes a cancellation performed by `cancel_domain_discovery`:
+    /// wakes the synchronous `Condvar` waiters and the given async
+    /// `Waker`s (as returned by that call). Call this only once any
+    /// replacement domains the cancellation was making way for are already
+    /// registered -- see `cancel_domain_discovery`'s doc comment for why
+    /// the two are split. A no-op (beyond the harmless `notify_all` with no
+    /// parked waiters) if nothing was cancelled.
+    ///
+    /// Not `pub` for the same reason as its counterpart: only useful as the
+    /// second half of that split, which isn't part of this crate's public
+    /// surface.
+    pub(crate) fn notify_cancelled_domain_discovery_waiters(&self, wakers: Vec<Waker>) {
+        self.domain_discovery_cond.notify_all();
+        for waker in wakers {
+            waker.wake();
+        }
+    }
+
+    /// Blocks the calling thread until background domain discovery (if
+    /// any is in progress) has finished, or `timeout` elapses, whichever
+    /// is sooner. A no-op if discovery hasn't started or has already
+    /// completed.
+    pub fn await_domain_discovery(&self, timeout: Duration) {
+        let deadline = Instant::now() + timeout;
+        let mut state = self.domain_discovery.lock();
+        while matches!(*state, DomainDiscoveryState::InProgress { .. }) {
+            let remaining = match deadline.checked_duration_since(Instant::now()) {
+                Some(remaining) => remaining,
+                None => return,
+            };
+            let result = self.domain_discovery_cond.wait_for(&mut state, remaining);
+            if result.timed_out() {
+                return;
+            }
+        }
+    }
+
+    /// Like `await_domain_discovery`, but with no timeout: blocks until
+    /// any in-progress background domain discovery finishes (a no-op if
+    /// none is in progress). Used only where the caller has already
+    /// committed to needing the outcome of discovery -- namely, resolving
+    /// a `default_domain`/`default_mux_server_domain` that was explicitly
+    /// configured to name a domain discovery hasn't found yet
+    /// (`pending_default` is set). An arbitrary timeout on that specific
+    /// path would incorrectly treat "discovery is still slow" as "the
+    /// domain doesn't exist" and fail GUI/mux-server startup outright;
+    /// before background discovery existed, this same case simply blocked
+    /// for as long as the (then-synchronous) discovery took, with no
+    /// cutoff, so this preserves that guarantee for the narrow case that
+    /// actually needs it while every other domain resolution keeps the
+    /// bounded wait.
+    pub fn await_domain_discovery_unbounded(&self) {
+        // How often this re-checks and, if still waiting, logs again.
+        // "Unbounded" describes the overall wait (no deadline after which
+        // this gives up), not this polling granularity: waking up
+        // periodically instead of parking on a single indefinite
+        // `Condvar::wait` costs nothing observable (the loop just goes
+        // straight back to sleep if the state hasn't changed) and turns a
+        // stuck wait from "silent forever" into "logged every 30s", which
+        // matters most in exactly the case `DOMAIN_DISCOVERY_STUCK_THRESHOLD`
+        // exists for: a genuinely hung `wsl.exe` that this same caller may
+        // itself never resolve without an external event (eg. a config
+        // reload) triggering the mux-level supersede.
+        const LOG_INTERVAL: Duration = Duration::from_secs(30);
+        let mut state = self.domain_discovery.lock();
+        let started_waiting = Instant::now();
+        let mut logged = false;
+        while matches!(*state, DomainDiscoveryState::InProgress { .. }) {
+            // Only reached when discovery is genuinely still in progress
+            // and we're about to actually block on it, not when this call
+            // is a no-op (`NotStarted`/`Done`). No deadline on this wait
+            // -- see the doc comment above -- so this periodic log is the
+            // only signal a caller gets that it's stuck here rather than
+            // merely slow.
+            if !logged {
+                log::info!("waiting for WSL domain discovery to finish (unbounded)");
+            } else {
+                log::info!(
+                    "still waiting for WSL domain discovery to finish (unbounded), {:?} elapsed",
+                    started_waiting.elapsed()
+                );
+            }
+            logged = true;
+            self.domain_discovery_cond
+                .wait_for(&mut state, LOG_INTERVAL);
+        }
+    }
+
+    /// Async-friendly counterpart to `await_domain_discovery`: resolves
+    /// once background domain discovery (if any is in progress) finishes,
+    /// or `timeout` elapses, without blocking the calling thread while it
+    /// waits. `await_domain_discovery`/`await_domain_discovery_unbounded`
+    /// park the *calling* thread on a condvar, which is fine for genuinely
+    /// synchronous callers (Lua API functions, `setup_mux` before the GUI
+    /// event loop starts) but wrong to `.await` from an `async fn` running
+    /// on the single-threaded main-thread executor (`Mux::split_pane`,
+    /// `Mux::spawn_tab_or_window`): polling a blocking wait there would
+    /// freeze that whole executor -- no repaints, no input, no other
+    /// spawns -- for the entire wait, unlike a real `.await` point, which
+    /// lets the executor run other work while this is pending.
+    ///
+    /// Returns a `DomainDiscoveryWaitFuture`, which registers its waker
+    /// directly in `DomainDiscoveryState` rather than parking a thread per
+    /// waiter, and which carries its own timer so the timeout is part of the
+    /// future itself instead of a second wait layered on top of it.
+    pub fn await_domain_discovery_async(
+        self: &Arc<Self>,
+        timeout: Duration,
+    ) -> DomainDiscoveryWaitFuture {
+        DomainDiscoveryWaitFuture::new(Arc::clone(self), Some(timeout))
+    }
+
+    /// Async-friendly counterpart to `await_domain_discovery_unbounded`;
+    /// see `await_domain_discovery_async` for why this doesn't just block
+    /// the calling thread directly.
+    pub fn await_domain_discovery_unbounded_async(self: &Arc<Self>) -> DomainDiscoveryWaitFuture {
+        DomainDiscoveryWaitFuture::new(Arc::clone(self), None)
+    }
+
+    /// Which flavor of discovery wait (if any) `await_domain_resolution_async`
+    /// needs for a given `resolve_spawn_tab_domain` target. Split out from
+    /// `await_domain_resolution_async` as a synchronous, thread/executor-free
+    /// decision so it can be unit tested directly, without needing the
+    /// global `promise::spawn` scheduler configured (as it would need to
+    /// be to actually drive `await_domain_discovery_async`'s `Task` to
+    /// completion in a test).
+    fn domain_resolution_wait_kind(
+        &self,
+        pane_id: Option<PaneId>,
+        domain: &SpawnTabDomain,
+    ) -> DomainResolutionWaitKind {
+        let is_discovery_in_progress = || {
+            matches!(
+                &*self.domain_discovery.lock(),
+                DomainDiscoveryState::InProgress { .. }
+            )
+        };
+        let needs_unbounded_wait_for_default = || {
+            matches!(
+                &*self.domain_discovery.lock(),
+                DomainDiscoveryState::InProgress {
+                    pending_default: Some(_),
+                    ..
+                }
+            )
+        };
+        match domain {
+            // Only worth spawning the async wait helper if discovery is
+            // actually in progress: if it's NotStarted or Done, there's
+            // nothing that could still register this name, and
+            // resolve_spawn_tab_domain will report "invalid domain"
+            // immediately either way.
+            SpawnTabDomain::DomainName(name)
+                if self.get_domain_by_name(name).is_none() && is_discovery_in_progress() =>
+            {
+                DomainResolutionWaitKind::Bounded
+            }
+            SpawnTabDomain::DefaultDomain if needs_unbounded_wait_for_default() => {
+                DomainResolutionWaitKind::Unbounded
+            }
+            SpawnTabDomain::CurrentPaneDomain
+                if pane_id.is_none() && needs_unbounded_wait_for_default() =>
+            {
+                DomainResolutionWaitKind::Unbounded
+            }
+            _ => DomainResolutionWaitKind::None,
+        }
+    }
+
+    /// Waits (asynchronously; see `await_domain_discovery_async`) for any
+    /// background domain discovery that resolving `domain` via
+    /// `resolve_spawn_tab_domain` would otherwise have to block on
+    /// synchronously. Intended to be called from `async fn` call sites
+    /// running on the main-thread executor (`split_pane`,
+    /// `spawn_tab_or_window`) *before* the synchronous
+    /// `resolve_spawn_tab_domain`, so that method's own (thread-blocking)
+    /// waits become no-ops by the time it's actually called: discovery
+    /// will already be resolved one way or the other. Mirrors the "should
+    /// I wait" conditions inside `resolve_spawn_tab_domain` and
+    /// `resolve_default_domain` -- a name not yet known, or a
+    /// `DefaultDomain`/pane-less-`CurrentPaneDomain` resolution while a
+    /// `pending_default` is still outstanding -- using the *unbounded*
+    /// async wait for the latter, matching `resolve_default_domain`'s own
+    /// no-arbitrary-cutoff guarantee. See `domain_resolution_wait_kind`
+    /// for the (separately tested) decision logic.
+    pub async fn await_domain_resolution_async(
+        self: &Arc<Self>,
+        pane_id: Option<PaneId>,
+        domain: &SpawnTabDomain,
+    ) {
+        match self.domain_resolution_wait_kind(pane_id, domain) {
+            DomainResolutionWaitKind::None => {}
+            DomainResolutionWaitKind::Bounded => {
+                let _ = self
+                    .await_domain_discovery_async(DOMAIN_DISCOVERY_TIMEOUT)
+                    .await;
+            }
+            DomainResolutionWaitKind::Unbounded => {
+                let _ = self.await_domain_discovery_unbounded_async().await;
+            }
+        }
     }
 
     pub fn set_mux(mux: &Arc<Mux>) {
@@ -1121,6 +2743,124 @@ impl Mux {
         *self.banner.write() = banner;
     }
 
+    /// Wait-free variant of resolve_default_domain for use after
+    /// an async pre-wait (await_domain_resolution_async). Does not block,
+    /// even if a brand new discovery run started in the gap - that's the
+    /// correct trade-off to avoid blocking the executor a second time.
+    /// Documented trade-off: if a genuinely new run would have found the
+    /// requested domain, this may report "not found" instead.
+    ///
+    /// `pub` for the same reason as `resolve_spawn_tab_domain_no_wait`
+    /// below: `async fn` call sites outside this crate that already did
+    /// their own `await_domain_resolution_async` pre-wait (the mux server's
+    /// startup, the `wezterm.mux` lua module) must not fall back to the
+    /// blocking `resolve_default_domain`, or they reintroduce exactly the
+    /// double-wait this was written to close.
+    pub fn resolve_default_domain_no_wait(&self) -> anyhow::Result<Arc<dyn Domain>> {
+        Ok(self.default_domain())
+    }
+
+    /// Wait-free variant of resolve_spawn_tab_domain for use after
+    /// an async pre-wait (await_domain_resolution_async). Does not block,
+    /// even if a brand new discovery run started in the gap - that's the
+    /// correct trade-off to avoid blocking the executor a second time.
+    /// Documented trade-off: if a genuinely new run would have found the
+    /// requested domain, this may report "not found" instead.
+    ///
+    /// `pub` (not just crate-internal) so that other `async fn` call
+    /// sites outside this crate that already do their own
+    /// `await_domain_resolution_async` pre-wait (eg. the GUI's `--domain`
+    /// startup handling in `wezterm-gui/src/main.rs`) can avoid the same
+    /// double-wait/TOCTOU this was written to close for `split_pane`/
+    /// `spawn_tab_or_window`.
+    pub fn resolve_spawn_tab_domain_no_wait(
+        &self,
+        pane_id: Option<PaneId>,
+        domain: &config::keyassignment::SpawnTabDomain,
+    ) -> anyhow::Result<Arc<dyn Domain>> {
+        let domain = match domain {
+            SpawnTabDomain::DefaultDomain => self.resolve_default_domain_no_wait()?,
+            SpawnTabDomain::CurrentPaneDomain => match pane_id {
+                Some(pane_id) => {
+                    let (pane_domain_id, _window_id, _tab_id) = self
+                        .resolve_pane_id(pane_id)
+                        .ok_or_else(|| anyhow!("pane_id {} invalid", pane_id))?;
+                    self.get_domain(pane_domain_id)
+                        .ok_or_else(|| anyhow!("domain id {} is invalid", pane_domain_id))?
+                }
+                None => self.resolve_default_domain_no_wait()?,
+            },
+            SpawnTabDomain::DomainId(domain_id) => self
+                .get_domain(*domain_id)
+                .ok_or_else(|| anyhow!("domain id {} is invalid", domain_id))?,
+            SpawnTabDomain::DomainName(name) => {
+                self.get_domain_by_name(&name).ok_or_else(|| {
+                    let names: Vec<String> = self
+                        .domains_by_name
+                        .read()
+                        .keys()
+                        .map(|name| format!("\"{name}\""))
+                        .collect();
+                    anyhow!(
+                        "domain name \"{name}\" is invalid. Possible names are {}.",
+                        names.join(", ")
+                    )
+                })?
+            }
+        };
+        Ok(domain)
+    }
+
+    /// Resolves the mux default domain, waiting for an in-progress
+    /// background domain discovery first if (and only if) that discovery
+    /// was started because the configured default domain name matched a
+    /// domain that wasn't known yet (see `pending_default` on
+    /// `DomainDiscoveryState`). This keeps the common case (default domain
+    /// already known, or discovery irrelevant to it) from ever blocking.
+    ///
+    /// Note: For async contexts, use `await_domain_resolution_async` before
+    /// calling this method to avoid double-waiting.
+    ///
+    /// **This blocks the calling thread**, potentially without bound, and
+    /// so must never be called synchronously from the GUI/main thread --
+    /// doing so reintroduces exactly the freeze that moving discovery off
+    /// the startup path was meant to eliminate. Such call sites should
+    /// `await_domain_resolution_async` and then use
+    /// `resolve_default_domain_no_wait`. As of this writing no production
+    /// call site outside this module calls this or
+    /// `resolve_spawn_tab_domain`; both are retained for external
+    /// consumers of the crate.
+    pub fn resolve_default_domain(&self) -> Arc<dyn Domain> {
+        let should_wait = matches!(
+            &*self.domain_discovery.lock(),
+            DomainDiscoveryState::InProgress {
+                pending_default: Some(_),
+                ..
+            }
+        );
+        if should_wait {
+            // The configured default domain names a domain that
+            // discovery hasn't found yet: wait for discovery to finish
+            // rather than a bounded timeout, since giving up early would
+            // mean silently falling back to the wrong domain (or, in
+            // wezterm-gui's case, failing startup outright) just because
+            // discovery was slower than an arbitrary cutoff. See
+            // `await_domain_discovery_unbounded`.
+            self.await_domain_discovery_unbounded();
+        }
+        self.default_domain()
+    }
+
+    /// Resolves a spawn tab domain, waiting for in-progress discovery
+    /// when needed. Callers in async contexts should use
+    /// `await_domain_resolution_async` before calling this method to avoid
+    /// double-waiting.
+    ///
+    /// **This blocks the calling thread** (bounded by
+    /// `DOMAIN_DISCOVERY_TIMEOUT` for a named domain, unbounded for
+    /// `DefaultDomain`), so the same GUI/main-thread caveat as
+    /// `resolve_default_domain` applies: use
+    /// `resolve_spawn_tab_domain_no_wait` there instead.
     pub fn resolve_spawn_tab_domain(
         &self,
         // TODO: disambiguate with TabId
@@ -1128,7 +2868,7 @@ impl Mux {
         domain: &config::keyassignment::SpawnTabDomain,
     ) -> anyhow::Result<Arc<dyn Domain>> {
         let domain = match domain {
-            SpawnTabDomain::DefaultDomain => self.default_domain(),
+            SpawnTabDomain::DefaultDomain => self.resolve_default_domain(),
             SpawnTabDomain::CurrentPaneDomain => match pane_id {
                 Some(pane_id) => {
                     let (pane_domain_id, _window_id, _tab_id) = self
@@ -1137,12 +2877,19 @@ impl Mux {
                     self.get_domain(pane_domain_id)
                         .expect("resolve_pane_id to give valid domain_id")
                 }
-                None => self.default_domain(),
+                None => self.resolve_default_domain(),
             },
             SpawnTabDomain::DomainId(domain_id) => self
                 .get_domain(*domain_id)
                 .ok_or_else(|| anyhow!("domain id {} is invalid", domain_id))?,
             SpawnTabDomain::DomainName(name) => {
+                if self.get_domain_by_name(name).is_none() {
+                    // Not found (yet): if a background domain discovery is
+                    // in flight, it may still register this domain, so
+                    // give it a bounded chance to do so before declaring
+                    // the name invalid.
+                    self.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+                }
                 self.get_domain_by_name(&name).ok_or_else(|| {
                     let names: Vec<String> = self
                         .domains_by_name
@@ -1194,7 +2941,7 @@ impl Mux {
     }
 
     pub async fn split_pane(
-        &self,
+        self: &Arc<Self>,
         // TODO: disambiguate with TabId
         pane_id: PaneId,
         request: SplitRequest,
@@ -1205,8 +2952,19 @@ impl Mux {
             .resolve_pane_id(pane_id)
             .ok_or_else(|| anyhow!("pane_id {} invalid", pane_id))?;
 
+        // Waits asynchronously (without blocking this executor) for any
+        // in-flight domain discovery that resolve_spawn_tab_domain below
+        // would otherwise have to block this thread on synchronously.
+        self.await_domain_resolution_async(Some(pane_id), &domain)
+            .await;
+
+        // Use wait-free variant after async pre-wait to avoid
+        // blocking the executor a second time if a brand new discovery run
+        // started in the gap. Trade-off: we may report "not found" for a
+        // domain that a genuinely new run would have found, but that's
+        // acceptable for not blocking the executor.
         let domain = self
-            .resolve_spawn_tab_domain(Some(pane_id), &domain)
+            .resolve_spawn_tab_domain_no_wait(Some(pane_id), &domain)
             .context("resolve_spawn_tab_domain")?;
 
         if domain.state() == DomainState::Detached {
@@ -1314,7 +3072,7 @@ impl Mux {
     }
 
     pub async fn spawn_tab_or_window(
-        &self,
+        self: &Arc<Self>,
         window_id: Option<WindowId>,
         domain: SpawnTabDomain,
         command: Option<CommandBuilder>,
@@ -1324,8 +3082,19 @@ impl Mux {
         workspace_for_new_window: String,
         window_position: Option<GuiPosition>,
     ) -> anyhow::Result<(Arc<Tab>, Arc<dyn Pane>, WindowId)> {
+        // Waits asynchronously (without blocking this executor) for any
+        // in-flight domain discovery that resolve_spawn_tab_domain below
+        // would otherwise have to block this thread on synchronously.
+        self.await_domain_resolution_async(current_pane_id, &domain)
+            .await;
+
+        // Use wait-free variant after async pre-wait to avoid
+        // blocking the executor a second time if a brand new discovery run
+        // started in the gap. Trade-off: we may report "not found" for a
+        // domain that a genuinely new run would have found, but that's
+        // acceptable for not blocking the executor.
         let domain = self
-            .resolve_spawn_tab_domain(current_pane_id, &domain)
+            .resolve_spawn_tab_domain_no_wait(current_pane_id, &domain)
             .context("resolve_spawn_tab_domain")?;
 
         let window_builder;
@@ -1471,5 +3240,1887 @@ impl wezterm_term::DownloadHandler for MuxDownloader {
                 data: Arc::new(data),
             });
         }
+    }
+}
+
+#[cfg(test)]
+mod domain_discovery_tests {
+    use super::*;
+    use domain::{alloc_domain_id, LocalDomain};
+
+    /// A freestanding `Mux` (not registered via `Mux::set_mux`), so these
+    /// tests don't share global state with each other or with anything
+    /// else that might call `Mux::get()`.
+    fn new_test_mux() -> Arc<Mux> {
+        Arc::new(Mux::new(None))
+    }
+
+    /// A cheap domain to seed as the initial mux default in tests that
+    /// need to distinguish "default changed because pending_default
+    /// fired" from "default was auto-assigned by `add_domain` because
+    /// there wasn't one yet" (`add_domain` assigns the first domain added
+    /// as the default if none is set), and also to stand in for whatever
+    /// `discover` closures in these tests pretend to have "discovered".
+    fn dummy_domain(name: &str) -> Arc<dyn Domain> {
+        Arc::new(LocalDomain::new(name).expect("LocalDomain::new is infallible in tests"))
+    }
+
+    /// Regression test for wezterm#7782: `begin_domain_discovery` must
+    /// hand the (potentially slow, `wsl.exe`-shaped) `discover` closure off
+    /// to a background thread and return immediately, rather than running
+    /// it inline. `discover` here blocks on a channel that the test never
+    /// closes until after the assertion, standing in for a `wsl.exe`
+    /// invocation that hasn't returned yet: if `begin_domain_discovery`
+    /// were still synchronous, this test would itself block past the
+    /// assertion.
+    #[test]
+    fn begin_domain_discovery_does_not_block_caller() {
+        let mux = new_test_mux();
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        let start = Instant::now();
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "begin_domain_discovery must return immediately, not wait for `discover` to finish"
+        );
+        drop(gate_tx);
+    }
+
+    /// Regression test for the race that moving discovery off the startup
+    /// path introduces: spawning directly into a domain by name
+    /// while discovery is still in flight must wait for that discovery
+    /// (bounded by DOMAIN_DISCOVERY_TIMEOUT) and succeed once it
+    /// completes, instead of immediately failing with "domain name is
+    /// invalid". Also covers that a `default_domain` naming a
+    /// not-yet-discovered domain gets applied once discovery finds it.
+    #[test]
+    fn resolve_spawn_tab_domain_waits_for_in_flight_discovery() {
+        // Seeded with a distinct default so that, below, `default_domain()`
+        // reading back "Discovered" can only be explained by the
+        // `pending_default` codepath actually firing -- not by
+        // `add_domain`'s "first domain becomes the default" fallback,
+        // which would make that assertion pass vacuously.
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                // Stands in for `wsl.exe -l -v` not having returned yet;
+                // released by the test below once resolution has had a
+                // chance to start waiting on it.
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("Discovered")])
+            },
+            Some("Discovered".to_string()),
+        );
+
+        // Keep the gate closed until this thread is about to resolve, so
+        // that in the common case the resolution really does start while
+        // discovery is still in flight -- which is the situation under
+        // test. It is a bias, not a guarantee: nothing stops the releaser
+        // from winning the handoff and letting discovery finish before
+        // `resolve_spawn_tab_domain` is even entered. That only ever makes
+        // this test *miss* a regression (a resolution that stopped waiting
+        // would then still find the domain), never fail spuriously, so the
+        // looseness is tolerable here; that a waiter really does block on
+        // an unfinished discovery is pinned down deterministically by
+        // `await_domain_discovery_respects_timeout` below, which holds its
+        // gate shut for the whole of the wait it measures.
+        let (start_tx, start_rx) = std::sync::mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            let _ = start_rx.recv();
+            let _ = gate_tx.send(());
+        });
+
+        let start = Instant::now();
+        let _ = start_tx.send(());
+        let resolved = mux
+            .resolve_spawn_tab_domain(None, &SpawnTabDomain::DomainName("Discovered".to_string()))
+            .expect("domain should be found once discovery completes");
+        let elapsed = start.elapsed();
+        assert_eq!(resolved.domain_name(), "Discovered");
+        assert!(
+            elapsed < DOMAIN_DISCOVERY_TIMEOUT,
+            "should resolve once discovery completes, not fall through to the timeout path"
+        );
+
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "Discovered",
+            "pending_default should be applied once the named domain is discovered"
+        );
+    }
+
+    /// `await_domain_discovery` must not wait past the requested timeout,
+    /// even if discovery never completes (e.g. a genuinely hung `wsl.exe`).
+    #[test]
+    fn await_domain_discovery_respects_timeout() {
+        let mux = new_test_mux();
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+        mux.begin_domain_discovery(
+            move || {
+                // Never released within this test, simulating a hung
+                // `wsl.exe`; kept alive until the end of the test function
+                // so `discover` stays blocked for the whole timeout window.
+                let _ = gate_rx.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+
+        let start = Instant::now();
+        mux.await_domain_discovery(Duration::from_millis(50));
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(50),
+            "must wait at least the requested timeout"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must not wait far past the requested timeout, got {:?}",
+            elapsed
+        );
+        drop(gate_tx);
+    }
+
+    /// Regression test: `DomainDiscoveryWaitFuture` must resolve to `false` at (or shortly
+    /// after) its deadline when driven by a *real* executor against a
+    /// permanently-stuck discovery run -- not just when a test manually
+    /// re-polls it in a loop (which `domain_discovery_wait_future_does_not_block_executor`
+    /// already does, and so cannot catch a missing independent timer wake
+    /// source). Uses `promise::spawn::block_on` (a real single-threaded
+    /// executor) to prove the future itself wakes its task at the
+    /// deadline, rather than relying on this test to keep polling it.
+    #[test]
+    fn domain_discovery_wait_future_bounded_wait_times_out_on_a_real_executor() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (_gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+        // `_gate_tx` is deliberately never sent to: this discovery run is
+        // permanently stuck, standing in for a hung `wsl.exe`.
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+
+        let future = mux.await_domain_discovery_async(Duration::from_millis(200));
+        let start = Instant::now();
+        let resolved = promise::spawn::block_on(future);
+        let elapsed = start.elapsed();
+
+        assert!(
+            !resolved,
+            "a bounded wait against a permanently-stuck discovery run must resolve to \
+             false (timed out), not hang forever waiting only for discovery completion"
+        );
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "must resolve at or shortly after its own deadline when driven by a real \
+             executor, not hang until this test's process exits; took {:?}",
+            elapsed
+        );
+    }
+
+    /// When no discovery is in flight at all (the common case: either
+    /// domains were configured explicitly, or discovery already
+    /// finished), resolving an unknown domain name must fail immediately,
+    /// exactly as before this change.
+    #[test]
+    fn resolve_spawn_tab_domain_reports_missing_domain_immediately_without_discovery() {
+        let mux = new_test_mux();
+
+        let start = Instant::now();
+        let err = mux
+            .resolve_spawn_tab_domain(None, &SpawnTabDomain::DomainName("nope".to_string()))
+            .err()
+            .expect("unknown domain name must be an error");
+        assert!(err.to_string().contains("nope"));
+        assert!(start.elapsed() < Duration::from_millis(200));
+    }
+
+    /// Regression test for a reload race: a config reload
+    /// landing while auto-discovery is still in flight, whose new choice
+    /// no longer wants a discovered default (`pending_default = None`),
+    /// must clear whatever `pending_default` an earlier
+    /// `begin_domain_discovery` call was going to apply -- not just ignore
+    /// the update because it's `None`. Otherwise the stale value wins once
+    /// the original discovery finishes, silently overriding the reload's
+    /// choice.
+    #[test]
+    fn begin_domain_discovery_repeat_call_with_none_clears_stale_pending_default() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("A")])
+            },
+            Some("A".to_string()),
+        );
+
+        // Simulates a reload landing mid-discovery that no longer wants a
+        // discovered default. Must not start a second discovery thread
+        // (the closure below must never run) since one is already in
+        // flight. Note: if it *did* run, `unreachable!` would panic on a
+        // detached background thread, which the test harness wouldn't
+        // observe as a failure by itself -- what actually catches a
+        // regression here is `gate_tx.send(...).expect(...)` below: if a
+        // second thread were spawned, both the (bad) second call
+        // resetting state and this test's own gate handling would no
+        // longer line up the way the assertions below expect, and/or the
+        // `expect` would fail because the first thread's `discover`
+        // never got a chance to consume this same `gate_rx`.
+        mux.begin_domain_discovery(
+            || unreachable!("must not start a second discovery thread while one is in flight"),
+            None,
+        );
+
+        gate_tx
+            .send(())
+            .expect("discovery thread should still be waiting on the gate");
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "dummy-default",
+            "the stale pending_default from the first call must not resurrect A"
+        );
+    }
+
+    /// Regression test: a repeat
+    /// `begin_domain_discovery` call landing while a run is already
+    /// `InProgress` must refresh *both* `pending_default` and the "did the
+    /// default change" baseline (`default_domain_id_at_start`) together --
+    /// not just `pending_default`, leaving the baseline pinned to whichever
+    /// call happened to be first to actually spawn the discovery thread.
+    ///
+    /// Scenario: discovery starts with default = "dummy-default"
+    /// (baseline captured then). Before it finishes, something sets an
+    /// intentional new default ("Explicit", eg. `wezterm connect`) and
+    /// *then* a repeat call asks discovery to apply "Discovered" once
+    /// found. From that repeat call's point of view, the default hasn't
+    /// changed since *it* asked -- it was already "Explicit" -- so once
+    /// discovery finds "Discovered" with nothing else having changed
+    /// in between, it must be applied. A stale baseline from the
+    /// original call would wrongly see "Explicit != dummy-default" as
+    /// "the default changed after all" and skip applying it.
+    #[test]
+    fn begin_domain_discovery_repeat_call_refreshes_default_baseline() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("Discovered")])
+            },
+            None,
+        );
+
+        // An intentional default change lands while discovery is still in
+        // flight -- eg. `wezterm connect`/`wezterm ssh` picking its own
+        // domain. This must not be clobbered later.
+        let explicit = dummy_domain("Explicit");
+        mux.set_default_domain(&explicit);
+
+        // A repeat call now asks discovery to apply "Discovered" once
+        // found. Its baseline must be "Explicit" (the default *now*, at
+        // this call), not "dummy-default" (the default when the first
+        // call started the still-running thread).
+        mux.begin_domain_discovery(
+            || unreachable!("must not start a second discovery thread while one is in flight"),
+            Some("Discovered".to_string()),
+        );
+
+        gate_tx
+            .send(())
+            .expect("discovery thread should still be waiting on the gate");
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "Discovered",
+            "nothing changed the default between the repeat call and discovery \
+             finishing, so pending_default must be applied -- a stale baseline \
+             from the original call would wrongly see this as a default change \
+             and skip it"
+        );
+    }
+
+    /// Regression test for a reload race: switching to an
+    /// explicitly configured domain list must invalidate any
+    /// auto-discovery still running from before the reload, so it can't
+    /// register extra domains or override the default the explicit
+    /// config is about to set, once it eventually finishes running its
+    /// (uninterruptible) `discover` closure.
+    #[test]
+    fn cancel_domain_discovery_unblocks_waiters_and_ignores_stale_results() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("Stale")])
+            },
+            Some("Stale".to_string()),
+        );
+
+        let start = Instant::now();
+        mux.notify_cancelled_domain_discovery_waiters(mux.cancel_domain_discovery());
+
+        // A waiter arriving right after cancellation (not one that was
+        // already parked beforehand -- see
+        // `cancel_domain_discovery_defers_sync_wakeup_until_notify_is_called`
+        // for that case) must not block at all: `cancel_domain_discovery`
+        // already flipped the state away from `InProgress` synchronously,
+        // so a fresh `await_domain_discovery_unbounded` call sees that on
+        // its very first check, before ever reaching the condvar wait --
+        // this doesn't depend on `notify_cancelled_domain_discovery_waiters`
+        // having been called, and this test deliberately never calls it.
+        mux.await_domain_discovery_unbounded();
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "a waiter arriving after cancel_domain_discovery must not block"
+        );
+
+        // Let the now-stale thread finish and give it plenty of time to
+        // run its (per-item generation-checked) loop and drop its finish
+        // guard. Polls repeatedly instead of a single fixed sleep: this
+        // fails immediately if the domain appears at any point in the
+        // window (a single point-in-time check after a fixed delay could
+        // still race and miss it), while a generous total window (rather
+        // than a short single sleep) keeps this from flaking under
+        // scheduler pressure on a loaded CI machine -- the tail work
+        // after `discover()` returns is a couple of uncontended lock
+        // operations, so it either shows up almost immediately or not at
+        // all; this isn't waiting for something slow, just being patient
+        // about scheduling jitter.
+        gate_tx
+            .send(())
+            .expect("discovery thread should still be waiting on the gate");
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Instant::now() < deadline {
+            assert!(
+                mux.get_domain_by_name("Stale").is_none(),
+                "a cancelled discovery must not register domains it finds after being cancelled"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "dummy-default",
+            "a cancelled discovery's pending_default must not be applied once it finishes late"
+        );
+    }
+
+    /// Regression test: `cancel_domain_discovery` must
+    /// not itself wake a waiter that was already parked *before* it ran --
+    /// only `notify_cancelled_domain_discovery_waiters`, called once any
+    /// replacement domains are registered, may do that. Otherwise a thread
+    /// already blocked in `await_domain_discovery_unbounded` (eg. via
+    /// `resolve_spawn_tab_domain`) could wake between a config reload's
+    /// `cancel_domain_discovery()` call and its subsequent explicit-domain
+    /// registration loop, observe discovery is no longer `InProgress`, and
+    /// look up a domain that hasn't been registered yet -- the same
+    /// intermediate-state race the cancel/notify split exists to close,
+    /// just for the synchronous `Condvar` waiters instead of the async
+    /// `Waker` ones.
+    #[test]
+    fn cancel_domain_discovery_defers_sync_wakeup_until_notify_is_called() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+
+        let waiter_mux = Arc::clone(&mux);
+        let waiter_returned = Arc::new(AtomicBool::new(false));
+        let waiter_returned2 = Arc::clone(&waiter_returned);
+        let (parked_tx, parked_rx) = std::sync::mpsc::channel::<()>();
+        let waiter = std::thread::spawn(move || {
+            let _ = parked_tx.send(()); // Signal we're about to wait
+            waiter_mux.await_domain_discovery_unbounded();
+            waiter_returned2.store(true, Ordering::SeqCst);
+        });
+
+        // Wait for the waiter thread to signal it's about to park, then
+        // for it to actually reach the condvar.
+        //
+        // "About to park" is not good enough on its own: if we cancelled
+        // while the waiter was still between the signal and the condvar,
+        // it would find the state already flipped away from `InProgress`,
+        // return immediately, and fail the assertion below -- reporting a
+        // bug that isn't there. So rather than sleeping a fixed 50ms and
+        // hoping, hold the discovery lock ourselves and only release it
+        // once the waiter is blocked *on that lock or on the condvar*. A
+        // parked waiter is precisely one that is inside
+        // `await_domain_discovery_unbounded` and therefore either holds or
+        // is queued for this mutex, so once we observe contention here and
+        // hand the lock over, cancellation cannot race ahead of it.
+        let _ = parked_rx.recv();
+        {
+            let _hold = mux.domain_discovery.lock();
+            // Give the waiter a chance to queue up behind this lock. Any
+            // delay works: it changes only how long we wait for the
+            // handshake, never whether the assertion is valid.
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        // In practice, parking_lot's eventual-fairness heuristic hands the lock
+        // to the waiter here once our hold has outlasted its internal fairness
+        // timeout (which our 50ms hold reliably does) -- but this is a `parking_lot`
+        // implementation detail, not a guarantee: a barging lock can in principle
+        // let this thread re-acquire the lock first. If this test ever becomes
+        // flaky, that's the first thing to suspect; the fix would be an explicit
+        // channel handshake signalled from inside `await_domain_discovery_unbounded`
+        // immediately before it parks on the condvar, rather than lock-timing.
+        let wakers = mux.cancel_domain_discovery();
+
+        // The waiter must still be parked: cancel alone must not wake it.
+        // Use a short poll loop rather than a single fixed sleep to reduce
+        // flakiness -- we only need to verify it hasn't woken within a
+        // reasonable window.
+        let deadline = Instant::now() + Duration::from_millis(200);
+        while Instant::now() < deadline {
+            assert!(
+                !waiter_returned.load(Ordering::SeqCst),
+                "a waiter parked before cancel_domain_discovery must not wake until \
+                 notify_cancelled_domain_discovery_waiters is called"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        mux.notify_cancelled_domain_discovery_waiters(wakers);
+        waiter.join().expect("waiter thread must not panic");
+        assert!(
+            waiter_returned.load(Ordering::SeqCst),
+            "notify_cancelled_domain_discovery_waiters must wake the previously-parked waiter"
+        );
+
+        let _ = gate_tx.send(());
+    }
+
+    /// A no-op `Waker` for manually driving a `Future::poll` from a test
+    /// without a real executor. Never dereferences its data pointer (it's
+    /// always null), so this is sound.
+    fn test_waker() -> Waker {
+        fn clone(_: *const ()) -> std::task::RawWaker {
+            std::task::RawWaker::new(std::ptr::null(), &VTABLE)
+        }
+        fn noop(_: *const ()) {}
+        static VTABLE: std::task::RawWakerVTable =
+            std::task::RawWakerVTable::new(clone, noop, noop, noop);
+        unsafe { Waker::from_raw(std::task::RawWaker::new(std::ptr::null(), &VTABLE)) }
+    }
+
+    /// Regression test for a lost-wakeup bug: `DomainDiscoveryWaitFuture`
+    /// originally tracked "have I ever registered a waker" as a plain
+    /// `bool`. If a run it had registered against got cancelled and a
+    /// *new* run started before the future was polled again, the stale
+    /// `true` flag made it skip registering with the new run's (separate,
+    /// freshly-empty) `wakers` list -- leaving the future parked nowhere,
+    /// pending forever. Registration must be tracked per-generation so a
+    /// new run is always detected and re-registered against.
+    #[test]
+    fn domain_discovery_wait_future_reregisters_across_a_new_discovery_generation() {
+        use std::future::Future;
+
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx_a, gate_rx_a) = std::sync::mpsc::channel::<()>();
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx_a.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+
+        let mut future = mux.await_domain_discovery_unbounded_async();
+        let waker = test_waker();
+        let mut cx = std::task::Context::from_waker(&waker);
+
+        assert_eq!(
+            std::pin::Pin::new(&mut future).poll(&mut cx),
+            Poll::Pending,
+            "must be pending while run A is in progress"
+        );
+        {
+            let state = mux.domain_discovery.lock();
+            match &*state {
+                DomainDiscoveryState::InProgress { wakers, .. } => {
+                    assert_eq!(
+                        wakers.len(),
+                        1,
+                        "future should have registered exactly once against run A"
+                    );
+                }
+                _ => panic!("expected InProgress after begin_domain_discovery"),
+            }
+        }
+
+        // Cancel run A -- its drained wakers are discarded here rather
+        // than published, standing in for a caller that's about to start
+        // a fresh run instead of registering replacement domains.
+        let _ = mux.cancel_domain_discovery();
+
+        // Start a brand-new run B before the future is ever polled again.
+        let (gate_tx_b, gate_rx_b) = std::sync::mpsc::channel::<()>();
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx_b.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+
+        assert_eq!(
+            std::pin::Pin::new(&mut future).poll(&mut cx),
+            Poll::Pending,
+            "must still be pending while run B is in progress"
+        );
+        {
+            let state = mux.domain_discovery.lock();
+            match &*state {
+                DomainDiscoveryState::InProgress { wakers, .. } => {
+                    assert_eq!(
+                        wakers.len(),
+                        1,
+                        "future must re-register against run B's generation, not silently \
+                         stay unregistered because it already registered against run A"
+                    );
+                }
+                _ => panic!("expected InProgress after the second begin_domain_discovery"),
+            }
+        }
+
+        // Let both gated discovery threads finish so they don't outlive
+        // the test.
+        let _ = gate_tx_a.send(());
+        let _ = gate_tx_b.send(());
+        mux.await_domain_discovery_unbounded();
+    }
+
+    /// Regression test: `cancel_domain_discovery`
+    /// used to set `Done` unconditionally, which is indistinguishable from
+    /// a discovery that actually completed successfully.
+    /// `begin_domain_discovery`'s "nothing new to discover" shortcut for
+    /// `Done` would then also fire after a cancel, so a config that starts
+    /// with explicit `wsl_domains` (calling `cancel_domain_discovery` from
+    /// `NotStarted` on every reload) would never run auto-discovery even
+    /// after `wsl_domains` was later removed from the config, until the
+    /// process restarted. Cancelling from `NotStarted` must be a no-op
+    /// that leaves a later call free to actually discover.
+    #[test]
+    fn cancel_domain_discovery_from_not_started_does_not_prevent_a_later_real_discovery() {
+        let mux = new_test_mux();
+
+        mux.notify_cancelled_domain_discovery_waiters(mux.cancel_domain_discovery());
+
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran2 = Arc::clone(&ran);
+        mux.begin_domain_discovery(
+            move || {
+                ran2.store(true, Ordering::SeqCst);
+                Ok(vec![dummy_domain("Real")])
+            },
+            None,
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "a discovery cancelled from NotStarted must not block a later real discovery"
+        );
+        assert!(mux.get_domain_by_name("Real").is_some());
+    }
+
+    /// Regression test: cancelling a genuinely
+    /// in-flight discovery must also leave a later call free to actually
+    /// (re-)discover, not be silently absorbed into a fake `Done` the way
+    /// it used to be.
+    #[test]
+    fn cancel_domain_discovery_in_flight_does_not_prevent_a_later_real_discovery() {
+        let mux = new_test_mux();
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("Cancelled")])
+            },
+            None,
+        );
+        mux.notify_cancelled_domain_discovery_waiters(mux.cancel_domain_discovery());
+
+        // Let the now-stale thread finish and give it a generous window
+        // to clean up before starting a new one, so this test is exercising
+        // "a real discovery after a cancelled one finished late", not racing it.
+        gate_tx
+            .send(())
+            .expect("discovery thread should still be waiting on the gate");
+        // Give the cancelled thread time to run to completion. There is
+        // deliberately nothing to poll for: a cancelled run publishes no
+        // state at all -- it sees `Superseded` while registering, returns
+        // without ever constructing its finish guard, and leaves
+        // `NotStarted` exactly as `cancel_domain_discovery` left it. That
+        // silence is the property under test, so a fixed window is the
+        // only thing available. The assertions below don't depend on this
+        // window having been long enough; it only decides whether the
+        // stale thread finishes before or after the second run starts,
+        // and both orders must work.
+        std::thread::sleep(Duration::from_millis(200));
+
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran2 = Arc::clone(&ran);
+        mux.begin_domain_discovery(
+            move || {
+                ran2.store(true, Ordering::SeqCst);
+                Ok(vec![dummy_domain("Real")])
+            },
+            None,
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "cancelling an in-flight discovery must not block a later real discovery"
+        );
+        assert!(mux.get_domain_by_name("Real").is_some());
+    }
+
+    /// Regression test: a waiter that
+    /// starts *while* `cancel_domain_discovery_and_replace` is running --
+    /// after it has cancelled the stale run but before it has finished
+    /// registering the replacement domain -- must not observe an
+    /// intermediate "nothing in progress, nothing registered yet" state
+    /// and report the domain missing. It must either block until the
+    /// replacement is visible, or (if it happens to run after
+    /// registration completes) find it immediately -- never a hard
+    /// "not found" for a domain the new configuration genuinely lists.
+    /// This is what `cancel_domain_discovery_and_replace` holding
+    /// `domain_discovery`'s lock across the whole cancel -> register ->
+    /// publish sequence is for.
+    #[test]
+    fn cancel_domain_discovery_and_replace_makes_new_waiters_see_replacement_domains() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+
+        let (waiter_may_start_tx, waiter_may_start_rx) = std::sync::mpsc::channel::<()>();
+        let (waiter_started_tx, waiter_started_rx) = std::sync::mpsc::channel::<()>();
+
+        let replace_mux = Arc::clone(&mux);
+        let replacer = std::thread::spawn(move || {
+            replace_mux
+                .cancel_domain_discovery_and_replace(|| {
+                    // Let the waiter thread start its lookup now, while
+                    // still inside this closure (ie. still holding
+                    // domain_discovery's lock), then wait for confirmation
+                    // it has actually issued the lookup call before
+                    // finishing registration -- maximizing the chance it
+                    // lands in the exact window this test is about.
+                    let _ = waiter_may_start_tx.send(());
+                    let _ = waiter_started_rx.recv();
+                    let domain = dummy_domain("Explicit");
+                    replace_mux.add_domain(&domain);
+                    Ok(())
+                })
+                .expect("register_replacements must not fail in this test");
+        });
+
+        let _ = waiter_may_start_rx.recv();
+        let waiter_mux = Arc::clone(&mux);
+        let waiter = std::thread::spawn(move || {
+            let _ = waiter_started_tx.send(());
+            waiter_mux
+                .resolve_spawn_tab_domain(None, &SpawnTabDomain::DomainName("Explicit".to_string()))
+        });
+
+        replacer.join().expect("replacer thread must not panic");
+        let result = waiter.join().expect("waiter thread must not panic");
+
+        assert_eq!(
+            result
+                .expect("Explicit must be found, not raced past an intermediate state")
+                .domain_name(),
+            "Explicit",
+            "a waiter starting during cancel_domain_discovery_and_replace must see \
+             the replacement domain once registered, not an intermediate state"
+        );
+    }
+
+    /// Regression test: a bounded timeout on the
+    /// default-domain resolution path incorrectly treats "discovery is
+    /// still slow" as "the domain doesn't exist": `resolve_default_domain`
+    /// must wait for an in-flight discovery to actually finish when it
+    /// has a `pending_default` to apply, not give up after
+    /// `DOMAIN_DISCOVERY_TIMEOUT` and silently keep the old default.
+    #[test]
+    fn resolve_default_domain_waits_unbounded_for_pending_default() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("Slow")])
+            },
+            Some("Slow".to_string()),
+        );
+
+        // Signal that we're about to start resolution. This ensures the
+        // releaser thread doesn't open the gate until after we've had a
+        // chance to actually start waiting.
+        let (start_tx, start_rx) = std::sync::mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            let _ = start_rx.recv();
+            std::thread::sleep(Duration::from_millis(80));
+            let _ = gate_tx.send(());
+        });
+
+        let _ = start_tx.send(());
+        let resolved = mux.resolve_default_domain();
+        assert_eq!(resolved.domain_name(), "Slow");
+    }
+
+    /// Regression test: if the default domain
+    /// changes (eg. a `wezterm connect`/`wezterm ssh` caller explicitly
+    /// sets one) *after* discovery started but *before* it finishes, the
+    /// finish guard applying `pending_default` must not clobber that
+    /// intentional choice once discovery completes late.
+    #[test]
+    fn finish_guard_does_not_clobber_default_domain_changed_after_discovery_started() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("WSL:Ubuntu")])
+            },
+            Some("WSL:Ubuntu".to_string()),
+        );
+
+        // Simulates eg. `wezterm connect my-remote`, which sets its own
+        // default domain after `begin_domain_discovery` was kicked off by
+        // `update_mux_domains_impl` but before discovery finishes.
+        let intentional_default = dummy_domain("my-remote");
+        mux.add_domain(&intentional_default);
+        mux.set_default_domain(&intentional_default);
+
+        gate_tx
+            .send(())
+            .expect("discovery thread should still be waiting on the gate");
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "my-remote",
+            "an intentional default domain change during discovery must survive discovery finishing"
+        );
+    }
+
+    /// Regression test for panic safety: a
+    /// `discover` closure that panics (eg. a malformed `wsl -l -v` output
+    /// tripping an indexing panic in the real parser) must not strand the
+    /// state machine in `InProgress` forever -- `FinishDomainDiscoveryOnDrop`
+    /// finishes the run either way -- and a later discovery must be able to
+    /// run normally afterwards. Note: the panicking thread prints its panic
+    /// message to stderr via the default panic hook; that's expected
+    /// noise from this test, not a failure.
+    ///
+    /// The panic is caught and reported as an error, so the resulting state
+    /// is `NotStarted` (retryable), *not* `Done`: a run that blew up hasn't
+    /// discovered anything, and treating it as completed would let
+    /// `begin_domain_discovery`'s already-completed shortcut skip the real
+    /// work later. This test asserts that state explicitly, because both
+    /// `Done` and `NotStarted` satisfy every other assertion here and an
+    /// implicit check would silently pass on either.
+    #[test]
+    fn begin_domain_discovery_panicking_discover_still_finishes_state() {
+        let mux = new_test_mux();
+
+        mux.begin_domain_discovery(|| panic!("simulated wsl.exe / parser panic"), None);
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::NotStarted
+            ),
+            "a panicking discover must finish the run as retryable NotStarted, \
+             neither stranded InProgress nor falsely Done"
+        );
+
+        let start = Instant::now();
+        let err = mux
+            .resolve_spawn_tab_domain(None, &SpawnTabDomain::DomainName("nope".to_string()))
+            .err()
+            .expect("unknown domain name must still be an error");
+        assert!(err.to_string().contains("nope"));
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "the run must be finished after the panic, not still InProgress"
+        );
+
+        // A `pending_default` naming a domain not yet known forces a real
+        // discovery run rather than the `Done`-with-nothing-to-do
+        // shortcut (see begin_domain_discovery_repeat_call_after_done_
+        // with_no_new_work_skips_thread below), so this proves discovery
+        // genuinely still works, not just that the state machine reports
+        // `Done`.
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran2 = Arc::clone(&ran);
+        mux.begin_domain_discovery(
+            move || {
+                ran2.store(true, Ordering::SeqCst);
+                Ok(vec![dummy_domain("AfterPanic")])
+            },
+            Some("AfterPanic".to_string()),
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "discovery must be able to run again after a prior panic"
+        );
+    }
+
+    /// A `Domain` whose `domain_name()` panics, to exercise the
+    /// registration loop's own panic path. `add_discovered_domain` calls
+    /// `domain_name()` while inserting into `domains_by_name`, so this
+    /// panics from *inside* the loop rather than from `discover()`.
+    #[derive(Debug)]
+    struct PanicOnNameDomain {
+        id: DomainId,
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl Domain for PanicOnNameDomain {
+        async fn spawn_pane(
+            &self,
+            _size: TerminalSize,
+            _command: Option<CommandBuilder>,
+            _command_dir: Option<String>,
+        ) -> anyhow::Result<Arc<dyn Pane>> {
+            anyhow::bail!("not used in this test")
+        }
+        fn detachable(&self) -> bool {
+            false
+        }
+        fn domain_id(&self) -> DomainId {
+            self.id
+        }
+        fn domain_name(&self) -> &str {
+            panic!("simulated panic from a Domain trait impl during registration")
+        }
+        async fn attach(&self, _window_id: Option<WindowId>) -> anyhow::Result<()> {
+            Ok(())
+        }
+        fn detach(&self) -> anyhow::Result<()> {
+            anyhow::bail!("not used in this test")
+        }
+        fn state(&self) -> DomainState {
+            DomainState::Attached
+        }
+    }
+
+    /// Regression test: the `catch_unwind` in
+    /// `begin_domain_discovery_with_default_filter` originally wrapped only
+    /// the `discover()` closure, while the `add_discovered_domain`
+    /// registration loop ran after the finish guard had already been
+    /// constructed holding `Ok(..)`. A panic out of any `Domain` method
+    /// reached from that loop therefore unwound with the guard believing
+    /// the run had succeeded, publishing `Done` despite the registration
+    /// being only partial -- and a later reload carrying
+    /// `pending_default: None` would then take the `Done` shortcut and
+    /// never retry discovery again. Registration must fail the run to
+    /// retryable `NotStarted` instead.
+    #[test]
+    fn panic_while_registering_discovered_domains_stays_retryable() {
+        let mux = new_test_mux();
+
+        mux.begin_domain_discovery(
+            || {
+                Ok(vec![Arc::new(PanicOnNameDomain {
+                    id: alloc_domain_id(),
+                }) as Arc<dyn Domain>])
+            },
+            None,
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::NotStarted
+            ),
+            "a panic during registration must finish the run as retryable NotStarted, \
+             not as Done -- Done would make a later reload skip discovery entirely"
+        );
+
+        // Proves the state really is retryable, not merely labelled so:
+        // with `pending_default: None` a `Done` state takes the shortcut
+        // and never invokes the closure at all.
+        let ran = Arc::new(AtomicBool::new(false));
+        let ran2 = Arc::clone(&ran);
+        mux.begin_domain_discovery(
+            move || {
+                ran2.store(true, Ordering::SeqCst);
+                Ok(vec![dummy_domain("AfterRegistrationPanic")])
+            },
+            None,
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            ran.load(Ordering::SeqCst),
+            "discovery must run again after a registration panic"
+        );
+        assert!(mux.get_domain_by_name("AfterRegistrationPanic").is_some());
+    }
+
+    /// Regression test: `cancel_domain_discovery_and_replace`
+    /// drains the async wakers out of the state *before* running the
+    /// caller-supplied `register_replacements` closure under the lock. If
+    /// that closure panics, the notify/wake calls that used to sit after it
+    /// were skipped and the drained wakers were simply dropped, leaving any
+    /// async waiter parked with no registration and nothing able to wake it
+    /// -- `Pending` forever. The publish half must happen on the unwind
+    /// path too.
+    #[test]
+    fn panicking_replacement_closure_still_wakes_async_waiters() {
+        let mux = new_test_mux();
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+
+        // Register a waker against the in-flight run, standing in for an
+        // async waiter parked in `DomainDiscoveryWaitFuture`.
+        let woken = Arc::new(AtomicBool::new(false));
+        {
+            let mut state = mux.domain_discovery.lock();
+            match &mut *state {
+                DomainDiscoveryState::InProgress {
+                    wakers,
+                    next_waiter_id,
+                    ..
+                } => {
+                    wakers.insert(*next_waiter_id, tracking_waker(Arc::clone(&woken)));
+                    *next_waiter_id += 1;
+                }
+                _ => panic!("discovery should still be in flight behind the gate"),
+            }
+        }
+
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            mux.cancel_domain_discovery_and_replace(|| {
+                panic!("simulated panic from a caller-supplied replacement closure")
+            })
+        }));
+        assert!(
+            panicked.is_err(),
+            "the closure's panic must still propagate to the caller"
+        );
+
+        assert!(
+            woken.load(Ordering::SeqCst),
+            "wakers drained before the panicking closure must still be woken, or the \
+             async waiters they belong to stay Pending forever"
+        );
+        // The lock must not have been left held either: parking_lot doesn't
+        // poison, and the guard is released on unwind, so this must not hang.
+        assert!(matches!(
+            &*mux.domain_discovery.lock(),
+            DomainDiscoveryState::NotStarted
+        ));
+
+        let _ = gate_tx.send(());
+    }
+
+    /// Regression test: once a discovery run
+    /// has completed and there is nothing new to discover (no
+    /// `pending_default`, or one that's already registered), a repeat
+    /// call must not spawn another discovery thread at all --
+    /// `update_mux_domains_impl` calls this on every config reload, and
+    /// wezterm reloads config on every file save, so spawning a fresh OS
+    /// thread each time just to re-derive the same (cached) answer would
+    /// add up.
+    #[test]
+    fn begin_domain_discovery_after_done_skips_redundant_thread_when_nothing_new() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+
+        // First run: completes with a domain registered, nothing pending.
+        mux.begin_domain_discovery(|| Ok(vec![dummy_domain("Known")]), None);
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        // pending_default = None: nothing to discover or apply, so this
+        // must return synchronously without spawning a thread at all.
+        // Uses a flag rather than `unreachable!` in the closure: a panic
+        // on a wrongly-spawned *detached* thread wouldn't fail the test
+        // by itself, whereas checking the flag directly is a definitive
+        // "was this closure ever invoked" signal.
+        //
+        // "No thread was spawned" is asserted on the state machine rather
+        // than on a timing window: `begin_domain_discovery` publishes
+        // `InProgress` *before* spawning, and only ever from the state
+        // lock, so a state that is still `Done` the moment the call
+        // returns is proof no run was started -- no sleeping, no
+        // scheduler-dependent grace period, and no way for a slow-but-real
+        // spawn to sneak past. The closure flag is then just a
+        // belt-and-braces cross-check with a short window.
+        let ran_first = Arc::new(AtomicBool::new(false));
+        let ran_first2 = Arc::clone(&ran_first);
+        let start = Instant::now();
+        mux.begin_domain_discovery(
+            move || {
+                ran_first2.store(true, Ordering::SeqCst);
+                Ok(vec![])
+            },
+            None,
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "must return synchronously when there is nothing new to discover"
+        );
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::Done { .. }
+            ),
+            "must not start a run when there is nothing new to discover"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !ran_first.load(Ordering::SeqCst),
+            "must not spawn a thread when there is nothing new to discover"
+        );
+
+        // pending_default names a domain already known from the first
+        // run: must apply it synchronously too, no thread spawned.
+        let ran_second = Arc::new(AtomicBool::new(false));
+        let ran_second2 = Arc::clone(&ran_second);
+        let start = Instant::now();
+        mux.begin_domain_discovery(
+            move || {
+                ran_second2.store(true, Ordering::SeqCst);
+                Ok(vec![])
+            },
+            Some("Known".to_string()),
+        );
+        assert!(start.elapsed() < Duration::from_secs(1));
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::Done { .. }
+            ),
+            "must not start a run when the pending_default is already known"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !ran_second.load(Ordering::SeqCst),
+            "must not spawn a thread when the pending_default is already known"
+        );
+        assert_eq!(mux.default_domain().domain_name(), "Known");
+    }
+
+    /// A `Waker` that records whether `wake`/`wake_by_ref` was ever called,
+    /// via the `Arc<AtomicBool>` it's constructed from. Unlike `test_waker`
+    /// (below), this one is actually observable, for tests that need to
+    /// prove a waker was really woken rather than just drive a `poll` by
+    /// hand.
+    fn tracking_waker(woken: Arc<AtomicBool>) -> Waker {
+        fn clone(data: *const ()) -> std::task::RawWaker {
+            let arc = unsafe { Arc::from_raw(data as *const AtomicBool) };
+            let cloned = Arc::into_raw(Arc::clone(&arc)) as *const ();
+            std::mem::forget(arc);
+            std::task::RawWaker::new(cloned, &VTABLE)
+        }
+        fn wake(data: *const ()) {
+            let arc = unsafe { Arc::from_raw(data as *const AtomicBool) };
+            arc.store(true, Ordering::SeqCst);
+        }
+        fn wake_by_ref(data: *const ()) {
+            let arc = unsafe { Arc::from_raw(data as *const AtomicBool) };
+            arc.store(true, Ordering::SeqCst);
+            std::mem::forget(arc);
+        }
+        fn drop_fn(data: *const ()) {
+            unsafe { drop(Arc::from_raw(data as *const AtomicBool)) };
+        }
+        static VTABLE: std::task::RawWakerVTable =
+            std::task::RawWakerVTable::new(clone, wake, wake_by_ref, drop_fn);
+        let ptr = Arc::into_raw(woken) as *const ();
+        unsafe { Waker::from_raw(std::task::RawWaker::new(ptr, &VTABLE)) }
+    }
+
+    /// Regression test: a discovery run
+    /// that never returns at all (eg. a permanently hung `wsl.exe`, not
+    /// just a slow one) must not leave `InProgress` stuck for the rest of
+    /// the process's life. A later `begin_domain_discovery` call -- eg.
+    /// from a config reload -- must notice the run has been `InProgress`
+    /// for longer than `DOMAIN_DISCOVERY_STUCK_THRESHOLD` and supersede it
+    /// with a fresh run instead of the usual no-op "refresh the fields and
+    /// return", waking anything parked on the stale run so it re-checks
+    /// against the new one instead of a generation nothing will ever
+    /// finish.
+    #[test]
+    fn begin_domain_discovery_supersedes_a_permanently_stuck_run() {
+        let mux = new_test_mux();
+
+        // Installs a stuck `InProgress` state directly rather than
+        // spawning a thread that really never returns (nothing in this
+        // test could ever unblock it): a `started_at` already past
+        // `DOMAIN_DISCOVERY_STUCK_THRESHOLD` is exactly the state a
+        // genuinely hung `wsl.exe` would eventually be observed in by a
+        // later caller. A waker is registered too, standing in for an
+        // async caller already parked on this run, to prove it gets woken
+        // rather than left registered forever against a generation
+        // nothing will ever finish.
+        let woken = Arc::new(AtomicBool::new(false));
+        let stuck_generation = {
+            let mut state = mux.domain_discovery.lock();
+            let generation = mux
+                .next_domain_discovery_generation
+                .fetch_add(1, Ordering::SeqCst);
+            let mut wakers = HashMap::new();
+            wakers.insert(0, tracking_waker(Arc::clone(&woken)));
+            *state = DomainDiscoveryState::InProgress {
+                generation,
+                pending_default: None,
+                default_domain_id_at_start: None,
+                wakers,
+                next_waiter_id: 1,
+                accepts_as_default: Arc::new(|_| true),
+                // `checked_sub` rather than plain `-`, matching
+                // `config::wsl`'s `abandoned_discovery_triggers_new_attempt`:
+                // subtracting from `Instant::now()` panics on underflow if
+                // the monotonic clock hasn't reached this far yet (a host
+                // less than ~91s past whatever it counts from, eg. a CI
+                // runner or container started moments ago). Unlike that
+                // test's fallback, this one degrades to a *failed
+                // assertion* rather than a silently-weaker check -- a
+                // non-backdated `started_at` reads as a healthy in-flight
+                // run, so `begin_domain_discovery` would take its normal
+                // refresh-and-return path and the assertions below would
+                // catch it. That's the right failure mode: visibly wrong
+                // for an inapplicable environment, rather than a confusing
+                // panic from inside a struct literal.
+                started_at: Instant::now()
+                    .checked_sub(DOMAIN_DISCOVERY_STUCK_THRESHOLD + Duration::from_secs(1))
+                    .unwrap_or_else(Instant::now),
+            };
+            generation
+        };
+
+        mux.begin_domain_discovery(|| Ok(vec![dummy_domain("Fresh")]), None);
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        assert!(
+            mux.get_domain_by_name("Fresh").is_some(),
+            "a repeat call against a stuck run must actually start and finish a fresh \
+             discovery, not treat it as a normal in-flight run and no-op"
+        );
+        assert!(
+            woken.load(Ordering::SeqCst),
+            "a waker registered against the stuck run's generation must be woken so it \
+             re-polls and re-registers against the fresh run, instead of being left \
+             registered against a generation nothing will ever finish"
+        );
+        let finished_generation = match &*mux.domain_discovery.lock() {
+            DomainDiscoveryState::Done { _generation, .. } => *_generation,
+            DomainDiscoveryState::NotStarted => {
+                panic!("expected Done after the fresh run finishes, got NotStarted")
+            }
+            DomainDiscoveryState::InProgress { .. } => {
+                panic!("expected Done after the fresh run finishes, got InProgress")
+            }
+        };
+        assert_ne!(
+            finished_generation, stuck_generation,
+            "the fresh run must publish under a newer generation than the one it superseded"
+        );
+    }
+
+    /// Drives the "slow run finishes after the run that replaced it already
+    /// failed" sequence deterministically, and returns the mux so each caller
+    /// can assert on the outcome it cares about.
+    ///
+    /// The ordering is forced with channels rather than real timing: run A is
+    /// installed as an already-stuck `InProgress` (so `begin_domain_discovery`
+    /// supersedes it without waiting out `DOMAIN_DISCOVERY_STUCK_THRESHOLD`),
+    /// A's thread is then released only *after* the replacement run B has
+    /// failed, and A returns success. `cancel` runs, if provided, between B
+    /// failing and A finishing -- standing in for a config reload switching to
+    /// an explicit `wsl_domains` list in exactly that window.
+    ///
+    /// `a_pending_default` is what run A was originally asked to apply;
+    /// `b_pending_default` is what the reload that superseded it asks for,
+    /// ie. the config as it stands by the time anything actually gets
+    /// applied. Passing different values models a reload changing or
+    /// dropping `default_domain` while A was stuck.
+    fn run_late_success_after_replacement_failed(
+        cancel: Option<Box<dyn FnOnce(&Arc<Mux>)>>,
+        a_pending_default: Option<&str>,
+        b_pending_default: Option<&str>,
+    ) -> Arc<Mux> {
+        let mux = new_test_mux();
+        // Seed a default so the "is there one at all" fallback in
+        // `register_discovered_domain_locked` can't be mistaken for
+        // `pending_default` having been applied.
+        let seeded_default = dummy_domain("seeded-default");
+        mux.add_domain(&seeded_default);
+        mux.set_default_domain(&seeded_default);
+
+        // Run A: a real thread, holding a generation that is about to be
+        // superseded, blocked until we release it.
+        let (release_a_tx, release_a_rx) = std::sync::mpsc::channel::<()>();
+        let (a_done_tx, a_done_rx) = std::sync::mpsc::channel::<()>();
+        {
+            let mut state = mux.domain_discovery.lock();
+            let generation = mux
+                .next_domain_discovery_generation
+                .fetch_add(1, Ordering::SeqCst);
+            let default_domain_id_at_start = Some(seeded_default.domain_id());
+            *state = DomainDiscoveryState::InProgress {
+                generation,
+                pending_default: a_pending_default.map(|s| s.to_string()),
+                default_domain_id_at_start,
+                wakers: HashMap::new(),
+                next_waiter_id: 0,
+                accepts_as_default: Arc::new(|_| true),
+                started_at: Instant::now()
+                    .checked_sub(DOMAIN_DISCOVERY_STUCK_THRESHOLD + Duration::from_secs(1))
+                    .unwrap_or_else(Instant::now),
+            };
+            // What a real `begin_*` call would have recorded when it
+            // published run A. Run B's `begin_domain_discovery` below
+            // overwrites this, which is the point: adoption must apply
+            // what was asked for *last*, not what A was spawned with.
+            *mux.domain_discovery_latest_default.lock() = Some(DomainDiscoveryDefaultRequest {
+                pending_default: a_pending_default.map(|s| s.to_string()),
+                default_domain_id_at_start,
+                accepts_as_default: Arc::new(|_| true),
+            });
+
+            // Mirrors what `begin_domain_discovery`'s spawned thread does once
+            // its `discover` closure returns: try to register, and on
+            // `Superseded` offer the result up for adoption.
+            let mux_a = Arc::clone(&mux);
+            let cancel_epoch_at_start = mux.domain_discovery_cancel_epoch.load(Ordering::SeqCst);
+            std::thread::spawn(move || {
+                let _ = release_a_rx.recv();
+                let domains = vec![dummy_domain("LateSuccess")];
+                let superseded = domains.iter().any(|domain| {
+                    matches!(
+                        mux_a.add_discovered_domain(generation, domain),
+                        AddDiscoveredDomainOutcome::Superseded
+                    )
+                });
+                if superseded {
+                    mux_a.adopt_orphaned_discovery(cancel_epoch_at_start, &domains);
+                }
+                let _ = a_done_tx.send(());
+            });
+        }
+
+        // Run B supersedes the stuck A and fails outright, carrying the
+        // pending default of the config as it stands at *its* reload.
+        mux.begin_domain_discovery(
+            || Err(anyhow!("simulated wsl.exe failure")),
+            b_pending_default.map(|s| s.to_string()),
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::NotStarted
+            ),
+            "a failed replacement run must leave the state retryable"
+        );
+
+        if let Some(cancel) = cancel {
+            cancel(&mux);
+        }
+
+        // Only now does A finish.
+        let _ = release_a_tx.send(());
+        a_done_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("run A must finish");
+
+        mux
+    }
+
+    /// Regression test: a slow run that succeeds only
+    /// after the run which superseded it has already failed must not leave the
+    /// config-level cache populated with nothing registered against it.
+    ///
+    /// The cache write happens inside the `discover` closure, before the run
+    /// learns it was superseded, and no generation check governs it -- so
+    /// dropping the mux half on the floor leaves the two describing different
+    /// sets of distributions. Since pane spawn resolves a domain's live
+    /// settings against that cache, a domain present in only one of them is
+    /// how a command ends up running on the Windows host instead of inside
+    /// WSL.
+    #[test]
+    fn late_success_after_replacement_failed_is_adopted() {
+        let mux = run_late_success_after_replacement_failed(None, None, None);
+
+        assert!(
+            mux.get_domain_by_name("LateSuccess").is_some(),
+            "the late result must be adopted: nothing else is going to register it, and \
+             its list is already in the config-level cache"
+        );
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::Done { .. }
+            ),
+            "adopting must finish the run, so a later reload takes the Done shortcut \
+             instead of rediscovering what is already registered"
+        );
+    }
+
+    /// Regression test: adopting a late result must also apply the
+    /// `pending_default` that run was carrying.
+    ///
+    /// `update_mux_domains_impl` already tried to apply the configured
+    /// `default_domain` before this domain existed, and found nothing; if
+    /// adoption registers the domain without also applying it, an explicitly
+    /// configured `default_domain` is silently ignored -- new tabs keep
+    /// opening in whatever the previous default was -- until some later reload
+    /// happens along.
+    #[test]
+    fn adopting_a_late_result_applies_its_pending_default() {
+        let mux = run_late_success_after_replacement_failed(
+            None,
+            Some("LateSuccess"),
+            Some("LateSuccess"),
+        );
+
+        assert!(mux.get_domain_by_name("LateSuccess").is_some());
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "LateSuccess",
+            "the configured default named the domain only this run could supply, and \
+             nothing changed the default in the meantime, so adoption must apply it"
+        );
+    }
+
+    /// Adoption must apply the default as *last* requested, not as requested
+    /// when the adopting run was spawned. Here the reload that superseded run
+    /// A dropped `default_domain` from the config (run B carries `None`), so
+    /// even though A was originally asked to apply "LateSuccess" -- and is
+    /// the run that finally supplies that domain -- adopting its result must
+    /// register the domain without touching the default. Before discovery
+    /// went asynchronous, a `default_domain` removed from the config could
+    /// never be applied again under any circumstances; applying A's
+    /// spawn-time copy would quietly break that, and no later reload could
+    /// undo it (a config with no `default_domain` has nothing to apply).
+    #[test]
+    fn adopting_a_late_result_does_not_apply_a_default_the_config_dropped() {
+        let mux = run_late_success_after_replacement_failed(None, Some("LateSuccess"), None);
+
+        assert!(
+            mux.get_domain_by_name("LateSuccess").is_some(),
+            "the domains themselves must still be adopted; only the stale default request \
+             is dropped"
+        );
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "seeded-default",
+            "the reload that superseded run A no longer asks for a default, so adoption \
+             must not apply the one A was spawned with"
+        );
+    }
+
+    /// The other half of the contract: adoption must *not* happen when the
+    /// reason there is no live run is that the config switched to an explicit
+    /// `wsl_domains` list. `NotStarted` alone cannot tell that apart from "the
+    /// replacement run failed" -- both produce it -- so this pins the
+    /// cancellation-epoch check that does.
+    ///
+    /// Getting this wrong resurrects auto-discovered domains that the user's
+    /// new config deliberately dropped.
+    #[test]
+    fn late_success_after_cancellation_is_not_adopted() {
+        let mux = run_late_success_after_replacement_failed(
+            Some(Box::new(|mux: &Arc<Mux>| {
+                mux.cancel_domain_discovery_and_replace(|| Ok(()))
+                    .expect("cancellation must succeed");
+            })),
+            None,
+            None,
+        );
+
+        assert!(
+            mux.get_domain_by_name("LateSuccess").is_none(),
+            "a cancelled discovery's late result must be discarded: this config asked for \
+             an explicit domain list and no longer wants discovered ones"
+        );
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::NotStarted
+            ),
+            "a discarded adoption must not move the state either"
+        );
+    }
+
+    /// Regression test: a `Done` run that failed
+    /// to find a domain named by `pending_default` must remember that name
+    /// and skip spawning a new thread on repeat calls for the same name,
+    /// rather than re-running discovery just to re-derive the same "not
+    /// found" answer. A *different* name must still spawn a fresh run.
+    #[test]
+    fn begin_domain_discovery_with_not_found_pending_default_skips_redundant_repeats() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+
+        // First run: completes with no domains, pending_default="NeverFound".
+        let ran_first = Arc::new(AtomicBool::new(false));
+        let ran_first2 = Arc::clone(&ran_first);
+        mux.begin_domain_discovery(
+            move || {
+                ran_first2.store(true, Ordering::SeqCst);
+                Ok(vec![]) // No domains registered
+            },
+            Some("NeverFound".to_string()),
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            ran_first.load(Ordering::SeqCst),
+            "first run must have executed"
+        );
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::Done {
+                    not_found_pending_default,
+                    ..
+                } if not_found_pending_default.as_deref() == Some("NeverFound")
+            ),
+            "Done state must remember the not-found pending_default name"
+        );
+
+        // Repeat call with the same name: must NOT spawn a new thread.
+        let ran_second = Arc::new(AtomicBool::new(false));
+        let ran_second2 = Arc::clone(&ran_second);
+        let start = Instant::now();
+        mux.begin_domain_discovery(
+            move || {
+                ran_second2.store(true, Ordering::SeqCst);
+                Ok(vec![])
+            },
+            Some("NeverFound".to_string()),
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "must return synchronously when same not-found name is requested again"
+        );
+        assert!(
+            matches!(
+                &*mux.domain_discovery.lock(),
+                DomainDiscoveryState::Done { .. }
+            ),
+            "must not start a run when same not-found name is requested again"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+        assert!(
+            !ran_second.load(Ordering::SeqCst),
+            "must not spawn a thread when same not-found name is requested again"
+        );
+
+        // Different name: MUST spawn a fresh run (this is the "genuinely new
+        // name" case the comment describes).
+        let ran_third = Arc::new(AtomicBool::new(false));
+        let ran_third2 = Arc::clone(&ran_third);
+        mux.begin_domain_discovery(
+            move || {
+                ran_third2.store(true, Ordering::SeqCst);
+                Ok(vec![])
+            },
+            Some("DifferentNeverFound".to_string()),
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            ran_third.load(Ordering::SeqCst),
+            "must spawn a fresh run for a different never-found name"
+        );
+    }
+
+    /// Regression test: decides the right wait
+    /// flavor for each `SpawnTabDomain` shape without needing the async
+    /// machinery (`promise::spawn` requires a configured global scheduler
+    /// to actually drive a `Task` to completion, which isn't set up in
+    /// this test binary). This is what keeps `split_pane`/
+    /// `spawn_tab_or_window`'s async pre-await from either over-waiting
+    /// (blocking on discovery unnecessarily for the common case, right
+    /// back to what this whole fix is for) or under-waiting (still
+    /// racing discovery for the cases `resolve_spawn_tab_domain`/
+    /// `resolve_default_domain` themselves wait for).
+    #[test]
+    fn domain_resolution_wait_kind_matches_resolve_methods() {
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+
+        // No discovery in flight at all: never wait, regardless of target.
+        assert_eq!(
+            mux.domain_resolution_wait_kind(None, &SpawnTabDomain::DefaultDomain),
+            DomainResolutionWaitKind::None
+        );
+        assert_eq!(
+            mux.domain_resolution_wait_kind(
+                None,
+                &SpawnTabDomain::DomainName("Unregistered".to_string())
+            ),
+            DomainResolutionWaitKind::None,
+            "no discovery in flight, so nothing could still register this name"
+        );
+        assert_eq!(
+            mux.domain_resolution_wait_kind(Some(1), &SpawnTabDomain::CurrentPaneDomain),
+            DomainResolutionWaitKind::None,
+            "CurrentPaneDomain with a pane_id never goes through discovery at all"
+        );
+        assert_eq!(
+            mux.domain_resolution_wait_kind(None, &SpawnTabDomain::CurrentPaneDomain),
+            DomainResolutionWaitKind::None,
+            "no pending_default outstanding, so nothing to wait for even though pane_id is None"
+        );
+
+        // Start a discovery with a pending_default: DefaultDomain / a
+        // pane-less CurrentPaneDomain must wait unbounded (matching
+        // resolve_default_domain); an explicit name lookup still only
+        // waits bounded (matching resolve_spawn_tab_domain), even for
+        // the same name as pending_default.
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![])
+            },
+            Some("WSL:Ubuntu".to_string()),
+        );
+
+        assert_eq!(
+            mux.domain_resolution_wait_kind(None, &SpawnTabDomain::DefaultDomain),
+            DomainResolutionWaitKind::Unbounded
+        );
+        assert_eq!(
+            mux.domain_resolution_wait_kind(None, &SpawnTabDomain::CurrentPaneDomain),
+            DomainResolutionWaitKind::Unbounded
+        );
+        assert_eq!(
+            mux.domain_resolution_wait_kind(Some(1), &SpawnTabDomain::CurrentPaneDomain),
+            DomainResolutionWaitKind::None,
+            "a concrete pane_id resolves via resolve_pane_id, never touching pending_default"
+        );
+        assert_eq!(
+            mux.domain_resolution_wait_kind(
+                None,
+                &SpawnTabDomain::DomainName("WSL:Ubuntu".to_string())
+            ),
+            DomainResolutionWaitKind::Bounded,
+            "an explicit name lookup always uses the bounded wait, even for the same name \
+             as pending_default"
+        );
+        drop(gate_tx);
+    }
+
+    /// Test that `add_domain` unconditionally registers domains, even when
+    /// they share the same name. The mux model does not guarantee globally-unique
+    /// domain names -- only `DomainId`s are unique. This matches the real-world
+    /// pattern used by `TermWizTerminalDomain` (always name "TermWizTerminalDomain")
+    /// and `TmuxDomain` (always name "tmux"), where multiple domain instances with
+    /// the same constant name but different `DomainId`s are created and must all
+    /// be reachable via `get_domain(id)`.
+    #[test]
+    fn add_domain_allows_same_name_different_ids() {
+        let mux = new_test_mux();
+        let first = dummy_domain("Dup");
+        let second = dummy_domain("Dup");
+        assert_ne!(first.domain_id(), second.domain_id());
+
+        mux.add_domain(&first);
+        mux.add_domain(&second);
+
+        // Both domains should be reachable by their unique IDs.
+        let resolved_first = mux
+            .get_domain(first.domain_id())
+            .expect("first domain should be registered by ID");
+        let resolved_second = mux
+            .get_domain(second.domain_id())
+            .expect("second domain should be registered by ID");
+        assert_eq!(resolved_first.domain_id(), first.domain_id());
+        assert_eq!(resolved_second.domain_id(), second.domain_id());
+
+        // `get_domain_by_name` returns one of them (the most recently
+        // inserted, which is the second in this case).
+        let resolved_by_name = mux
+            .get_domain_by_name("Dup")
+            .expect("domain should be registered by name");
+        assert_eq!(
+            resolved_by_name.domain_id(),
+            second.domain_id(),
+            "get_domain_by_name returns the most recent insertion for that name"
+        );
+    }
+
+    /// Test that background discovery deduplicates by name within a single
+    /// discovery run: if a domain with a given name is already registered
+    /// (by a config reload, or by an earlier discovery in the same run), the
+    /// discovery thread should not register a duplicate. This is tested
+    /// indirectly by having the discovery closure return two domains with the
+    /// same name and asserting that only one ends up registered.
+    #[test]
+    fn discovery_dedup_by_name_within_same_run() {
+        let mux = Arc::new(Mux::new(None));
+
+        // Start discovery with two domains having the same name.
+        mux.begin_domain_discovery(
+            || Ok(vec![dummy_domain("WSL:Ubuntu"), dummy_domain("WSL:Ubuntu")]),
+            None,
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        // Only one domain with name "WSL:Ubuntu" should be registered.
+        let registered = mux
+            .iter_domains()
+            .into_iter()
+            .filter(|d| d.domain_name() == "WSL:Ubuntu")
+            .collect::<Vec<_>>();
+        assert_eq!(
+            registered.len(),
+            1,
+            "discovery should deduplicate domains with the same name within the same run"
+        );
+    }
+
+    /// Regression test: `discovery_dedup_by_name_within_same_run` above only proves a
+    /// duplicate name gets deduplicated -- it can't distinguish "the
+    /// worker correctly skipped the dup and kept going" from "the worker
+    /// treated the dup as the whole run being superseded and gave up",
+    /// because there's nothing else in the list to notice going missing.
+    /// This test puts a domain with a *different* name right after the
+    /// duplicate: if `add_discovered_domain` conflates "name already
+    /// taken" with "generation superseded" and the worker loop `return`s
+    /// on either, the domain after the duplicate never gets registered.
+    #[test]
+    fn discovery_continues_registering_domains_after_a_name_collision() {
+        let mux = Arc::new(Mux::new(None));
+
+        mux.begin_domain_discovery(
+            || {
+                Ok(vec![
+                    dummy_domain("WSL:Ubuntu"),
+                    dummy_domain("WSL:Ubuntu"), // collides with the one above
+                    dummy_domain("WSL:Debian"), // must still be registered
+                ])
+            },
+            None,
+        );
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+
+        assert!(
+            mux.get_domain_by_name("WSL:Ubuntu").is_some(),
+            "the first, non-colliding registration must still succeed"
+        );
+        assert!(
+            mux.get_domain_by_name("WSL:Debian").is_some(),
+            "a name collision earlier in the discovered list must not abort \
+             registration of a later, differently-named domain"
+        );
+    }
+
+    /// Regression test: a discovery run superseded by cancellation *and* a
+    /// subsequent fresh discovery run must not have its late-finishing
+    /// guard mistake the newer run's `InProgress` state for its own and
+    /// finish it early.
+    #[test]
+    fn stale_finish_guard_does_not_finish_a_newer_discovery_run() {
+        let mux = new_test_mux();
+        let (first_gate_tx, first_gate_rx) = std::sync::mpsc::channel::<()>();
+
+        // First (soon-to-be-cancelled) run.
+        mux.begin_domain_discovery(
+            move || {
+                let _ = first_gate_rx.recv();
+                Ok(vec![])
+            },
+            None,
+        );
+        mux.notify_cancelled_domain_discovery_waiters(mux.cancel_domain_discovery());
+
+        // Second run starts while the first thread is still parked on its
+        // gate, so its finish guard hasn't dropped yet.
+        let (second_gate_tx, second_gate_rx) = std::sync::mpsc::channel::<()>();
+        mux.begin_domain_discovery(
+            move || {
+                let _ = second_gate_rx.recv();
+                Ok(vec![dummy_domain("Second")])
+            },
+            Some("Second".to_string()),
+        );
+
+        // Let the stale first thread finish while the second run's gate
+        // is still closed. If its finish guard mistakes the second run's
+        // `InProgress` state for its own, it will mark it `Done` here --
+        // before the second run has actually produced anything.
+        first_gate_tx
+            .send(())
+            .expect("first discovery thread should still be waiting on its gate");
+        // Give the stale thread time to reach and drop its finish guard.
+        // Correct behavior leaves no trace to poll for -- the guard finds
+        // itself generation-stale and returns without touching the state --
+        // so this is a fixed window that only *exits early* in the failure
+        // case it is guarding against: a stale guard that wrongly moved the
+        // second run out of `InProgress`.
+        let deadline = Instant::now() + Duration::from_millis(500);
+        while Instant::now() < deadline {
+            let state = mux.domain_discovery.lock();
+            if !matches!(&*state, DomainDiscoveryState::InProgress { .. }) {
+                break;
+            }
+            drop(state);
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        // A short bounded wait here must still time out (the second run
+        // must still be InProgress), not return immediately as it would
+        // if the stale first guard had wrongly finished it.
+        let start = Instant::now();
+        mux.await_domain_discovery(Duration::from_millis(80));
+        assert!(
+            start.elapsed() >= Duration::from_millis(70),
+            "the second run must still be InProgress; a stale guard must not finish it early"
+        );
+        assert!(
+            mux.get_domain_by_name("Second").is_none(),
+            "the second run hasn't produced its domain yet"
+        );
+
+        // Now let the second (genuine) run finish and confirm it
+        // completes normally, applying its own pending_default.
+        second_gate_tx
+            .send(())
+            .expect("second discovery thread should still be waiting on its gate");
+        mux.await_domain_discovery(DOMAIN_DISCOVERY_TIMEOUT);
+        assert!(
+            mux.get_domain_by_name("Second").is_some(),
+            "the second run's domain must be registered once it completes"
+        );
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "Second",
+            "the second run's pending_default must still be applied by its own guard"
+        );
+    }
+
+    /// Test that `DomainDiscoveryWaitFuture` genuinely doesn't block
+    /// the executor while pending: when run on a real executor with a
+    /// concurrently-executing second future that makes progress on each
+    /// poll, the counter should advance while discovery is gated closed,
+    /// proving the executor wasn't blocked waiting for discovery to complete.
+    #[test]
+    fn domain_discovery_wait_future_does_not_block_executor() {
+        use std::future::Future;
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+        use std::time::{Duration, Instant};
+
+        // Create a mux and gate discovery closed.
+        let mux = Arc::new(Mux::new(Some(dummy_domain("dummy-default"))));
+        let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
+        mux.begin_domain_discovery(
+            move || {
+                let _ = gate_rx.recv();
+                Ok(vec![dummy_domain("Discovered")])
+            },
+            Some("Discovered".to_string()),
+        );
+
+        // A simple future that increments a counter on each poll.
+        struct CounterFuture {
+            counter: Arc<AtomicUsize>,
+        }
+
+        impl CounterFuture {
+            fn new(counter: Arc<AtomicUsize>) -> Self {
+                Self { counter }
+            }
+        }
+
+        impl Future for CounterFuture {
+            type Output = ();
+
+            fn poll(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Self::Output> {
+                self.counter.fetch_add(1, Ordering::SeqCst);
+                // Never complete -- we just want to observe it being polled.
+                Poll::Pending
+            }
+        }
+
+        // Run both futures together with a simple executor (select-like).
+        // We'll manually drive the executor to simulate concurrent polling.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let mut wait_future = mux.await_domain_discovery_unbounded_async();
+        let mut counter_future = CounterFuture::new(Arc::clone(&counter));
+        let waker = test_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // Poll both futures several times while discovery is gated.
+        // If the wait future blocks the executor, the counter won't advance.
+        let start = Instant::now();
+        let deadline = start + Duration::from_millis(200);
+        while Instant::now() < deadline {
+            let _ = Pin::new(&mut wait_future).poll(&mut cx);
+            let _ = Pin::new(&mut counter_future).poll(&mut cx);
+            std::thread::sleep(Duration::from_millis(5));
+        }
+
+        let initial_counter = counter.load(Ordering::SeqCst);
+        assert!(
+            initial_counter > 0,
+            "counter should advance while discovery is gated, proving executor wasn't blocked"
+        );
+
+        // Now open the gate and let discovery complete.
+        let _ = gate_tx.send(());
+        let mut completed = false;
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < deadline {
+            match Pin::new(&mut wait_future).poll(&mut cx) {
+                Poll::Ready(_) => {
+                    completed = true;
+                    break;
+                }
+                Poll::Pending => {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            }
+        }
+        assert!(
+            completed,
+            "wait future should complete once discovery finishes"
+        );
+
+        assert_eq!(
+            mux.default_domain().domain_name(),
+            "Discovered",
+            "pending_default should be applied once discovery completes"
+        );
     }
 }

--- a/wezterm-gui/src/main.rs
+++ b/wezterm-gui/src/main.rs
@@ -444,9 +444,31 @@ async fn async_run_terminal_gui(
     let mux = Mux::get();
 
     let domain = if let Some(name) = &opts.domain {
-        let domain = mux
-            .get_domain_by_name(name)
-            .ok_or_else(|| anyhow!("invalid domain {name}"))?;
+        // Waits unbounded (not resolve_spawn_tab_domain's own bounded
+        // DOMAIN_DISCOVERY_TIMEOUT) for a background discovery kicked off
+        // by setup_mux/update_mux_domains to register this domain if it
+        // hasn't yet. This is an explicit, user-requested startup domain,
+        // so a bounded cutoff would incorrectly treat "still discovering"
+        // as "doesn't exist" and fail startup outright -- on exactly the
+        // slow-`wsl.exe` machines this whole fix targets, where discovery
+        // can easily take longer than the bound. Mirrors setup_mux's own
+        // wait, for the same reason. Goes through the async wrapper
+        // (rather than blocking this thread directly) since this runs on
+        // the main-thread executor.
+        if mux.get_domain_by_name(name).is_none() {
+            let _ = mux.await_domain_discovery_unbounded_async().await;
+        }
+        // Wait-free lookup after the async pre-wait above, rather than
+        // the plain synchronous `resolve_spawn_tab_domain`: if a brand
+        // new discovery run started in the gap between the pre-wait
+        // finishing and this call running, the synchronous resolver
+        // would block this main-thread executor again -- unbounded, for
+        // this DefaultDomain-adjacent path -- defeating the point of
+        // having awaited already.
+        let domain = mux.resolve_spawn_tab_domain_no_wait(
+            None,
+            &SpawnTabDomain::DomainName(name.to_string()),
+        )?;
         Some(domain)
     } else {
         None
@@ -697,12 +719,26 @@ fn setup_mux(
     let default_name =
         default_domain_name.unwrap_or(config.default_domain.as_deref().unwrap_or("local"));
 
-    let domain = mux.get_domain_by_name(default_name).ok_or_else(|| {
-        anyhow::anyhow!(
-            "desired default domain '{}' was not found in mux!?",
-            default_name
-        )
-    })?;
+    let domain = match mux.get_domain_by_name(default_name) {
+        Some(domain) => domain,
+        None => {
+            // The requested domain may be a WSL domain that a background
+            // discovery kicked off by update_mux_domains hasn't finished
+            // registering yet. Wait for it to finish rather than bailing
+            // out after an arbitrary timeout: `wsl.exe` can legitimately
+            // take many seconds on a cold start, and this is the domain
+            // the user explicitly asked wezterm to start in, so failing
+            // startup just because discovery hadn't caught up yet would
+            // be a regression from the old fully-synchronous behavior.
+            mux.await_domain_discovery_unbounded();
+            mux.get_domain_by_name(default_name).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "desired default domain '{}' was not found in mux!?",
+                    default_name
+                )
+            })?
+        }
+    };
     mux.set_default_domain(&domain);
 
     Ok(mux)

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -3055,7 +3055,17 @@ impl TermWindow {
                 }
             }
             DetachDomain(domain) => {
-                let domain = Mux::get().resolve_spawn_tab_domain(Some(pane.pane_id()), domain)?;
+                // Wait-free resolve: this runs synchronously on the GUI
+                // thread, and the waiting variant can park it for the
+                // duration of an in-flight background domain discovery
+                // (unbounded, for the DefaultDomain case) -- ie. exactly
+                // the freeze that moving discovery off the startup path
+                // was meant to eliminate, just relocated to a key press.
+                // Detaching only makes sense for a domain that is already
+                // attached, and therefore already registered, so there is
+                // nothing for it to wait on in the first place.
+                let domain =
+                    Mux::get().resolve_spawn_tab_domain_no_wait(Some(pane.pane_id()), domain)?;
                 domain.detach()?;
             }
             AttachDomain(domain) => {

--- a/wezterm-mux-server-impl/src/lib.rs
+++ b/wezterm-mux-server-impl/src/lib.rs
@@ -36,6 +36,71 @@ pub fn update_mux_domains_for_server(config: &ConfigHandle) -> anyhow::Result<()
     update_mux_domains_impl(config, true)
 }
 
+/// Registers the `exec_domains` and `serial_ports` from `config` that `mux`
+/// doesn't already know about.
+///
+/// Split out from `update_mux_domains_impl` so both of its paths can share it:
+/// with an explicit `wsl_domains` list this runs inside
+/// `cancel_domain_discovery_and_replace`'s closure, and without one it runs
+/// directly. Safe in the former because it is pure in-memory work --
+/// `LocalDomain::new_exec_domain` and `new_serial_domain` only build the domain
+/// object (`SerialTty::new` just records the port name and settings; the port
+/// isn't opened until a pane is spawned into it), so nothing here does I/O or
+/// blocks while the discovery lock is held.
+fn register_exec_and_serial_domains(mux: &Arc<Mux>, config: &ConfigHandle) -> anyhow::Result<()> {
+    for exec_dom in &config.exec_domains {
+        if mux.get_domain_by_name(&exec_dom.name).is_some() {
+            continue;
+        }
+
+        let domain: Arc<dyn Domain> = Arc::new(LocalDomain::new_exec_domain(exec_dom.clone())?);
+        mux.add_domain(&domain);
+    }
+
+    for serial in &config.serial_ports {
+        if mux.get_domain_by_name(&serial.name).is_some() {
+            continue;
+        }
+
+        let domain: Arc<dyn Domain> = Arc::new(LocalDomain::new_serial_domain(serial.clone())?);
+        mux.add_domain(&domain);
+    }
+
+    Ok(())
+}
+
+/// Applies the configured default domain, if it names one that is registered
+/// by now. Deliberately a no-op when it isn't: on the auto-discovery path the
+/// name may belong to a WSL domain that hasn't been found yet, and discovery
+/// applies it via `pending_default` once it appears.
+///
+/// Only takes `default_domain`'s lock (through `Mux::set_default_domain`), so
+/// this is safe to call with the discovery lock held: `domain_discovery` is the
+/// outer lock relative to `default_domain` everywhere in `mux`, never the
+/// reverse.
+fn apply_default_domain(
+    mux: &Arc<Mux>,
+    config: &ConfigHandle,
+    is_standalone_mux: bool,
+) -> anyhow::Result<()> {
+    let configured = if is_standalone_mux {
+        &config.default_mux_server_domain
+    } else {
+        &config.default_domain
+    };
+
+    if let Some(name) = configured {
+        if let Some(dom) = mux.get_domain_by_name(name) {
+            if is_standalone_mux && dom.is::<ClientDomain>() {
+                anyhow::bail!("default_mux_server_domain cannot be set to a client domain!");
+            }
+            mux.set_default_domain(&dom);
+        }
+    }
+
+    Ok(())
+}
+
 fn update_mux_domains_impl(config: &ConfigHandle, is_standalone_mux: bool) -> anyhow::Result<()> {
     let mux = Mux::get();
 
@@ -61,48 +126,113 @@ fn update_mux_domains_impl(config: &ConfigHandle, is_standalone_mux: bool) -> an
         mux.add_domain(&domain);
     }
 
-    for wsl_dom in config.wsl_domains() {
-        if mux.get_domain_by_name(&wsl_dom.name).is_some() {
-            continue;
-        }
-
-        let domain: Arc<dyn Domain> = Arc::new(LocalDomain::new_wsl(wsl_dom.clone())?);
-        mux.add_domain(&domain);
-    }
-
-    for exec_dom in &config.exec_domains {
-        if mux.get_domain_by_name(&exec_dom.name).is_some() {
-            continue;
-        }
-
-        let domain: Arc<dyn Domain> = Arc::new(LocalDomain::new_exec_domain(exec_dom.clone())?);
-        mux.add_domain(&domain);
-    }
-
-    for serial in &config.serial_ports {
-        if mux.get_domain_by_name(&serial.name).is_some() {
-            continue;
-        }
-
-        let domain: Arc<dyn Domain> = Arc::new(LocalDomain::new_serial_domain(serial.clone())?);
-        mux.add_domain(&domain);
-    }
-
-    if is_standalone_mux {
-        if let Some(name) = &config.default_mux_server_domain {
-            if let Some(dom) = mux.get_domain_by_name(name) {
-                if dom.is::<ClientDomain>() {
-                    anyhow::bail!("default_mux_server_domain cannot be set to a client domain!");
+    if let Some(wsl_domains) = &config.wsl_domains {
+        // Use cancel_domain_discovery_and_replace to close the TOCTOU race
+        // where a new waiter arriving between cancel and notify would see NotStarted
+        // and do its lookup before replacement domains are registered.
+        //
+        // If a previous reload left an auto-discovery (from when
+        // wsl_domains wasn't configured) still running in the background,
+        // it's now stale: this config no longer wants discovered domains
+        // or a discovery-driven default. Cancel it, register the explicit
+        // wsl_domains atomically, then publish -- so every waiter -- sync or
+        // async -- sees either the old discovery state or the new explicit
+        // domains, never an intermediate state.
+        //
+        // The barrier deliberately spans the *whole* synchronous reload, not
+        // just the WSL part: the exec domains, the serial ports and the new
+        // default are all applied while the discovery lock is still held.
+        // Publishing after only the WSL domains were registered would leave a
+        // woken waiter able to observe a half-applied configuration -- looking
+        // up an exec/serial domain the new config does define and being told it
+        // is invalid, or reading the previous default. Since `mux` has no
+        // WSL-specific knowledge, a waiter parked on discovery may well be
+        // waiting for a name that has nothing to do with WSL, which is exactly
+        // how that becomes observable.
+        mux.cancel_domain_discovery_and_replace(|| {
+            // Explicitly configured: already in memory and cheap to use, so
+            // apply synchronously exactly as before. No need to shell out to
+            // `wsl.exe`, so no reason to defer.
+            for wsl_dom in wsl_domains {
+                if mux.get_domain_by_name(&wsl_dom.name).is_some() {
+                    continue;
                 }
-                mux.set_default_domain(&dom);
+
+                let domain: Arc<dyn Domain> = Arc::new(LocalDomain::new_wsl(wsl_dom.clone())?);
+                mux.add_domain(&domain);
             }
-        }
+
+            register_exec_and_serial_domains(&mux, config)?;
+            apply_default_domain(&mux, config, is_standalone_mux)?;
+
+            Ok(())
+        })?;
     } else {
-        if let Some(name) = &config.default_domain {
-            if let Some(dom) = mux.get_domain_by_name(name) {
-                mux.set_default_domain(&dom);
-            }
+        // No explicit list, so there is no in-flight discovery to cancel and
+        // nothing to publish atomically against -- these can just be applied
+        // directly. Registration still has to happen *before*
+        // `begin_domain_discovery` below, so that the `pending_default` it
+        // computes reflects a genuine "not discovered yet" rather than merely
+        // "not reached in this function yet".
+        register_exec_and_serial_domains(&mux, config)?;
+        // Not configured: discovering the default list shells out to
+        // `wsl.exe -l -v`, which can block for many seconds (starting the
+        // LxssManager service and/or booting the WSL2 utility VM) on
+        // Windows. Do that on a background thread instead of blocking
+        // mux/gui startup on it (see mux::Mux::begin_domain_discovery,
+        // which has no WSL-specific knowledge itself -- constructing the
+        // actual WSL `LocalDomain`s happens in the closure below, kept
+        // here alongside the rest of this function's domain-registration
+        // logic). This runs after every synchronously-known domain
+        // (client/ssh/exec/serial) has already been registered above, so
+        // `pending_default` below reflects a genuine "not found yet"
+        // rather than "hasn't been reached in this function yet". If the
+        // configured default domain isn't known at this point, it may be
+        // a WSL domain that's about to be discovered, so let discovery
+        // apply it once found rather than leaving it unset.
+        let default_domain_name = if is_standalone_mux {
+            config.default_mux_server_domain.clone()
+        } else {
+            config.default_domain.clone()
+        };
+        let pending_default =
+            default_domain_name.filter(|name| mux.get_domain_by_name(name).is_none());
+        let discover = || {
+            config::WslDomain::try_default_domains().map(|domains| {
+                domains
+                    .into_iter()
+                    .filter_map(|wsl_dom| match LocalDomain::new_wsl(wsl_dom.clone()) {
+                        Ok(domain) => Some(Arc::new(domain) as Arc<dyn Domain>),
+                        Err(err) => {
+                            log::error!(
+                                "Error constructing wsl domain {}: {:#}",
+                                wsl_dom.name,
+                                err
+                            );
+                            None
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+        };
+        if is_standalone_mux {
+            // Keep the same "default_mux_server_domain cannot be a client
+            // domain" invariant enforced below for the synchronous case
+            // from being silently bypassed if the named domain is instead
+            // found asynchronously by discovery.
+            mux.begin_domain_discovery_with_default_filter(discover, pending_default, |dom| {
+                !dom.is::<ClientDomain>()
+            });
+        } else {
+            mux.begin_domain_discovery(discover, pending_default);
         }
+
+        // Applied after `begin_domain_discovery` rather than before it purely
+        // to preserve the original ordering; the call above doesn't register
+        // anything synchronously, so the outcome is the same either way. If
+        // the configured name isn't registered by now this is a no-op and
+        // discovery applies it via `pending_default` once it finds it.
+        apply_default_domain(&mux, config, is_standalone_mux)?;
     }
 
     Ok(())

--- a/wezterm-mux-server/src/main.rs
+++ b/wezterm-mux-server/src/main.rs
@@ -273,7 +273,16 @@ async fn async_run(cmd: Option<CommandBuilder>) -> anyhow::Result<()> {
         true
     });
 
-    let domain = mux.default_domain();
+    // Waits for an in-flight background domain discovery (see
+    // update_mux_domains_for_server / Mux::begin_domain_discovery) if the
+    // configured default_mux_server_domain named a domain that hasn't
+    // been registered yet, instead of silently falling back to whatever
+    // default was already in place.
+    // The pre-wait above is the wait; resolving must not block a second
+    // time if a fresh discovery run happened to start in the gap.
+    mux.await_domain_resolution_async(None, &config::keyassignment::SpawnTabDomain::DefaultDomain)
+        .await;
+    let domain = mux.resolve_default_domain_no_wait()?;
 
     {
         if let Err(err) = config::with_lua_config_on_main_thread(trigger_mux_startup).await {


### PR DESCRIPTION
On Windows, starting wezterm -- and, separately, spawning the first pane --
could take 15-50+ seconds when `wsl_domains` was left unconfigured. Two
separate causes, both of them synchronous `wsl.exe -l -v` invocations:

* `update_mux_domains` built the default WSL domain list on the startup
  path, so the GUI didn't come up until `wsl.exe` did.
* `LocalDomain::resolve_wsl_domain` re-derived that list on *every* pane
  spawn, for every domain type -- including plain local ones that have
  nothing to do with WSL.

`wsl.exe -l -v` is slow for reasons outside wezterm's control (it may have
to start the LxssManager service and/or boot the WSL2 utility VM), and it
can hang outright when WSL is in a bad state, so the fix is to stop
blocking on it rather than to try to make it faster. Fixes #7782.

Discovery now runs on a background thread and publishes into the mux as it
completes; its result is cached for the life of the process rather than
recomputed per spawn. The non-blocking `cached_default_domains()` accessor
is what the spawn path uses, and it distinguishes "discovery hasn't
finished yet" (fall back to the domain's construction-time snapshot, which
carries the real distribution name -- resolving to `None` here would make
`fixup_command` silently run the command on the Windows host instead of
inside WSL) from "the list is known and doesn't contain this name" (a real
"no longer a WSL domain"). Only domains actually constructed as WSL domains
(explicit `wsl_domains` entries or auto-discovery) get this treatment now;
a plain domain whose name happens to collide with a `wsl_domains` entry no
longer does.

The hard part is not the background thread, it's not letting spawns race
it. A `DomainDiscoveryState` state machine (`NotStarted`/`InProgress`/
`Done`) coordinates that:

* Resolving a domain *by name* that isn't registered yet waits for an
  in-flight run, bounded by `DOMAIN_DISCOVERY_TIMEOUT`, instead of
  immediately reporting "invalid domain name". Bounded rather than
  unbounded because such a name is much more likely to be one that will
  never appear -- a typo, or a distribution since removed -- than the
  startup-critical case below, and blocking that spawn for the whole of a
  cold `wsl.exe` before saying so is its own kind of wrong. The cost of
  that choice is real and worth naming: `wsl.exe` can take longer than the
  bound on the very machines this targets, so a by-name spawn issued in the
  first seconds -- most plausibly from a `gui-startup` handler -- can be
  told the name is invalid even though discovery finds it shortly after.
  Configs that need a specific WSL domain available that early should set
  `wsl_domains` explicitly; the constant's own doc comment and the
  `wsl_domains`/`mux.get_domain` docs say so too.
* A `default_domain`/`default_mux_server_domain`/`--domain` that names a
  not-yet-discovered domain waits unbounded: a timeout there would treat
  "discovery is slow" as "the domain doesn't exist" and fail startup
  outright, which is exactly what happens on the slow-`wsl.exe` machines
  this targets. This is also the pre-existing behaviour, since discovery
  used to be synchronous. The wait re-checks periodically and logs while it
  is still waiting, so a slow or stuck startup is diagnosable from the log
  rather than being silent.
* Async callers (`split_pane`, `spawn_tab_or_window`, the GUI's `--domain`
  handling, the mux server's startup) `await` a `DomainDiscoveryWaitFuture`
  and then resolve wait-free, rather than parking the main-thread executor
  on a condvar. Blocking resolution from the GUI thread would freeze
  repaints and input for the whole wait -- every synchronous resolver call
  site left in the GUI thread (including `DetachDomain`) was audited and
  switched to the wait-free variant.
* A config reload that switches to an explicit `wsl_domains` list cancels
  the in-flight run and applies the whole of the rest of that reload -- the
  explicit WSL domains, the exec domains, the serial ports and the new
  default -- while still holding the discovery lock, so no waiter can
  observe a half-applied configuration. Publishing after only the WSL part
  would let a woken waiter be told an exec or serial domain the new config
  does define is invalid, or read the previous default; since `Mux` has no
  WSL-specific knowledge, a waiter parked on discovery may well be waiting
  for a name that has nothing to do with WSL, which is what makes that
  observable. Cancelling resets to
  `NotStarted`, never `Done`: conflating "cancelled without discovering
  anything" with "completed" would make a later reload back to
  auto-discovery skip discovery entirely for the rest of the process's
  life. That atomic cancel-and-replace is the only cancellation entry
  point exposed; the two-phase split it is built on stays crate-private,
  since a caller that drops the drained `Waker`s, returns early, or panics
  between the two halves parks every async waiter forever, and
  `#[must_use]` only warns.
* `wsl.exe` failures stay failures. They finish the run as `NotStarted`
  (retryable on the next reload) and are logged, rather than being cached
  as a successful empty list -- otherwise one transient failure means "you
  have no WSL domains" until restart. A `pending_default` name a completed
  run already failed to find is remembered, so a stale/typo'd
  `default_domain` doesn't spawn a fresh discovery thread on every config
  reload just to re-derive the same "not found" answer.
* Concurrent `wsl.exe` invocations *on this path* are capped at one via a
  claimed-timestamp guard (`wezterm.default_wsl_domains()` deliberately
  bypasses it, since it is documented to always produce a live answer);
  a caller that finds a run already in flight waits for it (bounded)
  and adopts its result instead of starting a second one, but a genuinely
  abandoned (permanently hung) claim is detected by age and treated as
  stale rather than blocking every later caller for the same timeout
  forever. A run still in flight past `DOMAIN_DISCOVERY_STUCK_THRESHOLD` is
  likewise superseded by the next `begin_domain_discovery` call rather than
  making it a no-op, so a permanently hung `wsl.exe` doesn't pin the state
  machine in `InProgress` for the life of the process.

`wezterm.mux.get_domain()`/`wezterm.mux.all_domains()` stay synchronous
snapshot lookups: both are reachable from synchronous lua callbacks
(`format-tab-title` and friends), where an mlua async function would fail
with "attempt to yield from outside a coroutine". This means a
`gui-startup`/`mux-startup` handler that runs before discovery finishes may
transiently not see an auto-discovered WSL domain by name; a config that
needs one deterministically available at startup should set `wsl_domains`
explicitly. `wezterm.default_wsl_domains()` keeps its documented
always-live semantics and is deliberately not served from the cache; only
wezterm's own internal default-list computation is cached. Because that
cache lives as long as the process does, a long-lived one (notably
`wezterm-mux-server`) won't notice a distribution installed or removed
after it started, even across a reload; the changelog and the docs for
`default_wsl_domains()` spell that out, along with the always-live escape
hatch and its own limit -- it picks up additions, but domains already
registered with the mux are never unregistered.

The concurrency details (lock ordering, panic-safety via
`FinishDomainDiscoveryOnDrop`, `catch_unwind` around the caller-supplied
`accepts_as_default` predicate, generation-based staleness, wake-after-
unlock, and how a superseded run's late success gets adopted -- including
applying the *current* default request rather than the one it was spawned
with) are covered by doc comments at each site and by named regression
tests in `mux/src/lib.rs` and `config/src/wsl.rs`; not restated here.

Known limitation: `WslDistro::load_distro_list` still invokes `wsl.exe`
without a deadline, so a permanently hung one is worked around (startup no
longer blocks on it, and stuck runs are superseded) rather than resolved --
each supersede leaves the blocked thread and its child process behind.
Giving that call a timeout with a kill and reap would address the root
cause, but that is pre-existing behaviour unrelated to the latency this
change targets, so it is left for a follow-up.


## Test plan

- [x] `cargo test -p mux -p config --lib` (61 tests, new regression tests for
      each of: non-blocking startup, bounded vs. unbounded waits, the
      construction-time fallback while the cache is unpopulated, applying
      `pending_default` at all three sites it can be applied, cancel/replace
      semantics, zero-distribution discovery, stuck-run supersession)
- [x] `cargo check` across `wezterm-gui`, `wezterm-mux-server`,
      `wezterm-mux-server-impl`, `mux-lua`, `wezterm`
- [x] `cargo +nightly fmt --all -- --check`
- [x] Built and ran both debug and release `wezterm-gui`/`wezterm` on
      Windows with a real (stopped) WSL distribution installed; GUI startup
      no longer blocks on `wsl.exe`
