### PR TITLE
perf(image): hash each transmitted image once

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -152,8 +152,8 @@ As features stabilize some brief notes about them will accumulate here.
   search matching. Thanks to @mrdziuban! #7385
 
 #### Fixed
-* Terminal images were hashed three times each on the transmit path; the sha256
-  an RGBA image already carries is now reused instead. #8065
+* perf: Terminal images were hashed three times each on the transmit path; the sha256
+  an RGBA image already carries is now reused instead. Thanks to @i-am-logger! #8065
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program
   that left it enabled and exited uncleanly could leave ctrl keys emitting
   escape sequences that the shell doesn't expect. RIS now also resets the

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -152,6 +152,8 @@ As features stabilize some brief notes about them will accumulate here.
   search matching. Thanks to @mrdziuban! #7385
 
 #### Fixed
+* Terminal images were hashed three times each on the transmit path; the sha256
+  an RGBA image already carries is now reused instead. #8065
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program
   that left it enabled and exited uncleanly could leave ctrl keys emitting
   escape sequences that the shell doesn't expect. RIS now also resets the

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -1,6 +1,8 @@
 //! Tests for inline image protocol handling
 
 use super::*;
+use wezterm_cell::image::ImageDataType;
+use wezterm_surface::change::ImageData;
 
 /// A tiny but valid 11x11 PNG, base64 encoded.
 /// Taken from the reproduction in <https://github.com/wezterm/wezterm/issues/6344>.
