### PR TITLE
fix(kitty): read shared memory objects by mapping them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7031,6 +7031,7 @@ dependencies = [
  "image",
  "k9",
  "log",
+ "memmap2 0.9.11",
  "nix",
  "num-derive",
  "num-traits",

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -156,6 +156,11 @@ As features stabilize some brief notes about them will accumulate here.
 #### Fixed
 * perf: Terminal images were hashed three times each on the transmit path; the sha256
   an RGBA image already carries is now reused instead. Thanks to @i-am-logger! #8065
+* macOS: Fixed the kitty image protocol shared memory transport (`t=s`), which
+  never drew anything. A POSIX shared memory object can only be mapped on macOS,
+  so reading one failed with `Device not configured` and the image was dropped
+  without any reply to the application. Such objects are now mapped rather than
+  read from, on all unix systems. Thanks to @eschnett! #7631
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program
   that left it enabled and exited uncleanly could leave ctrl keys emitting
   escape sequences that the shell doesn't expect. RIS now also resets the

--- a/wezterm-escape-parser/Cargo.toml
+++ b/wezterm-escape-parser/Cargo.toml
@@ -30,6 +30,11 @@ wezterm-color-types.workspace = true
 wezterm-dynamic.workspace = true
 wezterm-input-types = {workspace = true, default-features=false}
 
+# Only the unix arm of read_shared_memory_data maps through memmap2; the
+# windows arm uses winapi below.
+[target.'cfg(all(unix, not(target_os = "android")))'.dependencies]
+memmap2 = {workspace=true, optional=true}
+
 [target."cfg(windows)".dependencies.winapi]
 workspace = true
 optional = true
@@ -49,7 +54,7 @@ features = [
 
 [features]
 std = ["vtparse/std", "thiserror/std", "wezterm-input-types/std", "hex/std", "wezterm-dynamic/std"]
-kitty-shm = ["dep:nix", "dep:winapi"]
+kitty-shm = ["dep:nix", "dep:winapi", "dep:memmap2"]
 use_serde = ["dep:serde", "wezterm-color-types/use_serde", "wezterm-blob-leases/serde", "bitflags/serde", "wezterm-input-types/serde"]
 use_image = ["image", "dep:image"]
 image = ["sha2", "wezterm-blob-leases"]

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -262,6 +262,12 @@ impl KittyImageData {
     }
 }
 
+/// Read the data a `t=s` transmission left in a POSIX shared memory object.
+///
+/// A shared memory object is not a stream on every platform: on Darwin it can
+/// only be mapped, and answers `read(2)` with `ENXIO` and `lseek(2)` with
+/// `ESPIPE`. Mapping it works everywhere, and is what the Windows
+/// implementation below does as well.
 #[cfg(all(feature = "kitty-shm", unix, not(target_os = "android")))]
 fn read_shared_memory_data(
     name: &str,
@@ -270,34 +276,22 @@ fn read_shared_memory_data(
 ) -> std::result::Result<std::vec::Vec<u8>, std::io::Error> {
     use nix::sys::mman::{shm_open, shm_unlink};
     use std::fs::File;
-    use std::io::{Read, Seek};
 
     let fd = shm_open(
         name,
         nix::fcntl::OFlag::O_RDONLY,
         nix::sys::stat::Mode::empty(),
     )
-    .map_err(|_| {
-        let err = std::io::Error::last_os_error();
+    .map_err(|err| {
         std::io::Error::new(
             std::io::ErrorKind::Other,
             format!("shm_open {} failed: {:#}", name, err),
         )
     })?;
-    let mut f = File::from(fd);
-    if let Some(offset) = data_offset {
-        f.seek(std::io::SeekFrom::Start(offset.into()))?;
-    }
-    let data = if let Some(len) = data_size {
-        let mut res = vec![0u8; len as usize];
-        f.read_exact(&mut res)?;
-        res
-    } else {
-        let mut res = vec![];
-        f.read_to_end(&mut res)?;
-        res
-    };
 
+    // The protocol asks the terminal to unlink the object once it has read it.
+    // Unlinking as soon as it is open keeps the descriptor alive for the read
+    // and narrows the window in which an error path leaves the object behind.
     if let Err(err) = shm_unlink(name) {
         log::warn!(
             "Unable to unlink kitty image protocol shm file {}: {:#}",
@@ -305,7 +299,54 @@ fn read_shared_memory_data(
             err
         );
     }
-    Ok(data)
+
+    // An empty object holds no image, and mapping one fails with EINVAL, so it
+    // is refused here where the error can name the object. Returning the empty
+    // read instead would report success for a transmission that carried nothing.
+    let file = File::from(fd);
+    if file.metadata()?.len() == 0 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("shm object {} is empty", name),
+        ));
+    }
+
+    // The mapping covers the whole object and `data_offset` indexes into it,
+    // because mmap only accepts a page aligned offset while the protocol places
+    // no such limit on `O`.
+    //
+    // SAFETY: a mapping is unsound if the object is written or truncated while
+    // it is mapped, and nothing here can prevent that. The unlink above is no
+    // help: it takes away the name, not a descriptor already open on it, and
+    // the client that staged the data holds one. What this rests on is `t=s`
+    // meaning the client has finished writing and handed the object over. The
+    // mapping lives only for the copy below.
+    let map = unsafe { memmap2::Mmap::map(&file) }.map_err(|err| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("mmap {} failed: {:#}", name, err),
+        )
+    })?;
+
+    // The size an object reports can exceed what the client staged in it, as
+    // Darwin rounds it up to a page. `data_size` is what narrows it back down.
+    let offset = data_offset.unwrap_or(0) as usize;
+    if offset >= map.len() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!(
+                "offset {} bigger than or equal to shm region size {}",
+                offset,
+                map.len()
+            ),
+        ));
+    }
+    let mut size = map.len() - offset;
+    if let Some(val) = data_size {
+        size = size.min(val as usize);
+    }
+
+    Ok(map[offset..offset + size].to_vec())
 }
 
 #[cfg(all(feature = "kitty-shm", unix, target_os = "android"))]
