### PR TITLE
deps: bump sha2 to 0.11, which picks the sha256 backend at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,6 +1217,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csscolorparser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1349,8 +1367,18 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -2523,6 +2551,15 @@ name = "humantime"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -5430,18 +5467,18 @@ checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ serde_json = "1.0"
 serde_with = {version="3.0", features = ["chrono_0_4"]}
 serde_yaml = "0.9"
 serial2 = "0.2"
-sha2 = "0.10"
+sha2 = { version = "0.11", default-features = false, features = ["alloc"] }
 share-data = { path = "lua-api-crates/share-data" }
 shared_library = "0.1"
 shell-words = "1.1"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -290,6 +290,11 @@ As features stabilize some brief notes about them will accumulate here.
 * Fix render loop freeze when closing workspaces. Thanks to @JafarAbdi! #7444
 
 #### Updated
+* sha2 crate to 0.11, which selects its sha256 backend at runtime rather than
+  behind a crate feature. On Apple silicon and aarch64 Linux that means image
+  hashing uses the CPU's sha2 instructions, where 0.10's default build used the
+  portable one: on an M-series Mac one pass over a 13.18MiB image frame drops
+  from about 22ms to about 4ms.
 * Bundled conpty.dll and OpenConsole.exe to build 1.22.250204002.nupkg
 * Bundled harfbuzz to 11.2.1
 * Bundled libssh to 0.11.1


### PR DESCRIPTION
Suggested by @bew on #8065, which started out enabling sha2 0.10's `asm` feature
for aarch64. 0.11 needs no feature, so that commit is out of #8065 and this
replaces it.

sha2 0.10 puts its aarch64 sha256 intrinsics behind the `asm` feature —
`#[cfg(all(feature = "asm", target_arch = "aarch64"))]` — so a default build
hashes in software even on a CPU that has the instructions. 0.11 compiles the
portable and hardware backends together and picks between them with
`cpufeatures` at runtime.

One sha256 pass over a 13.18MiB buffer (2400x1440 RGBA), Apple M-series, 20
timed iterations after 3 warmups:

| | per pass |
| --- | --- |
| 0.10 | ~22ms |
| 0.11 | ~4ms |

Forcing the portable backend on 0.11 with `--cfg sha2_256_backend="soft"` gives
~20ms back, so the runtime selection is what accounts for the difference.

### Why the declaration is not just `sha2 = "0.11"`

0.11's default features are `["alloc", "oid"]`, and `oid` pulls in `const-oid`,
which 0.10 did not. Nothing here reads an OID, so `default-features = false,
features = ["alloc"]` leaves the dependency graph where it was.

One addition is unavoidable: `digest` 0.11 arrives alongside `digest` 0.10,
which `sha1` still needs by way of `zbus` — on Linux and the BSDs only.

### Scope

x86 is unaffected: it already selected SHA-NI at runtime on 0.10. `cpufeatures`
detects the aarch64 extension on Apple, Linux and Android, so aarch64 Windows
and the BSDs keep the portable backend either way.

### Testing

`cargo test --all`, unchanged — no source is touched. Verified on aarch64 macOS;
the Linux and Windows graphs are resolved with `cargo tree` rather than built,
and no CI has run on this branch yet.

- [0.10's gate](https://github.com/RustCrypto/hashes/blob/sha2-v0.10.9/sha2/src/sha256.rs)
- [0.11's runtime selection](https://github.com/RustCrypto/hashes/blob/sha2-v0.11.0/sha2/src/sha256.rs)
- [CHANGELOG 0.11.0](https://github.com/RustCrypto/hashes/blob/master/sha2/CHANGELOG.md), which lists `asm` under Removed

*AI-disclosure: drafted by AI, manually reviewed and iterated on by me.*