### PR TITLE
Missing verb in docs/config/keyboard-concepts.md

### DIFF
--- a/docs/config/keyboard-concepts.md
+++ b/docs/config/keyboard-concepts.md
@@ -121,7 +121,7 @@ WezTerm is now able to perform dead-key expansion when `use_ime = false`.  Dead
 keys are treated as composition effects, so with the default settings of
 `send_composed_key_when_left_alt_is_pressed` and
 `send_composed_key_when_right_alt_is_pressed` above, in a US layout, `Left-Opt
-n` will produce `Alt N` and `Right-Opt n` will for a subsequent key press
+n` will produce `Alt N` and `Right-Opt n` will wait for a subsequent key press
 before generating an event; `Right-Opt n SPACE` will emit `~` whereas `Right-Opt n
 n` will emit `ñ`.
 


### PR DESCRIPTION
"will" (or something equivalent) seems to be missing from the documentation on dead keys. 