@@ -1265,5 +1306,221 @@ mod test {
                 },
             }
         );
+    }
+}
+
+/// The shared memory transport, against a real POSIX object.
+///
+/// A shared memory object can only be mapped on some platforms, so these go
+/// through `load_data` rather than asserting on the parse, and cover the offset
+/// and size a `t=s` transmission may carry.
+#[cfg(all(test, feature = "kitty-shm", unix, not(target_os = "android")))]
+mod shm_test {
+    use super::*;
+    use k9::assert_equal as assert_eq;
+    use nix::fcntl::OFlag;
+    use nix::sys::mman::{MapFlags, ProtFlags, mmap, munmap, shm_open, shm_unlink};
+    use nix::sys::stat::Mode;
+    use nix::unistd::ftruncate;
+    use std::num::NonZeroUsize;
+
+    /// Stage `data` in a shared memory object of that name, as a client sending
+    /// `t=s` does.
+    ///
+    /// The name must fit macOS' `PSHMNAMLEN` of 31 bytes including the leading
+    /// slash. A longer one fails `shm_open` with `ENAMETOOLONG`, which is not
+    /// the failure these tests are looking for.
+    fn stage(name: &str, data: &[u8]) -> String {
+        assert!(
+            name.len() <= 31,
+            "{} is longer than macOS accepts for a shm name",
+            name
+        );
+
+        // macOS refuses to resize an object that already has a size, so an
+        // object left behind by an earlier run has to go first.
+        let _ = shm_unlink(name);
+
+        let fd = shm_open(
+            name,
+            OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_RDWR,
+            Mode::S_IRUSR | Mode::S_IWUSR,
+        )
+        .unwrap();
+        ftruncate(&fd, data.len() as _).unwrap();
+
+        let len = NonZeroUsize::new(data.len()).unwrap();
+        // SAFETY: the object was created above and sized to `len`, so a mapping
+        // of that length is backed for its whole extent.
+        let ptr = unsafe {
+            mmap(
+                None,
+                len,
+                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                MapFlags::MAP_SHARED,
+                &fd,
+                0,
+            )
+        }
+        .unwrap();
+        // SAFETY: `ptr` maps `len` writable bytes and `data` is `len` long, so
+        // the copy stays inside both, and the two cannot overlap because the
+        // mapping was just created.
+        unsafe {
+            std::ptr::copy_nonoverlapping(data.as_ptr(), ptr.as_ptr() as *mut u8, len.get());
+            munmap(ptr, len.get()).unwrap();
+        }
+
+        name.to_string()
+    }
+
+    /// Whether an object of this name still exists.
+    ///
+    /// Only `ENOENT` counts as gone. Taking every error for absence would let a
+    /// permission or name length problem pass as a successful unlink.
+    fn present(name: &str) -> bool {
+        match shm_open(name, OFlag::O_RDONLY, Mode::empty()) {
+            Ok(_) => true,
+            Err(nix::errno::Errno::ENOENT) => false,
+            Err(err) => panic!("asking whether {} is still there answered {}", name, err),
+        }
+    }
+
+    fn pattern(len: usize) -> Vec<u8> {
+        (0..=255u8).cycle().take(len).collect()
+    }
+
+    /// With neither `O` nor `S`, the whole object comes back.
+    #[test]
+    fn shm_reads_the_whole_object() {
+        let data = pattern(4096);
+        let name = stage("/wtshm-whole", &data);
+
+        let got = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: None,
+            data_size: None,
+        }
+        .load_data()
+        .unwrap();
+
+        // An object can report more than was staged in it, as Darwin rounds the
+        // size up to a page; the data sits at the front.
+        assert!(got.len() >= data.len());
+        assert_eq!(&got[..data.len()], &data[..]);
+        assert!(!present(&name), "the object is unlinked once it is read");
+    }
+
+    /// `O` and `S` select a range within the object. `O` is applied to the
+    /// mapped bytes rather than to mmap, which only accepts a page aligned
+    /// offset.
+    #[test]
+    fn shm_reads_the_slice_it_is_asked_for() {
+        let data = pattern(4096);
+        let name = stage("/wtshm-slice", &data);
+
+        let got = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: Some(10),
+            data_size: Some(80),
+        }
+        .load_data()
+        .unwrap();
+
+        assert_eq!(got, data[10..90].to_vec());
+        assert!(!present(&name), "the object is unlinked once it is read");
+    }
+
+    /// `S=0` asks for no bytes, which is not an error.
+    #[test]
+    fn shm_reads_nothing_when_asked_for_nothing() {
+        let name = stage("/wtshm-none", &pattern(64));
+
+        let got = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: None,
+            data_size: Some(0),
+        }
+        .load_data()
+        .unwrap();
+
+        assert_eq!(got, Vec::<u8>::new());
+        assert!(!present(&name), "the object is unlinked once it is read");
+    }
+
+    /// An `O` beyond the object is refused rather than read, and the object is
+    /// still unlinked so a rejected transmission leaves nothing behind.
+    #[test]
+    fn shm_refuses_an_offset_past_the_end() {
+        let name = stage("/wtshm-oob", &pattern(64));
+
+        let err = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: Some(1 << 20),
+            data_size: Some(4),
+        }
+        .load_data()
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("offset"),
+            "an offset past the end says so: {}",
+            err
+        );
+        assert!(!present(&name), "a refused read still unlinks the object");
+    }
+
+    /// A name that does not exist names itself in the error, so a client that
+    /// sent the wrong name, or one too long for the platform, can tell.
+    #[test]
+    fn shm_reports_an_object_that_is_not_there() {
+        let _ = shm_unlink("/wtshm-absent");
+
+        let err = KittyImageData::SharedMem {
+            name: "/wtshm-absent".to_string(),
+            data_offset: None,
+            data_size: None,
+        }
+        .load_data()
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("/wtshm-absent"),
+            "the error names the object: {}",
+            err
+        );
+    }
+
+    /// An object with nothing in it carries no image, and a client that asked
+    /// for bytes is told so rather than handed an empty read that reports
+    /// success.
+    #[test]
+    fn shm_refuses_an_empty_object() {
+        // Staged by hand rather than through `stage`, which maps the object and
+        // so cannot size one at zero.
+        let name = "/wtshm-empty".to_string();
+        let _ = shm_unlink(name.as_str());
+        let fd = shm_open(
+            name.as_str(),
+            OFlag::O_CREAT | OFlag::O_EXCL | OFlag::O_RDWR,
+            Mode::S_IRUSR | Mode::S_IWUSR,
+        )
+        .unwrap();
+        drop(fd);
+
+        let err = KittyImageData::SharedMem {
+            name: name.clone(),
+            data_offset: None,
+            data_size: Some(80),
+        }
+        .load_data()
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("empty"),
+            "an empty object says so: {}",
+            err
+        );
+        assert!(!present(&name), "a refused read still unlinks the object");
     }
 }


