### PR TITLE
term: don't stack attachments when redrawing a kitty image with no id

### DIFF
--- a/term/src/terminalstate/image.rs
+++ b/term/src/terminalstate/image.rs
@@ -235,9 +235,18 @@ impl TerminalState {
                     params.placement_id,
                 ));
                 match params.style {
-                    ImageAttachStyle::Kitty => cell.attrs_mut().attach_image(img),
+                    ImageAttachStyle::Kitty => {
+                        // Anonymous images (id 0) are never scrubbed by kitty_img_place(),
+                        // so without this every re-placement stacks another attachment.
+                        // See #7400.
+                        if let Some(image_id) = params.image_id {
+                            cell.attrs_mut()
+                                .detach_image_with_placement(image_id, params.placement_id);
+                        }
+                        cell.attrs_mut().attach_image(img);
+                    }
                     ImageAttachStyle::Sixel | ImageAttachStyle::Iterm => {
-                        cell.attrs_mut().set_image(img)
+                        cell.attrs_mut().set_image(img);
                     }
                 };
 

--- a/term/src/terminalstate/kitty.rs
+++ b/term/src/terminalstate/kitty.rs
@@ -35,9 +35,9 @@ impl KittyImageState {
     }
 
     fn record_id_to_data(&mut self, image_id: u32, data: Arc<ImageData>) {
-        if image_id != 0 {
-            self.remove_data_for_id(image_id);
-        }
+        // insert() below replaces the entry for any id, including 0, so the old
+        // size must be dropped for every id or used_memory never shrinks.
+        self.remove_data_for_id(image_id);
         self.prune_unreferenced();
         self.used_memory += data.len();
         self.id_to_data.insert(image_id, data);

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -2,6 +2,123 @@
 
 use super::*;
 
+/// Minimal base64 encoder so that the tests below can synthesize kitty
+/// direct-transmission payloads without adding a dependency.
+fn base64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::new();
+    for chunk in data.chunks(3) {
+        let b = [
+            chunk[0],
+            chunk.get(1).copied().unwrap_or(0),
+            chunk.get(2).copied().unwrap_or(0),
+        ];
+        let n = ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32;
+        out.push(ALPHABET[(n >> 18) as usize & 0x3f] as char);
+        out.push(ALPHABET[(n >> 12) as usize & 0x3f] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[(n >> 6) as usize & 0x3f] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[n as usize & 0x3f] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+/// Aggregate per-cell image attachment statistics over the visible screen:
+/// (cells with images, total attachments, max attachments on a single cell,
+/// number of distinct (image_id, placement_id) pairs).
+fn image_attachment_stats(term: &mut TestTerm) -> (usize, usize, usize, usize) {
+    let screen = term.screen_mut();
+    let phys_rows = screen.physical_rows;
+    let top = screen.visible_row_to_stable_row(0);
+    let range = screen.stable_range(&(top..top + phys_rows as crate::StableRowIndex));
+    let mut cells = 0;
+    let mut total = 0;
+    let mut max = 0;
+    let mut pairs = std::collections::HashSet::new();
+    for idx in range {
+        let line = screen.line_mut(idx);
+        for cell in line.visible_cells() {
+            if let Some(images) = cell.attrs().images() {
+                cells += 1;
+                total += images.len();
+                max = max.max(images.len());
+                for im in &images {
+                    pairs.insert((im.image_id(), im.placement_id()));
+                }
+            }
+        }
+    }
+    (cells, total, max, pairs.len())
+}
+
+/// A client that sends no image id (`viu`, once per GIF frame) lands in the
+/// anonymous id 0 bucket; re-placing must replace the attachment, not stack.
+/// See <https://github.com/wezterm/wezterm/issues/7400>.
+#[test]
+fn kitty_anonymous_placement_reissue_does_not_accumulate() {
+    let mut term = TestTerm::new(6, 10, 0);
+
+    // 32x16 RGBA; at the 8x16 cell size of TestTerm we scale it to
+    // 4 columns x 2 rows via c=/r=. a=T transmits and displays in one shot
+    // with no image id at all, which is what viuer emits per frame.
+    let rgba: Vec<u8> = std::iter::repeat([0x80u8, 0x80, 0x80, 0xff])
+        .take(32 * 16)
+        .flatten()
+        .collect();
+    let payload = base64_encode(&rgba);
+
+    for _ in 0..20 {
+        term.print("\x1b[H");
+        term.print(format!(
+            "\x1b_Ga=T,t=d,f=32,q=2,s=32,v=16,c=4,r=2,C=1;{}\x1b\\",
+            payload
+        ));
+    }
+
+    let (cells, total, max, pairs) = image_attachment_stats(&mut term);
+    k9::assert_equal!(
+        (cells, total, max, pairs),
+        (8, 8, 1, 1),
+        "after any number of anonymous re-placements each covered cell holds \
+         exactly one attachment"
+    );
+}
+
+/// Guards the fix above from over-scrubbing: several distinct images may
+/// coexist under id 0, so `viu a.png; viu b.png` must leave both on screen.
+#[test]
+fn kitty_anonymous_placements_at_distinct_positions_coexist() {
+    let mut term = TestTerm::new(6, 10, 0);
+
+    let rgba: Vec<u8> = std::iter::repeat([0x80u8, 0x80, 0x80, 0xff])
+        .take(32 * 16)
+        .flatten()
+        .collect();
+    let payload = base64_encode(&rgba);
+
+    for home in ["\x1b[H", "\x1b[4;1H"] {
+        term.print(home);
+        term.print(format!(
+            "\x1b_Ga=T,t=d,f=32,q=2,s=32,v=16,c=4,r=2,C=1;{}\x1b\\",
+            payload
+        ));
+    }
+
+    let (cells, total, max, pairs) = image_attachment_stats(&mut term);
+    k9::assert_equal!(
+        (cells, total, max, pairs),
+        (16, 16, 1, 1),
+        "two anonymous images placed at different positions both remain attached"
+    );
+}
+
 /// A tiny but valid 11x11 PNG, base64 encoded.
 /// Taken from the reproduction in <https://github.com/wezterm/wezterm/issues/6344>.
 const TINY_PNG_BASE64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAsAAAALCAYAAACprHcmAAAACXBIWXMAAAGKAAABigEzlzBYAAAAOUlEQVQYlZXOwQ0AMAzCQEdi7yaT0xWAN7JuDCac2PQKYxflycOoICOKtPIuqFCg4/LzKxiz6xjyAYh9DR1sLUN1AAAAAElFTkSuQmCC";


### PR DESCRIPTION
## Problem

Fixes #7400.

A Kitty image sent with no id — no `i=` and no `I=` — lands in the anonymous id `0` bucket, which `viu` does once per GIF frame. `kitty_img_place` scrubs the previous placement only when `image_id != 0`, and `assign_image_to_cells` writes back a clone of the cell that still carries the last frame's attachment. So every covered cell gains one `ImageCell` per frame, and the renderer emits a quad per attachment.

`record_id_to_data` also skipped `remove_data_for_id` for id `0` while the `insert` below it replaces every id, so `used_memory` only ever grew.

## Fix

Detach the cell's existing attachment for the same `(image_id, placement_id)` before attaching the new one. Keying on the pair, not the id alone, keeps distinct anonymous images coexisting; images with an id are unaffected since they were already scrubbed. Plus drop the id-`0` special case in `record_id_to_data`.

## Tests

Two in `term/src/test/image.rs`: 20 anonymous re-placements must leave 1 attachment per cell (20 without the fix), and two anonymous images at different positions must both survive. 54/54 pass, fmt clean.

Peak GUI RSS on macOS/arm64, 6000 placements at a fixed position:

| build | anonymous | `i=1` control |
|---|---|---|
| `main` | 3853 MB | 112 MB |
| this branch | **113 MB** | 112 MB |

## Relationship to PR #8035

Independent bugs in the same function — PR 8035 fixes duplication that occurs when you place an "image" *over* an existing image/attachment, This PR is different by specifically fixing the replacement of an *anonymous* image.
