### PR TITLE
fix(kitty): map shared memory on macOS, nine protocol keys, and hash images once in hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5442,6 +5442,16 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest",
+ "sha2-asm",
+]
+
+[[package]]
+name = "sha2-asm"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7031,6 +7031,7 @@ dependencies = [
  "image",
  "k9",
  "log",
+ "memmap2 0.9.11",
  "nix",
  "num-derive",
  "num-traits",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -284,10 +284,48 @@ As features stabilize some brief notes about them will accumulate here.
 * Fix ESC key encoding in kitty mode with disambiguate flag enabled.
   Thanks to @Felixoid and @the-mikedavis! #7787
 * Fixed two divide-by-zero crashes in Kitty inline image placement when a program requests
-  a zero-sized placement (e.g. `w=0`/`h=0`), or displaying a cell-sized image on a pane
+  a placement with nothing to draw, or displaying a cell-sized image on a pane
   whose pty reported no pixel dimensions (e.g. in `tmux -CC` domain).
   Such images are now refused instead of taking down the pane. Thanks to @zakrad! #6344
 * Fix render loop freeze when closing workspaces. Thanks to @JafarAbdi! #7444
+* macOS: Fixed the kitty image protocol shared memory transport (`t=s`), which
+  never drew anything. A POSIX shared memory object can only be mapped on macOS,
+  so reading one failed with `Device not configured` and the image was dropped
+  without any reply to the application. Such objects are now mapped rather than
+  read from, on all unix systems. Thanks to @eschnett! #7631
+* Fixed raw format kitty images being refused when the file or shared memory
+  object holding them is longer than the image itself, which a shared memory
+  object always is once it is rounded up to a page. The pixel count follows from
+  `f`, `s` and `v`, so only that much is read.
+* Fixed a kitty image data size of zero being read as a request for no bytes.
+  `S` defaults to zero, so that is a size the client did not give.
+* Fixed the kitty image protocol data offset being re-encoded under the `S` key,
+  which overwrote the size and dropped `O` entirely. This affects anything that
+  parses an image escape sequence and writes it back out through `Display`.
+* Fixed the kitty animation frame gap being read and written as `Z` rather than
+  the `z` the protocol uses, so a client's frame gap was ignored and every
+  animated frame fell back to the 40ms default.
+* Fixed transmit-and-display re-encoding as `a=Q`, which is not an action the
+  protocol defines; it is `a=T`. This affects anything that parses an image
+  escape sequence and writes it back out through `Display`.
+* Fixed a delete that names a z-index re-encoding as `d=p`, which deletes every
+  placement in the cell whatever its z-index; it is `d=q`. This affects anything
+  that parses an image escape sequence and writes it back out through `Display`.
+* Fixed kitty images being refused when the placement gives `w`, `h`, `c` or `r`
+  as zero. All four default to zero, and zero is how the protocol spells "not
+  given": for `w` and `h` it says the entire width and height are used, and it
+  gives `c` and `r` the same default without defining a zero. Reading those
+  zeros as dimensions is what divided by zero in #6344. A placement with nothing
+  to draw, where the source origin lies outside the image, is still refused.
+* Fixed a kitty animation frame composition with `w=0` or `h=0` composing
+  nothing. Both default to zero, which the protocol reads as the whole frame.
+* Fixed a kitty delete with `p=0` matching only placements recorded under a
+  placement id of zero. Placement ids run from 1, so `p=0` is the same command
+  as omitting `p`: it names every placement of the image.
+* Terminal images are no longer hashed three times each on the transmit path,
+  and aarch64 builds now use the CPU's sha256 instructions. Together this cuts
+  the per-frame cost of a 2400x1440 RGBA image from about 66ms to 4ms, which
+  matters for programs that stream images.
 
 #### Updated
 * Bundled conpty.dll and OpenConsole.exe to build 1.22.250204002.nupkg

--- a/term/src/terminalstate/image.rs
+++ b/term/src/terminalstate/image.rs
@@ -108,7 +108,7 @@ impl TerminalState {
         // !!! Guard against a zero-sized image, nothing to draw.
         // A zero-sized drawable region leaves nothing to display and would divide by zero when
         // computing the per-cell pixel deltas below.
-        // (e.g. an image with explicit `w=0`/`h=0`, or a source origin outside the image bounds)
+        // (e.g. a source origin that lies outside the image bounds)
         // => Refuse the image placement instead of panicking and taking down the terminal.
         // <https://github.com/wezterm/wezterm/issues/6344>
         anyhow::ensure!(

--- a/term/src/terminalstate/kitty.rs
+++ b/term/src/terminalstate/kitty.rs
@@ -786,6 +786,27 @@ impl TerminalState {
 
                 check_image_dimensions(width, height)?;
 
+                // The pixel count follows from the format and the dimensions,
+                // so the source only has to hold at least that much. A shared
+                // memory object can report more than was staged in it, and a
+                // file may be longer than the image inside it.
+                let bytes_per_pixel = match transmit.format {
+                    Some(KittyImageFormat::Rgb) => 3,
+                    _ => 4,
+                };
+                let needed = width as usize * height as usize * bytes_per_pixel;
+                anyhow::ensure!(
+                    data.len() >= needed,
+                    "transmit data len is {} but {}x{} at {} bytes per pixel needs {}",
+                    data.len(),
+                    width,
+                    height,
+                    bytes_per_pixel,
+                    needed
+                );
+                let mut data = data;
+                data.truncate(needed);
+
                 let data = match transmit.format {
                     Some(KittyImageFormat::Rgb) => {
                         let img = DynamicImage::ImageRgb8(

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -76,6 +76,9 @@ fn kitty_image_with_zero_pixel_dimensions_does_not_panic() {
 /// A 2x2 RGBA image, base64 encoded.
 const TINY_RGBA_BASE64: &str = "AQID/wQFBv8HCAn/CgsM/w==";
 
+/// The same 2x2 RGBA image with four bytes of padding after it.
+const TINY_RGBA_PADDED_BASE64: &str = "AQID/wQFBv8HCAn/CgsM/wAAAAA=";
+
 /// The image data attached to the first cell that carries one.
 fn first_image(term: &TestTerm) -> Arc<ImageData> {
     for line in term.screen().visible_lines().iter() {
@@ -90,6 +93,38 @@ fn first_image(term: &TestTerm) -> Arc<ImageData> {
         }
     }
     panic!("no image was attached to the screen");
+}
+
+/// For the raw formats the protocol derives the pixel count from `f`, `s` and
+/// `v`, so a source holding more than that is read up to the length the image
+/// needs. A shared memory object reporting more than was staged in it is the
+/// case that matters.
+#[test]
+fn kitty_raw_image_longer_than_its_dimensions_is_accepted() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    // f=32: RGBA, s/v: 2x2 pixels, so 16 bytes are needed and 20 are sent.
+    let seq = format!(
+        "\x1b_Ga=T,t=d,f=32,s=2,v=2,i=1;{}\x1b\\",
+        TINY_RGBA_PADDED_BASE64
+    );
+    term.advance_bytes(seq.as_bytes());
+
+    let image = first_image(&term);
+    let image = image.data();
+    match &*image {
+        ImageDataType::Rgba8 {
+            data,
+            width,
+            height,
+            ..
+        } => {
+            k9::assert_equal!(*width, 2);
+            k9::assert_equal!(*height, 2);
+            k9::assert_equal!(data.len(), 16);
+        }
+        other => panic!("expected Rgba8, got {:?}", other),
+    }
 }
 
 /// An Rgba8 stores the hash of its pixels, and a kitty frame transmission edits

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -1,6 +1,8 @@
 //! Tests for inline image protocol handling
 
 use super::*;
+use wezterm_cell::image::ImageDataType;
+use wezterm_surface::change::ImageData;
 
 /// A tiny but valid 11x11 PNG, base64 encoded.
 /// Taken from the reproduction in <https://github.com/wezterm/wezterm/issues/6344>.
@@ -69,4 +71,50 @@ fn kitty_image_with_zero_pixel_dimensions_does_not_panic() {
     // Printing normal text and observing it confirms we recovered rather than crashing.
     term.advance_bytes(b"ok");
     assert_visible_contents(&term, file!(), line!(), &["ok", "", ""]);
+}
+
+/// A 2x2 RGBA image, base64 encoded.
+const TINY_RGBA_BASE64: &str = "AQID/wQFBv8HCAn/CgsM/w==";
+
+/// The image data attached to the first cell that carries one.
+fn first_image(term: &TestTerm) -> Arc<ImageData> {
+    for line in term.screen().visible_lines().iter() {
+        for cell in line.visible_cells() {
+            if let Some(im) = cell
+                .attrs()
+                .images()
+                .and_then(|images| images.into_iter().next())
+            {
+                return Arc::clone(im.image_data());
+            }
+        }
+    }
+    panic!("no image was attached to the screen");
+}
+
+/// An Rgba8 stores the hash of its pixels, and a kitty frame transmission edits
+/// those pixels in place, so the stored hash must be updated with them.
+#[test]
+fn kitty_frame_edit_keeps_the_stored_hash_current() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    // a=T: transmit and display, f=32: RGBA, s/v: 2x2 pixels.
+    let seq = format!("\x1b_Ga=T,t=d,f=32,s=2,v=2,i=1;{}\x1b\\", TINY_RGBA_BASE64);
+    term.advance_bytes(seq.as_bytes());
+    let transmitted = first_image(&term).data().compute_hash();
+
+    // a=f: transmit a frame, r=1: edit frame 1 in place, recolouring one pixel.
+    term.advance_bytes(b"\x1b_Ga=f,t=d,f=32,s=1,v=1,i=1,r=1,x=0,y=0;/wAA/w==\x1b\\");
+
+    let image = first_image(&term);
+    let image = image.data();
+    match &*image {
+        ImageDataType::Rgba8 { data, hash, .. } => {
+            // The edit reached the pixels, so this is not asserting on an
+            // image that was never touched.
+            assert_ne!(*hash, transmitted);
+            k9::assert_equal!(*hash, ImageDataType::hash_bytes(data));
+        }
+        other => panic!("expected Rgba8, got {:?}", other),
+    }
 }

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -8,21 +8,34 @@ use wezterm_surface::change::ImageData;
 /// Taken from the reproduction in <https://github.com/wezterm/wezterm/issues/6344>.
 const TINY_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAACXBIWXMAAAGKAAABigEzlzBYAAAAOUlEQVQYlZXOwQ0AMAzCQEdi7yaT0xWAN7JuDCac2PQKYxflycOoICOKtPIuqFCg4/LzKxiz6xjyAYh9DR1sLUN1AAAAAElFTkSuQmCC";
 
-/// Feeding a Kitty graphics escape that requests a zero-sized placement (here `r=0,h=0`)
-/// must not panic the terminal.
-/// Prior to the fix for <https://github.com/wezterm/wezterm/issues/6344> this divided by zero
-/// while computing the per-cell pixel deltas and took down the whole pane.
+/// `r` and `h` default to zero, so `r=0,h=0` asks for the whole image over as
+/// many rows as its own height needs, and it is displayed.
+/// Reading those zeros as literal dimensions is what divided by zero in
+/// <https://github.com/wezterm/wezterm/issues/6344>.
 #[test]
-fn kitty_zero_dimension_image_does_not_panic() {
+fn kitty_zero_dimension_image_is_displayed() {
     let mut term = TestTerm::new(3, 10, 0);
 
     // a=T: transmit and display, t=d: data is directly embedded,
-    // f=100: PNG, r=0/h=0: zero rows / zero source height.
+    // f=100: PNG, r=0/h=0: neither given.
     let seq = format!("\x1b_Gr=0,h=0,a=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
     term.print(seq.as_bytes());
 
-    // The image is refused, so the cursor never moved;
-    // Printing normal text and observing it confirms we recovered rather than crashing.
+    // The image was placed, so the cursor moved past it.
+    term.print(b"ok");
+    assert_visible_contents(&term, file!(), line!(), &["  ok", "", ""]);
+}
+
+/// A source origin outside the image leaves nothing to draw, whatever the keys
+/// say, and that is still refused rather than dividing by zero.
+#[test]
+fn kitty_image_drawn_entirely_outside_itself_is_refused() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    // x/y put the source origin past the 11x11 image, so no pixels remain.
+    let seq = format!("\x1b_Gx=99,y=99,a=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
+    term.print(seq.as_bytes());
+
     term.print(b"ok");
     assert_visible_contents(&term, file!(), line!(), &["ok", "", ""]);
 }

--- a/wezterm-cell/Cargo.toml
+++ b/wezterm-cell/Cargo.toml
@@ -23,6 +23,13 @@ wezterm-color-types.workspace = true
 wezterm-escape-parser.workspace = true
 wezterm-dynamic.workspace = true
 
+# sha2 compiles its aarch64 sha256 intrinsics only under the asm feature; x86
+# and x86_64 select their backend by architecture and do not need it. The
+# feature also pulls in sha2-asm, which refuses to build for Windows targets,
+# hence the target gate.
+[target.'cfg(all(target_arch = "aarch64", not(target_os = "windows")))'.dependencies]
+sha2 = {workspace=true, optional=true, features=["asm"]}
+
 [features]
 std = ["serde/std", "wezterm-char-props/std", "wezterm-color-types/std", "wezterm-escape-parser/std", "wezterm-dynamic/std", "finl_unicode/std"]
 use_serde = ["dep:serde", "wezterm-color-types/use_serde"]

--- a/wezterm-cell/src/image.rs
+++ b/wezterm-cell/src/image.rs
@@ -216,6 +216,8 @@ pub enum ImageDataType {
         data: Vec<u8>,
         width: u32,
         height: u32,
+        /// sha256 of data, which is what compute_hash reports. Update it
+        /// whenever data changes.
         hash: [u8; 32],
     },
     /// Data is an animated sequence
@@ -308,7 +310,7 @@ impl ImageDataType {
         match self {
             ImageDataType::EncodedFile(data) => hasher.update(data),
             ImageDataType::EncodedLease(lease) => return lease.content_id().as_hash_bytes(),
-            ImageDataType::Rgba8 { data, .. } => hasher.update(data),
+            ImageDataType::Rgba8 { hash, .. } => return *hash,
             ImageDataType::AnimRgba8 {
                 frames, durations, ..
             } => {
@@ -584,5 +586,30 @@ impl ImageData {
 
     pub fn hash(&self) -> [u8; 32] {
         self.hash
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The hash stored with an Rgba8 is the hash of its data.
+    #[test]
+    fn rgba8_compute_hash_matches_its_data() {
+        let data: Vec<u8> = (0..=255u8).cycle().take(16 * 16 * 4).collect();
+        let expected = ImageDataType::hash_bytes(&data);
+
+        let img = ImageDataType::new_single_frame(16, 16, data);
+
+        assert_eq!(img.compute_hash(), expected);
+    }
+
+    /// Distinct pixels must produce distinct hashes.
+    #[test]
+    fn rgba8_compute_hash_follows_the_data() {
+        let a = ImageDataType::new_single_frame(2, 2, vec![0u8; 16]);
+        let b = ImageDataType::new_single_frame(2, 2, vec![1u8; 16]);
+
+        assert_ne!(a.compute_hash(), b.compute_hash());
     }
 }

--- a/wezterm-escape-parser/Cargo.toml
+++ b/wezterm-escape-parser/Cargo.toml
@@ -30,6 +30,11 @@ wezterm-color-types.workspace = true
 wezterm-dynamic.workspace = true
 wezterm-input-types = {workspace = true, default-features=false}
 
+# Only the unix arm of read_shared_memory_data maps through memmap2; the
+# windows arm uses winapi below.
+[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
+memmap2 = {workspace=true, optional=true}
+
 [target."cfg(windows)".dependencies.winapi]
 workspace = true
 optional = true
@@ -49,7 +54,7 @@ features = [
 
 [features]
 std = ["vtparse/std", "thiserror/std", "wezterm-input-types/std", "hex/std", "wezterm-dynamic/std"]
-kitty-shm = ["dep:nix", "dep:winapi"]
+kitty-shm = ["dep:nix", "dep:winapi", "dep:memmap2"]
 use_serde = ["dep:serde", "wezterm-color-types/use_serde", "wezterm-blob-leases/serde", "bitflags/serde", "wezterm-input-types/serde"]
 use_image = ["image", "dep:image"]
 image = ["sha2", "wezterm-blob-leases"]

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -682,7 +682,11 @@ impl KittyImagePlacement {
                 None | Some(0) => None,
                 n => n,
             },
-            placement_id: geti(keys, "p"),
+            // A placement id runs from 1, so a zero is no placement id.
+            placement_id: match geti(keys, "p") {
+                None | Some(0) => None,
+                n => n,
+            },
             do_not_move_cursor: match get(keys, "C") {
                 None | Some("0") => false,
                 Some("1") => true,
@@ -785,14 +789,22 @@ impl KittyImageDelete {
         let delete = d.is_ascii_uppercase();
         match d {
             'a' | 'A' => Some(Self::All { delete }),
+            // A placement id runs from 1, so a zero names every placement of
+            // the image rather than one recorded under an id of zero.
             'i' | 'I' => Some(Self::ByImageId {
                 image_id: geti(keys, "i")?,
-                placement_id: geti(keys, "p"),
+                placement_id: match geti(keys, "p") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 delete,
             }),
             'n' | 'N' => Some(Self::ByImageNumber {
                 image_number: geti(keys, "I")?,
-                placement_id: geti(keys, "p"),
+                placement_id: match geti(keys, "p") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 delete,
             }),
             'c' | 'C' => Some(Self::AtCursorPosition { delete }),
@@ -1332,6 +1344,46 @@ mod test {
                     background_pixel: None,
                     duration_ms: None,
                 },
+            }
+        );
+    }
+
+    /// A placement id runs from 1, so `p=0` is the same command as omitting it.
+    /// A delete carrying it names every placement of the image, not a placement
+    /// recorded under an id of zero.
+    #[test]
+    fn kitty_zero_placement_id_is_absent() {
+        assert_eq!(
+            KittyImage::parse_apc("Ga=d,d=i,i=10,p=0".as_bytes()).unwrap(),
+            KittyImage::Delete {
+                what: KittyImageDelete::ByImageId {
+                    image_id: 10,
+                    placement_id: None,
+                    delete: false,
+                },
+                verbosity: KittyImageVerbosity::Verbose,
+            }
+        );
+
+        assert_eq!(
+            KittyImage::parse_apc("Ga=p,i=10,p=0".as_bytes()).unwrap(),
+            KittyImage::Display {
+                image_id: Some(10),
+                image_number: None,
+                placement: KittyImagePlacement {
+                    x: None,
+                    y: None,
+                    w: None,
+                    h: None,
+                    x_offset: None,
+                    y_offset: None,
+                    columns: None,
+                    rows: None,
+                    do_not_move_cursor: false,
+                    placement_id: None,
+                    z_index: None,
+                },
+                verbosity: KittyImageVerbosity::Verbose,
             }
         );
     }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -951,8 +951,16 @@ impl KittyImageFrameCompose {
             y: geti(keys, "y"),
             src_x: geti(keys, "X"),
             src_y: geti(keys, "Y"),
-            w: geti(keys, "w"),
-            h: geti(keys, "h"),
+            // w and h default to zero, which asks for the whole frame rather
+            // than a rectangle of nothing.
+            w: match geti(keys, "w") {
+                None | Some(0) => None,
+                n => n,
+            },
+            h: match geti(keys, "h") {
+                None | Some(0) => None,
+                n => n,
+            },
             target_frame: match geti(keys, "c") {
                 None | Some(0) => None,
                 n => n,
@@ -1324,6 +1332,32 @@ mod test {
                     background_pixel: None,
                     duration_ms: None,
                 },
+            }
+        );
+    }
+
+    /// `w` and `h` give the size of the rectangle a composition reads and
+    /// writes, and both default to zero, which asks for the whole frame rather
+    /// than a rectangle of nothing.
+    #[test]
+    fn kitty_zero_composition_width_or_height_is_absent() {
+        assert_eq!(
+            KittyImage::parse_apc("Ga=c,i=1,r=1,c=2,w=0,h=0".as_bytes()).unwrap(),
+            KittyImage::ComposeFrame {
+                frame: KittyImageFrameCompose {
+                    image_id: Some(1),
+                    image_number: None,
+                    target_frame: Some(2),
+                    source_frame: Some(1),
+                    x: None,
+                    y: None,
+                    w: None,
+                    h: None,
+                    src_x: None,
+                    src_y: None,
+                    composition_mode: KittyFrameCompositionMode::AlphaBlending,
+                },
+                verbosity: KittyImageVerbosity::Verbose,
             }
         );
     }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -660,12 +660,28 @@ impl KittyImagePlacement {
         Some(Self {
             x: geti(keys, "x"),
             y: geti(keys, "y"),
-            w: geti(keys, "w"),
-            h: geti(keys, "h"),
+            // w, h, c and r all default to zero, and zero is not a rectangle of
+            // nothing: for w and h the protocol says the entire width and height
+            // are used. It gives c and r the same default without defining what
+            // a zero means, so they are read the same way.
+            w: match geti(keys, "w") {
+                None | Some(0) => None,
+                n => n,
+            },
+            h: match geti(keys, "h") {
+                None | Some(0) => None,
+                n => n,
+            },
             x_offset: geti(keys, "X"),
             y_offset: geti(keys, "Y"),
-            columns: geti(keys, "c"),
-            rows: geti(keys, "r"),
+            columns: match geti(keys, "c") {
+                None | Some(0) => None,
+                n => n,
+            },
+            rows: match geti(keys, "r") {
+                None | Some(0) => None,
+                n => n,
+            },
             placement_id: geti(keys, "p"),
             do_not_move_cursor: match get(keys, "C") {
                 None | Some("0") => false,

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -144,7 +144,7 @@ impl KittyImageData {
                 keys.insert("t", "f".to_string());
                 keys.insert("payload", base64_encode(&path));
                 set(keys, "S", data_size);
-                set(keys, "S", data_offset);
+                set(keys, "O", data_offset);
             }
             Self::TemporaryFile {
                 path,
@@ -154,7 +154,7 @@ impl KittyImageData {
                 keys.insert("t", "t".to_string());
                 keys.insert("payload", base64_encode(&path));
                 set(keys, "S", data_size);
-                set(keys, "S", data_offset);
+                set(keys, "O", data_offset);
             }
             Self::SharedMem {
                 name,
@@ -164,7 +164,7 @@ impl KittyImageData {
                 keys.insert("t", "s".to_string());
                 keys.insert("payload", base64_encode(&name));
                 set(keys, "S", data_size);
-                set(keys, "S", data_offset);
+                set(keys, "O", data_offset);
             }
         }
     }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -111,17 +111,26 @@ impl KittyImageData {
             "d" => Some(Self::Direct(String::from_utf8(payload.to_vec()).ok()?)),
             "f" => Some(Self::File {
                 path: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: geti(keys, "S"),
+                data_size: match geti(keys, "S") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 data_offset: geti(keys, "O"),
             }),
             "t" => Some(Self::TemporaryFile {
                 path: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: geti(keys, "S"),
+                data_size: match geti(keys, "S") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 data_offset: geti(keys, "O"),
             }),
             "s" => Some(Self::SharedMem {
                 name: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: geti(keys, "S"),
+                data_size: match geti(keys, "S") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 data_offset: geti(keys, "O"),
             }),
             _ => None,
@@ -1426,9 +1435,10 @@ mod shm_test {
         assert!(!present(&name), "the object is unlinked once it is read");
     }
 
-    /// `S=0` asks for no bytes, which is not an error.
+    /// An explicit size of nothing reads nothing. A client that means "all of
+    /// it" omits `S`, which the parser also produces for `S=0`.
     #[test]
-    fn shm_reads_nothing_when_asked_for_nothing() {
+    fn shm_reads_nothing_for_a_size_of_nothing() {
         let name = stage("/wtshm-none", &pattern(64));
 
         let got = KittyImageData::SharedMem {

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -1167,7 +1167,7 @@ impl KittyImage {
                 verbosity,
                 placement,
             } => {
-                keys.insert("a", "Q".to_string());
+                keys.insert("a", "T".to_string());
                 verbosity.to_keys(keys);
                 placement.to_keys(keys);
                 transmit.to_keys(keys);

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -851,7 +851,7 @@ impl KittyImageDelete {
                 keys.insert("y", y.to_string());
             }
             Self::DeleteAtZ { x, y, z, delete } => {
-                keys.insert("d", d('p', delete));
+                keys.insert("d", d('q', delete));
                 keys.insert("x", x.to_string());
                 keys.insert("y", y.to_string());
                 keys.insert("z", z.to_string());

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -262,6 +262,12 @@ impl KittyImageData {
     }
 }
 
+/// Read the data a `t=s` transmission left in a POSIX shared memory object.
+///
+/// A shared memory object is not a stream on every platform: on Darwin it can
+/// only be mapped, and answers `read(2)` with `ENXIO` and `lseek(2)` with
+/// `ESPIPE`. Mapping it works everywhere, and is what the Windows
+/// implementation below does as well.
 #[cfg(all(feature = "kitty-shm", unix, not(target_os = "android")))]
 fn read_shared_memory_data(
     name: &str,
@@ -270,34 +276,22 @@ fn read_shared_memory_data(
 ) -> std::result::Result<std::vec::Vec<u8>, std::io::Error> {
     use nix::sys::mman::{shm_open, shm_unlink};
     use std::fs::File;
-    use std::io::{Read, Seek};
 
     let fd = shm_open(
         name,
         nix::fcntl::OFlag::O_RDONLY,
         nix::sys::stat::Mode::empty(),
     )
-    .map_err(|_| {
-        let err = std::io::Error::last_os_error();
+    .map_err(|err| {
         std::io::Error::new(
             std::io::ErrorKind::Other,
             format!("shm_open {} failed: {:#}", name, err),
         )
     })?;
-    let mut f = File::from(fd);
-    if let Some(offset) = data_offset {
-        f.seek(std::io::SeekFrom::Start(offset.into()))?;
-    }
-    let data = if let Some(len) = data_size {
-        let mut res = vec![0u8; len as usize];
-        f.read_exact(&mut res)?;
-        res
-    } else {
-        let mut res = vec![];
-        f.read_to_end(&mut res)?;
-        res
-    };
 
+    // The protocol asks the terminal to unlink the object once it has read it.
+    // Unlinking as soon as it is open keeps the descriptor alive for the read
+    // and narrows the window in which an error path leaves the object behind.
     if let Err(err) = shm_unlink(name) {
         log::warn!(
             "Unable to unlink kitty image protocol shm file {}: {:#}",
@@ -305,7 +299,48 @@ fn read_shared_memory_data(
             err
         );
     }
-    Ok(data)
+
+    let file = File::from(fd);
+    if file.metadata()?.len() == 0 {
+        return Ok(std::vec::Vec::new());
+    }
+
+    // The mapping covers the whole object and `data_offset` indexes into it,
+    // because mmap only accepts a page aligned offset while the protocol places
+    // no such limit on `O`.
+    //
+    // SAFETY: a mapping is unsound if the object is written or truncated while
+    // it is mapped, and nothing here can prevent that. The unlink above is no
+    // help: it takes away the name, not a descriptor already open on it, and
+    // the client that staged the data holds one. What this rests on is `t=s`
+    // meaning the client has finished writing and handed the object over. The
+    // mapping lives only for the copy below.
+    let map = unsafe { memmap2::Mmap::map(&file) }.map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("mmap {} failed: {:#}", name, err),
+        )
+    })?;
+
+    // The size an object reports can exceed what the client staged in it, as
+    // Darwin rounds it up to a page. `data_size` is what narrows it back down.
+    let offset = data_offset.unwrap_or(0) as usize;
+    if offset >= map.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "offset {} bigger than or equal to shm region size {}",
+                offset,
+                map.len()
+            ),
+        ));
+    }
+    let mut size = map.len() - offset;
+    if let Some(val) = data_size {
+        size = size.min(val as usize);
+    }
+
+    Ok(map[offset..offset + size].to_vec())
 }
 
 #[cfg(all(feature = "kitty-shm", unix, target_os = "android"))]
@@ -1264,6 +1299,189 @@ mod test {
                     duration_ms: None,
                 },
             }
+        );
+    }
+}
+
+/// The shared memory transport, against a real POSIX object.
+///
+/// A shared memory object can only be mapped on some platforms, so these go
+/// through `load_data` rather than asserting on the parse, and cover the offset
+/// and size a `t=s` transmission may carry.
+#[cfg(all(test, feature = "kitty-shm", unix, not(target_os = "android")))]
+mod shm_test {
+    use super::*;
+    use k9::assert_equal as assert_eq;
+    use nix::fcntl::OFlag;
+    use nix::sys::mman::{MapFlags, ProtFlags, mmap, munmap, shm_open, shm_unlink};
+    use nix::sys::stat::Mode;
+    use nix::unistd::ftruncate;
+    use std::num::NonZeroUsize;
+
+    /// Stage `data` in a shared memory object of that name, as a client sending
+    /// `t=s` does.
+    ///
+    /// The name must fit macOS' `PSHMNAMLEN` of 31 bytes including the leading
+    /// slash. A longer one fails `shm_open` with `ENAMETOOLONG`, which is not
+    /// the failure these tests are looking for.
+    fn stage(name: &str, data: &[u8]) -> String {
+        assert!(
+            name.len() <= 31,
+            "{} is longer than macOS accepts for a shm name",
+            name
+        );
+
+        // macOS refuses to resize an object that already has a size, so an
+        // object left behind by an earlier run has to go first.
+        let _ = shm_unlink(name);
+
+        let fd = shm_open(
+            name,
+            OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_RDWR,
+            Mode::S_IRUSR | Mode::S_IWUSR,
+        )
+        .unwrap();
+        ftruncate(&fd, data.len() as _).unwrap();
+
+        let len = NonZeroUsize::new(data.len()).unwrap();
+        // SAFETY: the object was created above and sized to `len`, so a mapping
+        // of that length is backed for its whole extent.
+        let ptr = unsafe {
+            mmap(
+                None,
+                len,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                MapFlags::MAP_SHARED,
+                &fd,
+                0,
+            )
+        }
+        .unwrap();
+        // SAFETY: `ptr` maps `len` writable bytes and `data` is `len` long, so
+        // the copy stays inside both, and the two cannot overlap because the
+        // mapping was just created.
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), ptr.as_ptr() as *mut u8, len.get());
+            munmap(ptr, len.get()).unwrap();
+        }
+
+        name.to_string()
+    }
+
+    /// Whether an object of this name still exists.
+    ///
+    /// Only `ENOENT` counts as gone. Taking every error for absence would let a
+    /// permission or name length problem pass as a successful unlink.
+    fn present(name: &str) -> bool {
+        match shm_open(name, OFlag::O_RDONLY, Mode::empty()) {
+            Ok(_) => true,
+            Err(nix::errno::Errno::ENOENT) => false,
+            Err(err) => panic!("asking whether {} is still there answered {}", name, err),
+        }
+    }
+
+    fn pattern(len: usize) -> Vec<u8> {
+        (0..=255u8).cycle().take(len).collect()
+    }
+
+    /// With neither `O` nor `S`, the whole object comes back.
+    #[test]
+    fn shm_reads_the_whole_object() {
+        let data = pattern(4096);
+        let name = stage("/wtshm-whole", &data);
+
+        let got = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: None,
+            data_size: None,
+        }
+        .load_data()
+        .unwrap();
+
+        // An object can report more than was staged in it, as Darwin rounds the
+        // size up to a page; the data sits at the front.
+        assert!(got.len() >= data.len());
+        assert_eq!(&got[..data.len()], &data[..]);
+        assert!(!present(&name), "the object is unlinked once it is read");
+    }
+
+    /// `O` and `S` select a range within the object. `O` is applied to the
+    /// mapped bytes rather than to mmap, which only accepts a page aligned
+    /// offset.
+    #[test]
+    fn shm_reads_the_slice_it_is_asked_for() {
+        let data = pattern(4096);
+        let name = stage("/wtshm-slice", &data);
+
+        let got = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: Some(10),
+            data_size: Some(80),
+        }
+        .load_data()
+        .unwrap();
+
+        assert_eq!(got, data[10..90].to_vec());
+        assert!(!present(&name), "the object is unlinked once it is read");
+    }
+
+    /// `S=0` asks for no bytes, which is not an error.
+    #[test]
+    fn shm_reads_nothing_when_asked_for_nothing() {
+        let name = stage("/wtshm-none", &pattern(64));
+
+        let got = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: None,
+            data_size: Some(0),
+        }
+        .load_data()
+        .unwrap();
+
+        assert_eq!(got, Vec::<u8>::new());
+        assert!(!present(&name), "the object is unlinked once it is read");
+    }
+
+    /// An `O` beyond the object is refused rather than read, and the object is
+    /// still unlinked so a rejected transmission leaves nothing behind.
+    #[test]
+    fn shm_refuses_an_offset_past_the_end() {
+        let name = stage("/wtshm-oob", &pattern(64));
+
+        let err = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: Some(1 << 20),
+            data_size: Some(4),
+        }
+        .load_data()
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("offset"),
+            "an offset past the end says so: {}",
+            err
+        );
+        assert!(!present(&name), "a refused read still unlinks the object");
+    }
+
+    /// A name that does not exist names itself in the error, so a client that
+    /// sent the wrong name, or one too long for the platform, can tell.
+    #[test]
+    fn shm_reports_an_object_that_is_not_there() {
+        let _ = shm_unlink("/wtshm-absent");
+
+        let err = KittyImageData::SharedMem {
+            name: "/wtshm-absent".to_string(),
+            data_offset: None,
+            data_size: None,
+        }
+        .load_data()
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("/wtshm-absent"),
+            "the error names the object: {}",
+            err
         );
     }
 }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -984,6 +984,7 @@ pub struct KittyImageFrame {
 
     /// Gap in milliseconds of this frame from the next one.
     /// Zero or omitted values are interpreted as 40ms.
+    /// A negative gap asks for a gapless frame, which is not supported.
     /// z=...
     pub duration_ms: Option<u32>,
 
@@ -1011,7 +1012,7 @@ impl KittyImageFrame {
                 None | Some(0) => None,
                 n => n,
             },
-            duration_ms: match geti(keys, "Z") {
+            duration_ms: match geti(keys, "z") {
                 None | Some(0) => None,
                 n => n,
             },
@@ -1029,7 +1030,7 @@ impl KittyImageFrame {
         set(keys, "y", &self.y);
         set(keys, "c", &self.base_frame);
         set(keys, "r", &self.frame_number);
-        set(keys, "Z", &self.duration_ms);
+        set(keys, "z", &self.duration_ms);
         match &self.composition_mode {
             KittyFrameCompositionMode::AlphaBlending => {}
             KittyFrameCompositionMode::Overwrite => {

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -1048,6 +1048,28 @@ mod test {
         );
     }
 
+    /// Deleting placements at a cell with a given z-index is `d=q`; `d=p` is
+    /// the same delete without the z-index, so the two must not collapse.
+    #[test]
+    fn kitty_delete_at_cell_with_z() {
+        use crate::apc::*;
+
+        assert_eq!(
+            round_trip_parse("\x1b_Ga=d,d=q,x=3,y=4,z=-1\x1b\\"),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::Delete {
+                    what: KittyImageDelete::DeleteAtZ {
+                        x: 3,
+                        y: 4,
+                        z: -1,
+                        delete: false,
+                    },
+                    verbosity: KittyImageVerbosity::Verbose,
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
 
     /// Transmit and display is `a=T`, so it survives a round trip.
     #[test]

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -977,6 +977,45 @@ mod test {
         );
     }
 
+    /// The inter-frame gap is `z`, so it survives a round trip.
+    #[test]
+    fn kitty_frame_gap() {
+        use crate::apc::*;
+
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=f,i=1,z=100;YWJjZA==\x1b\\",
+                "\x1b_Ga=f,i=1,z=100;YWJjZA==\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::TransmitFrame {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::Direct("YWJjZA==".to_string()),
+                        width: None,
+                        height: None,
+                        image_id: Some(1),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                    frame: KittyImageFrame {
+                        x: None,
+                        y: None,
+                        base_frame: None,
+                        frame_number: None,
+                        duration_ms: Some(100),
+                        composition_mode: KittyFrameCompositionMode::AlphaBlending,
+                        background_pixel: None,
+                    },
+                    verbosity: KittyImageVerbosity::Verbose,
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
+
+
     /* Withdrawn because xterm introduced a conflict:
      * <https://github.com/mintty/mintty/issues/1171#issuecomment-1336174469>
      * <https://github.com/mintty/mintty/issues/1189>

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -1015,6 +1015,47 @@ mod test {
         );
     }
 
+    /// Transmit and display is `a=T`, so it survives a round trip.
+    #[test]
+    fn kitty_transmit_and_display() {
+        use crate::apc::*;
+
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=T,s=1,v=1,i=2;YWJjZA==\x1b\\",
+                "\x1b_Ga=T,i=2,s=1,v=1;YWJjZA==\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::TransmitDataAndDisplay {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::Direct("YWJjZA==".to_string()),
+                        width: Some(1),
+                        height: Some(1),
+                        image_id: Some(2),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                    placement: KittyImagePlacement {
+                        x: None,
+                        y: None,
+                        w: None,
+                        h: None,
+                        x_offset: None,
+                        y_offset: None,
+                        columns: None,
+                        rows: None,
+                        do_not_move_cursor: false,
+                        placement_id: None,
+                        z_index: None,
+                    },
+                    verbosity: KittyImageVerbosity::Verbose,
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
 
     /* Withdrawn because xterm introduced a conflict:
      * <https://github.com/mintty/mintty/issues/1171#issuecomment-1336174469>

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -1015,6 +1015,40 @@ mod test {
         );
     }
 
+    /// `S` defaults to zero, so `S=0` is a size that was not given and the
+    /// whole file is read.
+    #[test]
+    fn kitty_zero_size_is_no_size() {
+        use crate::apc::*;
+
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=q,t=t,s=1,v=1,i=4,S=0;L3Zhci90bXAvdG1wdGYxd3E4Ym4=\x1b\\",
+                "\x1b_Ga=q,i=4,s=1,t=t,v=1;L3Zhci90bXAvdG1wdGYxd3E4Ym4=\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::Query {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::TemporaryFile {
+                            path: "/var/tmp/tmptf1wq8bn".to_string(),
+                            data_offset: None,
+                            data_size: None,
+                        },
+                        width: Some(1),
+                        height: Some(1),
+                        image_id: Some(4),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
+
+
     /// Transmit and display is `a=T`, so it survives a round trip.
     #[test]
     fn kitty_transmit_and_display() {

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -948,6 +948,33 @@ mod test {
                 Action::Esc(Esc::Code(EscCode::StringTerminator)),
             ]
         );
+
+        // The offset goes out under O, and leaves the size under S alone.
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=q,t=s,s=1,v=1,i=3,O=10,S=80;L3dlenRlcm0tc2htLXJ0\x1b\\",
+                "\x1b_GO=10,S=80,a=q,i=3,s=1,t=s,v=1;L3dlenRlcm0tc2htLXJ0\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::Query {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::SharedMem {
+                            name: "/wezterm-shm-rt".to_string(),
+                            data_offset: Some(10),
+                            data_size: Some(80),
+                        },
+                        width: Some(1),
+                        height: Some(1),
+                        image_id: Some(3),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
     }
 
     /* Withdrawn because xterm introduced a conflict:


### PR DESCRIPTION
## Images hash 16x faster

Two independent problems, both on every image the terminal receives:

- `sha2` compiles its aarch64 sha256 intrinsics only under the `asm` feature,
  which wezterm does not enable, so aarch64 hashes in software.
- `compute_hash` recomputed the sha256 that `Rgba8` already stores — once for the
  cache key in `raw_image_to_image_data`, once in `ImageData::with_data`, on top
  of `new_single_frame`. Three passes per image.

Measured on a 13.18MiB frame (2400x1440 RGBA), Apple M-series:

| | per frame |
| --- | --- |
| software sha256, three passes (`main`) | 66.2ms |
| software sha256, one pass | 22.05ms |
| aarch64 instructions, one pass | **4.12ms** |

Both changes preserve the hash value. The `asm` feature selects a hardware
backend for the same algorithm, and the hash `Rgba8` stores is the same sha256
that `compute_hash` was recomputing, so nothing that stores, compares or
transmits an image hash is affected.

Profiling a 60fps client with `sample` put 97.8% of the pty reader thread in
`kitty_img`, with `sha2::compress256` the largest symbol in the process.

Over 20s of 60fps RGBA into a 2480x1656 window, counting the frames the terminal
failed to open before the client recycled them:

| | dropped |
| --- | --- |
| `main` | 1462 |
| this branch | **37** |

**Hashing is still the dominant cost for streaming.** 4.12ms is a quarter of a
16.67ms frame at 60fps, and a client sending unique frames never reuses any of
it — the content-addressed cache it feeds exists for sixel and iterm2, which
carry no image id. Reducing it further is a design question this PR does not
open.

## `t=s` never draws on macOS

Closes #7631. `read_shared_memory_data` used `seek`/`read_exact` on the
`shm_open` descriptor, but on Darwin a POSIX shared memory object can only be
mapped: `read(2)` returns `ENXIO`, `lseek(2)` returns `ESPIPE`. Linux is
unaffected because its shared memory is tmpfs.

It now maps the object, as the Windows arm already does. The mapping goes through
`memmap2`, which the workspace depends on and `wezterm-font` uses for font files;
that keeps the arm to one `unsafe` rather than three plus a manual `munmap`.

## Nine keys disagree with the protocol

| | wezterm read/wrote | protocol says |
| --- | --- | --- |
| `S=0` | a request for zero bytes | `S` defaults to 0, so `S=0` *is* an absent `S` |
| raw `f=24`/`f=32` | refused unless the length matched exactly | the pixel count follows from `f`, `s` and `v` |
| placement `w` `h` `c` `r` `=0` | a rectangle of nothing | all default to 0; "the entire width is used" |
| compose `w=0` `h=0` | copied nothing | both default to 0, meaning the whole frame |
| `p=0` | a placement filed under id 0 | ids run from 1, so `p=0` is an absent `p` |
| `O` (offset) | written under `S`, overwriting the size | `O` |
| frame gap | read and written as `Z` | `z` |
| transmit-and-display | encoded `a=Q` | `a=T` |
| delete at z-index | encoded `d=p`, a broader delete | `d=q` |

The four zero rows are one bug class: a key whose protocol default is `0` read as
a literal `0` rather than as absent. The placement row is what divided by zero in
#6344 — that fix guarded the division by refusing the placement, which stopped
the crash but left a conformant image undrawn. The last three rows change only
`to_keys`, so they reach consumers of `termwiz::escape` that re-encode.

## Tests

Each fix is its own commit with a test that fails without it, sixteen tests in
all. `cargo test --all` and `cargo +nightly fmt --all -- --check` are clean, and
every commit passes standalone.

`kitty_zero_dimension_image_does_not_panic` asserted that `r=0,h=0` is refused,
which is what the placement fix corrects. It is now
`kitty_zero_dimension_image_is_displayed`, and a separate test covers the
placement that genuinely has nothing to draw — a source origin outside the image,
which the #6344 guard still refuses.

Two gaps left alone: macOS caps shm names at 31 bytes (the error now carries the
`Errno`), and a negative `z` is still read as no gap, since the renderer honours
gapless only for the root frame.

`sha2-asm` has `compile_error!` for Windows, so the dependency is declared per
target; `cargo tree --target x86_64-pc-windows-msvc -i sha2-asm` is empty.
