### PR TITLE
fix(kitty): nine protocol key and default-value corrections

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -156,35 +156,16 @@ As features stabilize some brief notes about them will accumulate here.
 #### Fixed
 * perf: Terminal images were hashed three times each on the transmit path; the sha256
   an RGBA image already carries is now reused instead. Thanks to @i-am-logger! #8065
-* Fixed raw format kitty images being refused when the file or shared memory
-  object holding them is longer than the image itself, which a shared memory
-  object always is once it is rounded up to a page. The pixel count follows from
-  `f`, `s` and `v`, so only that much is read.
-* Fixed a kitty image data size of zero being read as a request for no bytes.
-  `S` defaults to zero, so that is a size the client did not give.
-* Fixed the kitty image protocol data offset being re-encoded under the `S` key,
-  which overwrote the size and dropped `O` entirely. This affects anything that
-  parses an image escape sequence and writes it back out through `Display`.
-* Fixed the kitty animation frame gap being read and written as `Z` rather than
-  the `z` the protocol uses, so a client's frame gap was ignored and every
-  animated frame fell back to the 40ms default.
-* Fixed transmit-and-display re-encoding as `a=Q`, which is not an action the
-  protocol defines; it is `a=T`. This affects anything that parses an image
-  escape sequence and writes it back out through `Display`.
-* Fixed a delete that names a z-index re-encoding as `d=p`, which deletes every
-  placement in the cell whatever its z-index; it is `d=q`. This affects anything
-  that parses an image escape sequence and writes it back out through `Display`.
-* Fixed kitty images being refused when the placement gives `w`, `h`, `c` or `r`
-  as zero. All four default to zero, and zero is how the protocol spells "not
-  given": for `w` and `h` it says the entire width and height are used, and it
-  gives `c` and `r` the same default without defining a zero. Reading those
-  zeros as dimensions is what divided by zero in #6344. A placement with nothing
-  to draw, where the source origin lies outside the image, is still refused.
-* Fixed a kitty animation frame composition with `w=0` or `h=0` composing
-  nothing. Both default to zero, which the protocol reads as the whole frame.
-* Fixed a kitty delete with `p=0` matching only placements recorded under a
-  placement id of zero. Placement ids run from 1, so `p=0` is the same command
-  as omitting `p`: it names every placement of the image.
+* Fixed nine places where the kitty image protocol implementation disagreed with
+  the spec. Keys whose protocol default is `0` were read as a literal zero
+  rather than as absent, and raw images were refused when their source held more
+  bytes than their dimensions imply, as a shared memory object always does.
+  Between them these refused conformant images, and were the root of the divide
+  by zero in #6344. #8064
+* Fixed the kitty image data offset, the animation frame gap, transmit-and-display
+  and delete-at-a-z-index being re-encoded under the wrong keys. This affects
+  anything that parses an image escape sequence and writes it back out through
+  `Display`. #8064
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program
   that left it enabled and exited uncleanly could leave ctrl keys emitting
   escape sequences that the shell doesn't expect. RIS now also resets the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -156,6 +156,35 @@ As features stabilize some brief notes about them will accumulate here.
 #### Fixed
 * perf: Terminal images were hashed three times each on the transmit path; the sha256
   an RGBA image already carries is now reused instead. Thanks to @i-am-logger! #8065
+* Fixed raw format kitty images being refused when the file or shared memory
+  object holding them is longer than the image itself, which a shared memory
+  object always is once it is rounded up to a page. The pixel count follows from
+  `f`, `s` and `v`, so only that much is read.
+* Fixed a kitty image data size of zero being read as a request for no bytes.
+  `S` defaults to zero, so that is a size the client did not give.
+* Fixed the kitty image protocol data offset being re-encoded under the `S` key,
+  which overwrote the size and dropped `O` entirely. This affects anything that
+  parses an image escape sequence and writes it back out through `Display`.
+* Fixed the kitty animation frame gap being read and written as `Z` rather than
+  the `z` the protocol uses, so a client's frame gap was ignored and every
+  animated frame fell back to the 40ms default.
+* Fixed transmit-and-display re-encoding as `a=Q`, which is not an action the
+  protocol defines; it is `a=T`. This affects anything that parses an image
+  escape sequence and writes it back out through `Display`.
+* Fixed a delete that names a z-index re-encoding as `d=p`, which deletes every
+  placement in the cell whatever its z-index; it is `d=q`. This affects anything
+  that parses an image escape sequence and writes it back out through `Display`.
+* Fixed kitty images being refused when the placement gives `w`, `h`, `c` or `r`
+  as zero. All four default to zero, and zero is how the protocol spells "not
+  given": for `w` and `h` it says the entire width and height are used, and it
+  gives `c` and `r` the same default without defining a zero. Reading those
+  zeros as dimensions is what divided by zero in #6344. A placement with nothing
+  to draw, where the source origin lies outside the image, is still refused.
+* Fixed a kitty animation frame composition with `w=0` or `h=0` composing
+  nothing. Both default to zero, which the protocol reads as the whole frame.
+* Fixed a kitty delete with `p=0` matching only placements recorded under a
+  placement id of zero. Placement ids run from 1, so `p=0` is the same command
+  as omitting `p`: it names every placement of the image.
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program
   that left it enabled and exited uncleanly could leave ctrl keys emitting
   escape sequences that the shell doesn't expect. RIS now also resets the