### PR DESCRIPTION
Closes #7631.

`t=s` never draws on macOS. `read_shared_memory_data` used `seek`/`read_exact` on
the `shm_open` descriptor, but on Darwin a POSIX shared memory object can only be
mapped: `read(2)` returns `ENXIO` and `lseek(2)` returns `ESPIPE`. Linux is
unaffected because its shared memory is tmpfs.

It now maps the object, as the Windows arm already does. The mapping goes through
`memmap2`, which the workspace already depends on and `wezterm-font` already uses
for font files; that keeps the arm to one `unsafe` rather than three plus a
manual `munmap`.

The unlink moved to immediately after the open. POSIX keeps the object alive
while a descriptor is, so the read is unaffected, and no error path leaves the
object behind.

### References

- **Darwin is mapping-only.** POSIX says a shared memory object need not support
  read/write: [`shm_open`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/shm_open.html) and [`mmap`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mmap.html).
  On Darwin the open is gated on read permission but `shm_unlink` on write
  permission *or* being the creator —
  [xnu `bsd/kern/posix_shm.c`](https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/posix_shm.c)
  (`pshm_open` vs `shm_unlink`), which is why a failed unlink is logged rather
  than fatal.
- **Unlink removes a name, not a descriptor.** `shm_unlink` postpones removal
  "until all open and map references have been removed"
  ([POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/functions/shm_unlink.html)).
  This is what the `SAFETY` comment now rests on, after a first draft of it
  overclaimed — see the Copilot thread on #8061.