@@ -69,4 +71,50 @@ fn kitty_image_with_zero_pixel_dimensions_does_not_panic() {
     // Printing normal text and observing it confirms we recovered rather than crashing.
     term.advance_bytes(b"ok");
     assert_visible_contents(&term, file!(), line!(), &["ok", "", ""]);
+}
+
+/// A 2x2 RGBA image, base64 encoded.
+const TINY_RGBA_BASE64: &str = "AQID/wQFBv8HCAn/CgsM/w==";
+
+/// The image data attached to the first cell that carries one.
+fn first_image(term: &TestTerm) -> Arc<ImageData> {
+    for line in term.screen().visible_lines().iter() {
+        for cell in line.visible_cells() {
+            if let Some(im) = cell
+                .attrs()
+                .images()
+                .and_then(|images| images.into_iter().next())
+            {
+                return Arc::clone(im.image_data());
+            }
+        }
+    }
+    panic!("no image was attached to the screen");
+}
+
+/// An Rgba8 stores the hash of its pixels, and a kitty frame transmission edits
+/// those pixels in place, so the stored hash must be updated with them.
+#[test]
+fn kitty_frame_edit_keeps_the_stored_hash_current() {
+    let mut term = TestTerm::new(3, 10, 0);
+
+    // a=T: transmit and display, f=32: RGBA, s/v: 2x2 pixels.
+    let seq = format!("\x1b_Ga=T,t=d,f=32,s=2,v=2,i=1;{}\x1b\\", TINY_RGBA_BASE64);
+    term.advance_bytes(seq.as_bytes());
+    let transmitted = first_image(&term).data().compute_hash();
+
+    // a=f: transmit a frame, r=1: edit frame 1 in place, recolouring one pixel.
+    term.advance_bytes(b"\x1b_Ga=f,t=d,f=32,s=1,v=1,i=1,r=1,x=0,y=0;/wAA/w==\x1b\\");
+
+    let image = first_image(&term);
+    let image = image.data();
+    match &*image {
+        ImageDataType::Rgba8 { data, hash, .. } => {
+            // The edit reached the pixels, so this is not asserting on an
+            // image that was never touched.
+            assert_ne!(*hash, transmitted);
+            k9::assert_equal!(*hash, ImageDataType::hash_bytes(data));
+        }
+        other => panic!("expected Rgba8, got {:?}", other),
+    }
 }

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -102,7 +102,7 @@ fn kitty_frame_edit_keeps_the_stored_hash_current() {
     // a=T: transmit and display, f=32: RGBA, s/v: 2x2 pixels.
     let seq = format!("\x1b_Ga=T,t=d,f=32,s=2,v=2,i=1;{}\x1b\\", TINY_RGBA_BASE64);
     term.advance_bytes(seq.as_bytes());
-    let transmitted = first_image(&term).data().compute_hash();
+    let transmitted_hash = first_image(&term).data().compute_hash();
 
     // a=f: transmit a frame, r=1: edit frame 1 in place, painting the top left
     // pixel opaque red over the 0x01,0x02,0x03 it arrived with.
@@ -110,17 +110,17 @@ fn kitty_frame_edit_keeps_the_stored_hash_current() {
 
     let image = first_image(&term);
     let image = image.data();
-    let edited = image.compute_hash();
+    let edited_hash = image.compute_hash();
 
     match &*image {
         ImageDataType::Rgba8 { data, .. } => {
             // Asserted on the pixels rather than on the hash, so a blit that
             // did nothing cannot be mistaken for a hash that went stale.
             k9::assert_equal!(&data[0..4], &[0xff, 0x00, 0x00, 0xff][..]);
-            k9::assert_equal!(edited, ImageDataType::hash_bytes(data));
+            k9::assert_equal!(edited_hash, ImageDataType::hash_bytes(data));
         }
         other => panic!("expected Rgba8, got {:?}", other),
     }
 
-    assert_ne!(edited, transmitted);
+    assert_ne!(edited_hash, transmitted_hash);
 }

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -92,8 +92,9 @@ fn first_image(term: &TestTerm) -> Arc<ImageData> {
     panic!("no image was attached to the screen");
 }
 
-/// An Rgba8 stores the hash of its pixels, and a kitty frame transmission edits
-/// those pixels in place, so the stored hash must be updated with them.
+/// An Rgba8 stores the hash of its pixels and `compute_hash` reports it without
+/// recomputing, so a kitty frame transmission that edits those pixels in place
+/// must leave the stored hash describing what is now there.
 #[test]
 fn kitty_frame_edit_keeps_the_stored_hash_current() {
     let mut term = TestTerm::new(3, 10, 0);
@@ -103,18 +104,23 @@ fn kitty_frame_edit_keeps_the_stored_hash_current() {
     term.advance_bytes(seq.as_bytes());
     let transmitted = first_image(&term).data().compute_hash();
 
-    // a=f: transmit a frame, r=1: edit frame 1 in place, recolouring one pixel.
+    // a=f: transmit a frame, r=1: edit frame 1 in place, painting the top left
+    // pixel opaque red over the 0x01,0x02,0x03 it arrived with.
     term.advance_bytes(b"\x1b_Ga=f,t=d,f=32,s=1,v=1,i=1,r=1,x=0,y=0;/wAA/w==\x1b\\");
 
     let image = first_image(&term);
     let image = image.data();
+    let edited = image.compute_hash();
+
     match &*image {
-        ImageDataType::Rgba8 { data, hash, .. } => {
-            // The edit reached the pixels, so this is not asserting on an
-            // image that was never touched.
-            assert_ne!(*hash, transmitted);
-            k9::assert_equal!(*hash, ImageDataType::hash_bytes(data));
+        ImageDataType::Rgba8 { data, .. } => {
+            // Asserted on the pixels rather than on the hash, so a blit that
+            // did nothing cannot be mistaken for a hash that went stale.
+            k9::assert_equal!(&data[0..4], &[0xff, 0x00, 0x00, 0xff][..]);
+            k9::assert_equal!(edited, ImageDataType::hash_bytes(data));
         }
         other => panic!("expected Rgba8, got {:?}", other),
     }
+
+    assert_ne!(edited, transmitted);
 }

--- a/wezterm-cell/src/image.rs
+++ b/wezterm-cell/src/image.rs
@@ -216,6 +216,8 @@ pub enum ImageDataType {
         data: Vec<u8>,
         width: u32,
         height: u32,
+        /// sha256 of data, which is what compute_hash reports. Update it
+        /// whenever data changes.
         hash: [u8; 32],
     },
     /// Data is an animated sequence
@@ -304,14 +306,19 @@ impl ImageDataType {
 
     pub fn compute_hash(&self) -> [u8; 32] {
         use sha2::Digest;
-        let mut hasher = sha2::Sha256::new();
         match self {
-            ImageDataType::EncodedFile(data) => hasher.update(data),
-            ImageDataType::EncodedLease(lease) => return lease.content_id().as_hash_bytes(),
-            ImageDataType::Rgba8 { data, .. } => hasher.update(data),
+            // Both of these already hold the hash, so neither builds a hasher.
+            ImageDataType::EncodedLease(lease) => lease.content_id().as_hash_bytes(),
+            ImageDataType::Rgba8 { hash, .. } => *hash,
+            ImageDataType::EncodedFile(data) => {
+                let mut hasher = sha2::Sha256::new();
+                hasher.update(data);
+                hasher.finalize().into()
+            }
             ImageDataType::AnimRgba8 {
                 frames, durations, ..
             } => {
+                let mut hasher = sha2::Sha256::new();
                 for data in frames {
                     hasher.update(data);
                 }
@@ -320,9 +327,9 @@ impl ImageDataType {
                     let b = d.to_ne_bytes();
                     hasher.update(b);
                 }
+                hasher.finalize().into()
             }
-        };
-        hasher.finalize().into()
+        }
     }
 
     /// Divides the animation frame durations by the provided
@@ -584,5 +591,30 @@ impl ImageData {
 
     pub fn hash(&self) -> [u8; 32] {
         self.hash
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The hash stored with an Rgba8 is the hash of its data.
+    #[test]
+    fn rgba8_compute_hash_matches_its_data() {
+        let data: Vec<u8> = (0..=255u8).cycle().take(16 * 16 * 4).collect();
+        let expected = ImageDataType::hash_bytes(&data);
+
+        let img = ImageDataType::new_single_frame(16, 16, data);
+
+        assert_eq!(img.compute_hash(), expected);
+    }
+
+    /// Distinct pixels must produce distinct hashes.
+    #[test]
+    fn rgba8_compute_hash_follows_the_data() {
+        let a = ImageDataType::new_single_frame(2, 2, vec![0u8; 16]);
+        let b = ImageDataType::new_single_frame(2, 2, vec![1u8; 16]);
+
+        assert_ne!(a.compute_hash(), b.compute_hash());
     }
 }

--- a/wezterm-cell/src/image.rs
+++ b/wezterm-cell/src/image.rs
@@ -310,11 +310,7 @@ impl ImageDataType {
             // Both of these already hold the hash, so neither builds a hasher.
             ImageDataType::EncodedLease(lease) => lease.content_id().as_hash_bytes(),
             ImageDataType::Rgba8 { hash, .. } => *hash,
-            ImageDataType::EncodedFile(data) => {
-                let mut hasher = sha2::Sha256::new();
-                hasher.update(data);
-                hasher.finalize().into()
-            }
+            ImageDataType::EncodedFile(data) => ImageDataType::hash_bytes(data),
             ImageDataType::AnimRgba8 {
                 frames, durations, ..
             } => {
@@ -591,30 +587,5 @@ impl ImageData {
 
     pub fn hash(&self) -> [u8; 32] {
         self.hash
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    /// The hash stored with an Rgba8 is the hash of its data.
-    #[test]
-    fn rgba8_compute_hash_matches_its_data() {
-        let data: Vec<u8> = (0..=255u8).cycle().take(16 * 16 * 4).collect();
-        let expected = ImageDataType::hash_bytes(&data);
-
-        let img = ImageDataType::new_single_frame(16, 16, data);
-
-        assert_eq!(img.compute_hash(), expected);
-    }
-
-    /// Distinct pixels must produce distinct hashes.
-    #[test]
-    fn rgba8_compute_hash_follows_the_data() {
-        let a = ImageDataType::new_single_frame(2, 2, vec![0u8; 16]);
-        let b = ImageDataType::new_single_frame(2, 2, vec![1u8; 16]);
-
-        assert_ne!(a.compute_hash(), b.compute_hash());
     }
 }


### PR DESCRIPTION
An `Rgba8` image is hashed three times on the transmit path. `compute_hash`
recomputed the sha256 that `Rgba8` already stores — once for the cache key in
`raw_image_to_image_data` (`term/src/terminalstate/image.rs:290`), once in
`ImageData::with_data` (`wezterm-cell/src/image.rs:564`), on top of the one
`new_single_frame` computed and kept (`image.rs:271`). It now returns the stored
hash, so three passes become one.

One pass over a 13.18MiB buffer (2400x1440 RGBA) is about 22ms on an Apple
M-series; `main` does three of them per image.

The value is unchanged — what `Rgba8` stores is the same sha256 `compute_hash`
was recomputing. `wezterm-gui`'s frame cache already keyed on that stored field
(`glyphcache.rs:918`), including for images arriving over the mux, so this makes
`compute_hash` agree with what the renderer already trusted.

The other variants are untouched: `EncodedFile` still hashes on demand,
`EncodedLease` already returned its content id without hashing, and `AnimRgba8`
keeps hashing because its `compute_hash` also covers frame durations.

Same redundancy `1c9bd347` fixed in `ImageData::hash`, in a path that commit did
not reach.

### Testing

```
cargo test --all
```

One test covers the invariant this relies on: that `compute_hash()` on an
`Rgba8` still describes its pixels after a kitty `a=f` in-place frame edit.
Break the refresh and it fails; break the blit and it fails on a different
assertion, so the two can be told apart.

It cannot detect a revert to recomputing, and no test can — the stored and the
recomputed value are equal by construction. What it guards is the invariant that
makes returning the stored one safe.

*AI-disclosure: drafted by AI, manually reviewed and iterated on by me.*