@@ -288,7 +317,7 @@ As features stabilize some brief notes about them will accumulate here.
 * Fix ESC key encoding in kitty mode with disambiguate flag enabled.
   Thanks to @Felixoid and @the-mikedavis! #7787
 * Fixed two divide-by-zero crashes in Kitty inline image placement when a program requests
-  a zero-sized placement (e.g. `w=0`/`h=0`), or displaying a cell-sized image on a pane
+  a placement with nothing to draw, or displaying a cell-sized image on a pane
   whose pty reported no pixel dimensions (e.g. in `tmux -CC` domain).
   Such images are now refused instead of taking down the pane. Thanks to @zakrad! #6344
 * Fix render loop freeze when closing workspaces. Thanks to @JafarAbdi! #7444

--- a/term/src/terminalstate/image.rs
+++ b/term/src/terminalstate/image.rs
@@ -108,7 +108,7 @@ impl TerminalState {
         // !!! Guard against a zero-sized image, nothing to draw.
         // A zero-sized drawable region leaves nothing to display and would divide by zero when
         // computing the per-cell pixel deltas below.
-        // (e.g. an image with explicit `w=0`/`h=0`, or a source origin outside the image bounds)
+        // (e.g. a source origin that lies outside the image bounds)
         // => Refuse the image placement instead of panicking and taking down the terminal.
         // <https://github.com/wezterm/wezterm/issues/6344>
         anyhow::ensure!(

--- a/term/src/terminalstate/kitty.rs
+++ b/term/src/terminalstate/kitty.rs
@@ -786,6 +786,27 @@ impl TerminalState {
 
                 check_image_dimensions(width, height)?;
 
+                // The pixel count follows from the format and the dimensions,
+                // so the source only has to hold at least that much. A shared
+                // memory object can report more than was staged in it, and a
+                // file may be longer than the image inside it.
+                let bytes_per_pixel = match transmit.format {
+                    Some(KittyImageFormat::Rgb) => 3,
+                    _ => 4,
+                };
+                let needed = width as usize * height as usize * bytes_per_pixel;
+                anyhow::ensure!(
+                    data.len() >= needed,
+                    "transmit data len is {} but {}x{} at {} bytes per pixel needs {}",
+                    data.len(),
+                    width,
+                    height,
+                    bytes_per_pixel,
+                    needed
+                );
+                let mut data = data;
+                data.truncate(needed);
+
                 let data = match transmit.format {
                     Some(KittyImageFormat::Rgb) => {
                         let img = DynamicImage::ImageRgb8(

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -142,9 +142,13 @@ fn kitty_frame_edit_keeps_the_stored_hash_current() {
 const TINY_RGBA_PADDED_BASE64: &str = "AQID/wQFBv8HCAn/CgsM/wAAAAA=";
 
 /// For the raw formats the protocol derives the pixel count from `f`, `s` and
-/// `v`, so a source holding more than that is read up to the length the image
-/// needs. A shared memory object reporting more than was staged in it is the
-/// case that matters.
+/// `v`, so a source holding more bytes than that is read up to the length the
+/// image needs rather than refused.
+///
+/// The transport that makes this matter is `t=s`: a POSIX shared memory object
+/// reports its size rounded up to a page, so it is nearly always longer than
+/// the frame staged in it. This test sends the same over-long payload inline,
+/// which exercises the same length check without needing a shm object.
 #[test]
 fn kitty_raw_image_longer_than_its_dimensions_is_accepted() {
     let mut term = TestTerm::new(3, 10, 0);

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -124,3 +124,38 @@ fn kitty_frame_edit_keeps_the_stored_hash_current() {
 
     assert_ne!(edited_hash, transmitted_hash);
 }
+
+/// A 2x2 RGBA image, base64 encoded, with four bytes of padding after it.
+const TINY_RGBA_PADDED_BASE64: &str = "AQID/wQFBv8HCAn/CgsM/wAAAAA=";
+
+/// For the raw formats the protocol derives the pixel count from `f`, `s` and
+/// `v`, so a source holding more than that is read up to the length the image
+/// needs. A shared memory object reporting more than was staged in it is the
+/// case that matters.
+#[test]
+fn kitty_raw_image_longer_than_its_dimensions_is_accepted() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    // f=32: RGBA, s/v: 2x2 pixels, so 16 bytes are needed and 20 are sent.
+    let seq = format!(
+        "\x1b_Ga=T,t=d,f=32,s=2,v=2,i=1;{}\x1b\\",
+        TINY_RGBA_PADDED_BASE64
+    );
+    term.advance_bytes(seq.as_bytes());
+
+    let image = first_image(&term);
+    let image = image.data();
+    match &*image {
+        ImageDataType::Rgba8 {
+            data,
+            width,
+            height,
+            ..
+        } => {
+            k9::assert_equal!(*width, 2);
+            k9::assert_equal!(*height, 2);
+            k9::assert_equal!(data.len(), 16);
+        }
+        other => panic!("expected Rgba8, got {:?}", other),
+    }
+}

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -8,21 +8,34 @@ use wezterm_surface::change::ImageData;
 /// Taken from the reproduction in <https://github.com/wezterm/wezterm/issues/6344>.
 const TINY_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAACXBIWXMAAAGKAAABigEzlzBYAAAAOUlEQVQYlZXOwQ0AMAzCQEdi7yaT0xWAN7JuDCac2PQKYxflycOoICOKtPIuqFCg4/LzKxiz6xjyAYh9DR1sLUN1AAAAAElFTkSuQmCC";
 
-/// Feeding a Kitty graphics escape that requests a zero-sized placement (here `r=0,h=0`)
-/// must not panic the terminal.
-/// Prior to the fix for <https://github.com/wezterm/wezterm/issues/6344> this divided by zero
-/// while computing the per-cell pixel deltas and took down the whole pane.
+/// `r` and `h` default to zero, so `r=0,h=0` asks for the whole image over as
+/// many rows as its own height needs, and it is displayed.
+/// Reading those zeros as literal dimensions is what divided by zero in
+/// <https://github.com/wezterm/wezterm/issues/6344>.
 #[test]
-fn kitty_zero_dimension_image_does_not_panic() {
+fn kitty_zero_dimension_image_is_displayed() {
     let mut term = TestTerm::new(3, 10, 0);
 
     // a=T: transmit and display, t=d: data is directly embedded,
-    // f=100: PNG, r=0/h=0: zero rows / zero source height.
+    // f=100: PNG, r=0/h=0: neither given.
     let seq = format!("\x1b_Gr=0,h=0,a=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
     term.print(seq.as_bytes());
 
-    // The image is refused, so the cursor never moved;
-    // Printing normal text and observing it confirms we recovered rather than crashing.
+    // The image was placed, so the cursor moved past it.
+    term.print(b"ok");
+    assert_visible_contents(&term, file!(), line!(), &["  ok", "", ""]);
+}
+
+/// A source origin outside the image leaves nothing to draw, whatever the keys
+/// say, and that is still refused rather than dividing by zero.
+#[test]
+fn kitty_image_drawn_entirely_outside_itself_is_refused() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    // x/y put the source origin past the 11x11 image, so no pixels remain.
+    let seq = format!("\x1b_Gx=99,y=99,a=T,t=d,f=100;{}\x1b\\", TINY_PNG_BASE64);
+    term.print(seq.as_bytes());
+
     term.print(b"ok");
     assert_visible_contents(&term, file!(), line!(), &["ok", "", ""]);
 }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -816,7 +816,7 @@ impl KittyImageDelete {
                 keys.insert("y", y.to_string());
             }
             Self::DeleteAtZ { x, y, z, delete } => {
-                keys.insert("d", d('p', delete));
+                keys.insert("d", d('q', delete));
                 keys.insert("x", x.to_string());
                 keys.insert("y", y.to_string());
                 keys.insert("z", z.to_string());

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -1133,7 +1133,7 @@ impl KittyImage {
                 verbosity,
                 placement,
             } => {
-                keys.insert("a", "Q".to_string());
+                keys.insert("a", "T".to_string());
                 verbosity.to_keys(keys);
                 placement.to_keys(keys);
                 transmit.to_keys(keys);

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -625,12 +625,28 @@ impl KittyImagePlacement {
         Some(Self {
             x: geti(keys, "x"),
             y: geti(keys, "y"),
-            w: geti(keys, "w"),
-            h: geti(keys, "h"),
+            // w, h, c and r all default to zero, and zero is not a rectangle of
+            // nothing: for w and h the protocol says the entire width and height
+            // are used. It gives c and r the same default without defining what
+            // a zero means, so they are read the same way.
+            w: match geti(keys, "w") {
+                None | Some(0) => None,
+                n => n,
+            },
+            h: match geti(keys, "h") {
+                None | Some(0) => None,
+                n => n,
+            },
             x_offset: geti(keys, "X"),
             y_offset: geti(keys, "Y"),
-            columns: geti(keys, "c"),
-            rows: geti(keys, "r"),
+            columns: match geti(keys, "c") {
+                None | Some(0) => None,
+                n => n,
+            },
+            rows: match geti(keys, "r") {
+                None | Some(0) => None,
+                n => n,
+            },
             placement_id: geti(keys, "p"),
             do_not_move_cursor: match get(keys, "C") {
                 None | Some("0") => false,

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -949,6 +949,8 @@ pub struct KittyImageFrame {
 
     /// Gap in milliseconds of this frame from the next one.
     /// Zero or omitted values are interpreted as 40ms.
+    /// A negative gap asks for a gapless frame. It does not parse as `u32`, so
+    /// it arrives here as `None` and takes the same 40ms as an omitted gap.
     /// z=...
     pub duration_ms: Option<u32>,
 
@@ -976,7 +978,7 @@ impl KittyImageFrame {
                 None | Some(0) => None,
                 n => n,
             },
-            duration_ms: match geti(keys, "Z") {
+            duration_ms: match geti(keys, "z") {
                 None | Some(0) => None,
                 n => n,
             },
@@ -994,7 +996,7 @@ impl KittyImageFrame {
         set(keys, "y", &self.y);
         set(keys, "c", &self.base_frame);
         set(keys, "r", &self.frame_number);
-        set(keys, "Z", &self.duration_ms);
+        set(keys, "z", &self.duration_ms);
         match &self.composition_mode {
             KittyFrameCompositionMode::AlphaBlending => {}
             KittyFrameCompositionMode::Overwrite => {

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -647,7 +647,11 @@ impl KittyImagePlacement {
                 None | Some(0) => None,
                 n => n,
             },
-            placement_id: geti(keys, "p"),
+            // A placement id runs from 1, so a zero is no placement id.
+            placement_id: match geti(keys, "p") {
+                None | Some(0) => None,
+                n => n,
+            },
             do_not_move_cursor: match get(keys, "C") {
                 None | Some("0") => false,
                 Some("1") => true,
@@ -750,14 +754,22 @@ impl KittyImageDelete {
         let delete = d.is_ascii_uppercase();
         match d {
             'a' | 'A' => Some(Self::All { delete }),
+            // A placement id runs from 1, so a zero names every placement of
+            // the image rather than one recorded under an id of zero.
             'i' | 'I' => Some(Self::ByImageId {
                 image_id: geti(keys, "i")?,
-                placement_id: geti(keys, "p"),
+                placement_id: match geti(keys, "p") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 delete,
             }),
             'n' | 'N' => Some(Self::ByImageNumber {
                 image_number: geti(keys, "I")?,
-                placement_id: geti(keys, "p"),
+                placement_id: match geti(keys, "p") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 delete,
             }),
             'c' | 'C' => Some(Self::AtCursorPosition { delete }),
@@ -1298,6 +1310,46 @@ mod test {
                     background_pixel: None,
                     duration_ms: None,
                 },
+            }
+        );
+    }
+
+    /// A placement id runs from 1, so `p=0` is the same command as omitting it.
+    /// A delete carrying it names every placement of the image, not a placement
+    /// recorded under an id of zero.
+    #[test]
+    fn kitty_zero_placement_id_is_absent() {
+        assert_eq!(
+            KittyImage::parse_apc("Ga=d,d=i,i=10,p=0".as_bytes()).unwrap(),
+            KittyImage::Delete {
+                what: KittyImageDelete::ByImageId {
+                    image_id: 10,
+                    placement_id: None,
+                    delete: false,
+                },
+                verbosity: KittyImageVerbosity::Verbose,
+            }
+        );
+
+        assert_eq!(
+            KittyImage::parse_apc("Ga=p,i=10,p=0".as_bytes()).unwrap(),
+            KittyImage::Display {
+                image_id: Some(10),
+                image_number: None,
+                placement: KittyImagePlacement {
+                    x: None,
+                    y: None,
+                    w: None,
+                    h: None,
+                    x_offset: None,
+                    y_offset: None,
+                    columns: None,
+                    rows: None,
+                    do_not_move_cursor: false,
+                    placement_id: None,
+                    z_index: None,
+                },
+                verbosity: KittyImageVerbosity::Verbose,
             }
         );
     }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -916,8 +916,16 @@ impl KittyImageFrameCompose {
             y: geti(keys, "y"),
             src_x: geti(keys, "X"),
             src_y: geti(keys, "Y"),
-            w: geti(keys, "w"),
-            h: geti(keys, "h"),
+            // w and h default to zero, which asks for the whole frame rather
+            // than a rectangle of nothing.
+            w: match geti(keys, "w") {
+                None | Some(0) => None,
+                n => n,
+            },
+            h: match geti(keys, "h") {
+                None | Some(0) => None,
+                n => n,
+            },
             target_frame: match geti(keys, "c") {
                 None | Some(0) => None,
                 n => n,
@@ -1290,6 +1298,32 @@ mod test {
                     background_pixel: None,
                     duration_ms: None,
                 },
+            }
+        );
+    }
+
+    /// `w` and `h` give the size of the rectangle a composition reads and
+    /// writes, and both default to zero, which asks for the whole frame rather
+    /// than a rectangle of nothing.
+    #[test]
+    fn kitty_zero_composition_width_or_height_is_absent() {
+        assert_eq!(
+            KittyImage::parse_apc("Ga=c,i=1,r=1,c=2,w=0,h=0".as_bytes()).unwrap(),
+            KittyImage::ComposeFrame {
+                frame: KittyImageFrameCompose {
+                    image_id: Some(1),
+                    image_number: None,
+                    target_frame: Some(2),
+                    source_frame: Some(1),
+                    x: None,
+                    y: None,
+                    w: None,
+                    h: None,
+                    src_x: None,
+                    src_y: None,
+                    composition_mode: KittyFrameCompositionMode::AlphaBlending,
+                },
+                verbosity: KittyImageVerbosity::Verbose,
             }
         );
     }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -111,17 +111,26 @@ impl KittyImageData {
             "d" => Some(Self::Direct(String::from_utf8(payload.to_vec()).ok()?)),
             "f" => Some(Self::File {
                 path: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: geti(keys, "S"),
+                data_size: match geti(keys, "S") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 data_offset: geti(keys, "O"),
             }),
             "t" => Some(Self::TemporaryFile {
                 path: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: geti(keys, "S"),
+                data_size: match geti(keys, "S") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 data_offset: geti(keys, "O"),
             }),
             "s" => Some(Self::SharedMem {
                 name: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: geti(keys, "S"),
+                data_size: match geti(keys, "S") {
+                    None | Some(0) => None,
+                    n => n,
+                },
                 data_offset: geti(keys, "O"),
             }),
             _ => None,

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -144,7 +144,7 @@ impl KittyImageData {
                 keys.insert("t", "f".to_string());
                 keys.insert("payload", base64_encode(&path));
                 set(keys, "S", data_size);
-                set(keys, "S", data_offset);
+                set(keys, "O", data_offset);
             }
             Self::TemporaryFile {
                 path,
@@ -154,7 +154,7 @@ impl KittyImageData {
                 keys.insert("t", "t".to_string());
                 keys.insert("payload", base64_encode(&path));
                 set(keys, "S", data_size);
-                set(keys, "S", data_offset);
+                set(keys, "O", data_offset);
             }
             Self::SharedMem {
                 name,
@@ -164,7 +164,7 @@ impl KittyImageData {
                 keys.insert("t", "s".to_string());
                 keys.insert("payload", base64_encode(&name));
                 set(keys, "S", data_size);
-                set(keys, "S", data_offset);
+                set(keys, "O", data_offset);
             }
         }
     }

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -10,6 +10,16 @@ fn geti<T: core::str::FromStr>(keys: &BTreeMap<&str, &str>, k: &str) -> Option<T
     get(keys, k).and_then(|s| s.parse().ok())
 }
 
+/// Read a key that the protocol gives a default of zero, where that default is
+/// how it spells "not given". A literal zero and an absent key are the same
+/// command, so both come back as `None`.
+fn geti_zero_is_absent<T: core::str::FromStr + Default + PartialEq>(
+    keys: &BTreeMap<&str, &str>,
+    k: &str,
+) -> Option<T> {
+    geti(keys, k).filter(|v| *v != T::default())
+}
+
 fn set<T: ToString>(keys: &mut BTreeMap<&'static str, String>, k: &'static str, v: &Option<T>) {
     if let Some(v) = v {
         keys.insert(k, v.to_string());
@@ -111,26 +121,17 @@ impl KittyImageData {
             "d" => Some(Self::Direct(String::from_utf8(payload.to_vec()).ok()?)),
             "f" => Some(Self::File {
                 path: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: match geti(keys, "S") {
-                    None | Some(0) => None,
-                    n => n,
-                },
+                data_size: geti_zero_is_absent(keys, "S"),
                 data_offset: geti(keys, "O"),
             }),
             "t" => Some(Self::TemporaryFile {
                 path: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: match geti(keys, "S") {
-                    None | Some(0) => None,
-                    n => n,
-                },
+                data_size: geti_zero_is_absent(keys, "S"),
                 data_offset: geti(keys, "O"),
             }),
             "s" => Some(Self::SharedMem {
                 name: String::from_utf8(base64_decode(payload.to_vec()).ok()?).ok()?,
-                data_size: match geti(keys, "S") {
-                    None | Some(0) => None,
-                    n => n,
-                },
+                data_size: geti_zero_is_absent(keys, "S"),
                 data_offset: geti(keys, "O"),
             }),
             _ => None,
@@ -629,29 +630,14 @@ impl KittyImagePlacement {
             // nothing: for w and h the protocol says the entire width and height
             // are used. It gives c and r the same default without defining what
             // a zero means, so they are read the same way.
-            w: match geti(keys, "w") {
-                None | Some(0) => None,
-                n => n,
-            },
-            h: match geti(keys, "h") {
-                None | Some(0) => None,
-                n => n,
-            },
+            w: geti_zero_is_absent(keys, "w"),
+            h: geti_zero_is_absent(keys, "h"),
             x_offset: geti(keys, "X"),
             y_offset: geti(keys, "Y"),
-            columns: match geti(keys, "c") {
-                None | Some(0) => None,
-                n => n,
-            },
-            rows: match geti(keys, "r") {
-                None | Some(0) => None,
-                n => n,
-            },
+            columns: geti_zero_is_absent(keys, "c"),
+            rows: geti_zero_is_absent(keys, "r"),
             // A placement id runs from 1, so a zero is no placement id.
-            placement_id: match geti(keys, "p") {
-                None | Some(0) => None,
-                n => n,
-            },
+            placement_id: geti_zero_is_absent(keys, "p"),
             do_not_move_cursor: match get(keys, "C") {
                 None | Some("0") => false,
                 Some("1") => true,
@@ -758,18 +744,12 @@ impl KittyImageDelete {
             // the image rather than one recorded under an id of zero.
             'i' | 'I' => Some(Self::ByImageId {
                 image_id: geti(keys, "i")?,
-                placement_id: match geti(keys, "p") {
-                    None | Some(0) => None,
-                    n => n,
-                },
+                placement_id: geti_zero_is_absent(keys, "p"),
                 delete,
             }),
             'n' | 'N' => Some(Self::ByImageNumber {
                 image_number: geti(keys, "I")?,
-                placement_id: match geti(keys, "p") {
-                    None | Some(0) => None,
-                    n => n,
-                },
+                placement_id: geti_zero_is_absent(keys, "p"),
                 delete,
             }),
             'c' | 'C' => Some(Self::AtCursorPosition { delete }),
@@ -930,22 +910,10 @@ impl KittyImageFrameCompose {
             src_y: geti(keys, "Y"),
             // w and h default to zero, which asks for the whole frame rather
             // than a rectangle of nothing.
-            w: match geti(keys, "w") {
-                None | Some(0) => None,
-                n => n,
-            },
-            h: match geti(keys, "h") {
-                None | Some(0) => None,
-                n => n,
-            },
-            target_frame: match geti(keys, "c") {
-                None | Some(0) => None,
-                n => n,
-            },
-            source_frame: match geti(keys, "r") {
-                None | Some(0) => None,
-                n => n,
-            },
+            w: geti_zero_is_absent(keys, "w"),
+            h: geti_zero_is_absent(keys, "h"),
+            target_frame: geti_zero_is_absent(keys, "c"),
+            source_frame: geti_zero_is_absent(keys, "r"),
             composition_mode: match geti(keys, "C") {
                 None | Some(0) => KittyFrameCompositionMode::AlphaBlending,
                 Some(1) => KittyFrameCompositionMode::Overwrite,
@@ -1015,18 +983,9 @@ impl KittyImageFrame {
         Some(Self {
             x: geti(keys, "x"),
             y: geti(keys, "y"),
-            base_frame: match geti(keys, "c") {
-                None | Some(0) => None,
-                n => n,
-            },
-            frame_number: match geti(keys, "r") {
-                None | Some(0) => None,
-                n => n,
-            },
-            duration_ms: match geti(keys, "z") {
-                None | Some(0) => None,
-                n => n,
-            },
+            base_frame: geti_zero_is_absent(keys, "c"),
+            frame_number: geti_zero_is_absent(keys, "r"),
+            duration_ms: geti_zero_is_absent(keys, "z"),
             composition_mode: match geti(keys, "X") {
                 None | Some(0) => KittyFrameCompositionMode::AlphaBlending,
                 Some(1) => KittyFrameCompositionMode::Overwrite,

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -1048,6 +1048,28 @@ mod test {
         );
     }
 
+    /// Deleting placements at a cell with a given z-index is `d=q`; `d=p` is
+    /// the same delete without the z-index, so the two must not collapse.
+    #[test]
+    fn kitty_delete_at_cell_with_z() {
+        use crate::apc::*;
+
+        assert_eq!(
+            round_trip_parse("\x1b_Ga=d,d=q,x=3,y=4,z=-1\x1b\\"),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::Delete {
+                    what: KittyImageDelete::DeleteAtZ {
+                        x: 3,
+                        y: 4,
+                        z: -1,
+                        delete: false,
+                    },
+                    verbosity: KittyImageVerbosity::Verbose,
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
 
     /// Transmit and display is `a=T`, so it survives a round trip.
     #[test]

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -977,6 +977,45 @@ mod test {
         );
     }
 
+    /// The inter-frame gap is `z`, so it survives a round trip.
+    #[test]
+    fn kitty_frame_gap() {
+        use crate::apc::*;
+
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=f,i=1,z=100;YWJjZA==\x1b\\",
+                "\x1b_Ga=f,i=1,z=100;YWJjZA==\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::TransmitFrame {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::Direct("YWJjZA==".to_string()),
+                        width: None,
+                        height: None,
+                        image_id: Some(1),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                    frame: KittyImageFrame {
+                        x: None,
+                        y: None,
+                        base_frame: None,
+                        frame_number: None,
+                        duration_ms: Some(100),
+                        composition_mode: KittyFrameCompositionMode::AlphaBlending,
+                        background_pixel: None,
+                    },
+                    verbosity: KittyImageVerbosity::Verbose,
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
+
+
     /* Withdrawn because xterm introduced a conflict:
      * <https://github.com/mintty/mintty/issues/1171#issuecomment-1336174469>
      * <https://github.com/mintty/mintty/issues/1189>

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -1015,6 +1015,47 @@ mod test {
         );
     }
 
+    /// Transmit and display is `a=T`, so it survives a round trip.
+    #[test]
+    fn kitty_transmit_and_display() {
+        use crate::apc::*;
+
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=T,s=1,v=1,i=2;YWJjZA==\x1b\\",
+                "\x1b_Ga=T,i=2,s=1,v=1;YWJjZA==\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::TransmitDataAndDisplay {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::Direct("YWJjZA==".to_string()),
+                        width: Some(1),
+                        height: Some(1),
+                        image_id: Some(2),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                    placement: KittyImagePlacement {
+                        x: None,
+                        y: None,
+                        w: None,
+                        h: None,
+                        x_offset: None,
+                        y_offset: None,
+                        columns: None,
+                        rows: None,
+                        do_not_move_cursor: false,
+                        placement_id: None,
+                        z_index: None,
+                    },
+                    verbosity: KittyImageVerbosity::Verbose,
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
 
     /* Withdrawn because xterm introduced a conflict:
      * <https://github.com/mintty/mintty/issues/1171#issuecomment-1336174469>

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -1015,6 +1015,40 @@ mod test {
         );
     }
 
+    /// `S` defaults to zero, so `S=0` is a size that was not given and the
+    /// whole file is read.
+    #[test]
+    fn kitty_zero_size_is_no_size() {
+        use crate::apc::*;
+
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=q,t=t,s=1,v=1,i=4,S=0;L3Zhci90bXAvdG1wdGYxd3E4Ym4=\x1b\\",
+                "\x1b_Ga=q,i=4,s=1,t=t,v=1;L3Zhci90bXAvdG1wdGYxd3E4Ym4=\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::Query {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::TemporaryFile {
+                            path: "/var/tmp/tmptf1wq8bn".to_string(),
+                            data_offset: None,
+                            data_size: None,
+                        },
+                        width: Some(1),
+                        height: Some(1),
+                        image_id: Some(4),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
+    }
+
+
     /// Transmit and display is `a=T`, so it survives a round trip.
     #[test]
     fn kitty_transmit_and_display() {

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -948,6 +948,33 @@ mod test {
                 Action::Esc(Esc::Code(EscCode::StringTerminator)),
             ]
         );
+
+        // The offset goes out under O, and leaves the size under S alone.
+        assert_eq!(
+            parse_as(
+                "\x1b_Ga=q,t=s,s=1,v=1,i=3,O=10,S=80;L3dlenRlcm0tc2htLXJ0\x1b\\",
+                "\x1b_GO=10,S=80,a=q,i=3,s=1,t=s,v=1;L3dlenRlcm0tc2htLXJ0\x1b\\"
+            ),
+            vec![
+                Action::KittyImage(Box::new(KittyImage::Query {
+                    transmit: KittyImageTransmit {
+                        format: None,
+                        data: KittyImageData::SharedMem {
+                            name: "/wezterm-shm-rt".to_string(),
+                            data_offset: Some(10),
+                            data_size: Some(80),
+                        },
+                        width: Some(1),
+                        height: Some(1),
+                        image_id: Some(3),
+                        image_number: None,
+                        compression: KittyImageCompression::None,
+                        more_data_follows: false,
+                    },
+                })),
+                Action::Esc(Esc::Code(EscCode::StringTerminator)),
+            ]
+        );
     }
 
     /* Withdrawn because xterm introduced a conflict:


### PR DESCRIPTION
Nine places where the kitty parser disagrees with the protocol. One commit each,
every one with a test that fails without it.

Four are the same bug: a key whose protocol default is `0` was read as a literal
`0` rather than as absent.

| | wezterm read/wrote | should be | backed by |
| --- | --- | --- | --- |
| `S=0` | a request for zero bytes | the same command as omitting `S` | default + impl |
| raw `f=24`/`f=32` | refused unless the length matched exactly | pixel count from `f`, `s`, `v` | spec + impl |
| placement `w` `h` `c` `r` `=0` | a rectangle of nothing | not given | spec (`w`/`h`), impl (`c`/`r`) |
| compose `w=0` `h=0` | copied nothing | the whole frame | spec |
| `p=0` | a placement filed under id 0 | no placement id | spec |
| `O` (offset) | written under `S`, overwriting the size | `O` | spec |
| frame gap | read and written as `Z` | `z` | spec |
| transmit-and-display | encoded `a=Q` | `a=T` | spec |
| delete at z-index | encoded `d=p`, a broader delete | `d=q` | spec |

The placement row is what divided by zero in #6344. That fix guarded the division
by refusing the placement, which stopped the crash but left a conformant image
undrawn; this removes the case at its source and keeps the guard for a placement
that really has nothing to draw. The last three rows change only `to_keys`, so
they reach consumers of `termwiz::escape` that re-encode.

### References

Spec quotes are from
[graphics-protocol.rst](https://raw.githubusercontent.com/kovidgoyal/kitty/master/docs/graphics-protocol.rst);
the reference implementation is
[kitty/graphics.c](https://github.com/kovidgoyal/kitty/blob/master/kitty/graphics.c).
I have marked what the spec **states** separately from what only the
implementation decides, because two of these are not spec-stated and I would
rather say so than have you find it.

- **`S=0`** — the [control data reference](https://sw.kovidgoyal.net/kitty/graphics-protocol/#control-data-reference)
  gives `S` default `0`, and defines Default as "the value they take when
  missing", so a missing `S` and `S=0` are the same value. That `0` must not mean
  a zero-length read is the *implementation's* decision, not the spec's:
  `mmap_img_file` treats a zero size as "map the whole file" via `fstat`. kitty
  also cannot distinguish the two — `GraphicsCommand g = {0}` with no presence
  flag (`parse-graphics-command.h`).
- **raw length** — spec, "RGB and RGBA data": *"Since `f=24` there are three
  bytes per pixel and therefore the pixel data must be `3 * 10 * 20 = 600`
  bytes."* That the source may be **longer** is the implementation's call:
  `process_image_data` errors only when the source is *short*
  (`mapped_file_sz < data_sz` → `ENODATA`), never when it is long. Note the spec
  shows `t=s` both with `S` (`s=10,v=2,t=s,S=80,O=10`, a partial read) and
  without (`i=31,s=10,v=2,t=s`) — so `S` is optional for raw formats, not
  confined to PNG.
- **placement `w`/`h`** — spec states it: *"The width (in pixels) of the image
  area to display. By default, the entire width is used."* For **`c`/`r`** the
  spec gives the same `0` default but never says what a zero means, so reading it
  as absent is wezterm's inference — a defensible one, since zero cells is not a
  placement.
- **compose `w`/`h`** — spec states it, [animation composition](https://sw.kovidgoyal.net/kitty/graphics-protocol/#composing-animation-frames):
  *"By default, the entire width is used."* kitty agrees: `width = g->width ?
  g->width : img->width`.
- **`p=0`** — spec: *"add the `p` key with a number between `1` and
  `4294967295`"*, and *"Not specifying a placement id or using `p=0` … results in
  multiple placements"*. kitty treats it as match-all: `!g->placement_id ||
  ref->client_id == g->placement_id`.
- **`d=q` vs `d=p`** — spec, [deleting images](https://sw.kovidgoyal.net/kitty/graphics-protocol/#deleting-images):
  `q` is *"Delete all placements that intersect a specific cell having a specific
  z-index"*. That `p` ignores z-index is inferred from its row omitting it, and
  confirmed by `point_filter_func` having no z term. Neither is cursor-relative —
  both take the cell from `x`/`y`; `d=c` is the cursor one.
- **`O`/`S`, `z`, `a=T`** — all in the [control data reference](https://sw.kovidgoyal.net/kitty/graphics-protocol/#control-data-reference)
  key tables.

### How to test

```
cargo test --all
```

Eight tests added. Each fails on `main`; the parser ones are
struct-literal round trips in `wezterm-escape-parser/src/apc.rs`, so a reviewer
can read the expected value directly.

`kitty_zero_dimension_image_does_not_panic` asserted that `r=0,h=0` is refused,
which is what the placement fix corrects. It is now
`kitty_zero_dimension_image_is_displayed`, with a separate test covering the
placement that genuinely has nothing to draw — a source origin outside the image,
which the #6344 guard still refuses.

Known divergence, stated rather than hidden: on `t=d` kitty caps the slack at
`data_sz + 10` bytes and returns `EFBIG` beyond it, while this accepts any
over-long source and truncates. The motivating case is `t=f`/`t=t`/`t=s`, where
kitty is permissive too.