- **What the protocol asks of the terminal**, kitty
  [graphics protocol, `t=s`](https://sw.kovidgoyal.net/kitty/graphics-protocol/#the-transmission-medium):
  "The terminal emulator must read the data from the memory object and then
  unlink and close it on POSIX and just close it on Windows."

### How to test

A self-contained C repro is in [#7631](https://github.com/wezterm/wezterm/issues/7631#issuecomment-5247169771)
— it needs no terminal at all: `shm_open` + `ftruncate` + write, then `read()`
gives `ENXIO`, `lseek()` gives `ESPIPE`, and `mmap()` works.

```
cargo test --all
```

Six shm tests are added. Four of them fail on `main` with the errnos above; I
checked that by putting `main`'s implementation back underneath them rather than
assuming it.

⚠️ `cargo test -p wezterm-escape-parser` runs **zero** of them — they sit behind
the non-default `kitty-shm` feature, which only arrives through
`termwiz/use_image`. Use `cargo test --all`, or
`cargo test -p wezterm-escape-parser --features std,kitty-shm`.

For an end-to-end check on macOS, any client that sends `t=s` will do.
[rav](https://github.com/i-am-logger/rav) deliberately does **not** — it stages
frames as `t=t` in `/dev/shm` precisely because `t=s` does not work here, which
is how I ran into this.

