### PR TITLE
mux: support semantic zones for remote panes

### DIFF
--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -34,7 +34,7 @@ use termwiz::image::{ImageData, TextureCoordinate};
 use termwiz::surface::{Line, SequenceNo};
 use thiserror::Error;
 use wezterm_term::color::ColorPalette;
-use wezterm_term::{Alert, ClipboardSelection, StableRowIndex, TerminalSize};
+use wezterm_term::{Alert, ClipboardSelection, SemanticZone, StableRowIndex, TerminalSize};
 
 #[derive(Error, Debug)]
 #[error("Corrupt Response: {0}")]
@@ -441,7 +441,7 @@ macro_rules! pdu {
 /// The overall version of the codec.
 /// This must be bumped when backwards incompatible changes
 /// are made to the types and protocol.
-pub const CODEC_VERSION: usize = 45;
+pub const CODEC_VERSION: usize = 46;
 
 // Defines the Pdu enum.
 // Each struct has an explicit identifying number.
@@ -502,6 +502,8 @@ pdu! {
     GetPaneDirection: 60,
     GetPaneDirectionResponse: 61,
     AdjustPaneSize: 62,
+    GetSemanticZones: 63,
+    GetSemanticZonesResponse: 64,
 }
 
 impl Pdu {
@@ -931,6 +933,17 @@ pub struct GetPaneRenderChangesResponse {
 pub struct GetLines {
     pub pane_id: PaneId,
     pub lines: Vec<Range<StableRowIndex>>,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct GetSemanticZones {
+    pub pane_id: PaneId,
+}
+
+#[derive(Deserialize, Serialize, PartialEq, Debug, Clone)]
+pub struct GetSemanticZonesResponse {
+    pub pane_id: PaneId,
+    pub zones: Vec<SemanticZone>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,9 @@ usually the best available version.
 As features stabilize some brief notes about them will accumulate here.
 
 #### Changed
+* Semantic zones (and thus `ScrollToPrompt`, copy-mode move-by-zone,
+  selection-by-zone, and the `pane:get_semantic_zones()` Lua API) now work
+  for panes served by a remote mux domain. #2880
 * DECRQCRA is now disabled by default to prevent silent screen scraping.
   Set `enable_checksum_rectangular_area = true` to re-enable it.
   Thanks to @jquast! #7701

--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -1361,6 +1361,11 @@ impl Client {
     );
     rpc!(get_lines, GetLines, GetLinesResponse);
     rpc!(
+        get_semantic_zones,
+        GetSemanticZones,
+        GetSemanticZonesResponse
+    );
+    rpc!(
         get_dimensions,
         GetPaneRenderableDimensions,
         GetPaneRenderableDimensionsResponse

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -27,8 +27,8 @@ use url::Url;
 use wezterm_dynamic::Value;
 use wezterm_term::color::ColorPalette;
 use wezterm_term::{
-    Alert, Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, Progress, StableRowIndex,
-    TerminalConfiguration, TerminalSize,
+    Alert, Clipboard, KeyCode, KeyModifiers, Line, MouseEvent, Progress, SemanticZone,
+    StableRowIndex, TerminalConfiguration, TerminalSize,
 };
 
 pub struct ClientPane {
@@ -305,6 +305,20 @@ impl Pane for ClientPane {
 
     fn get_current_seqno(&self) -> SequenceNo {
         self.renderable.lock().get_current_seqno()
+    }
+
+    fn get_semantic_zones(&self) -> anyhow::Result<Vec<SemanticZone>> {
+        let client = Arc::clone(&self.client);
+        let remote_pane_id = self.remote_pane_id;
+        promise::spawn::block_on(async move {
+            let resp = client
+                .client
+                .get_semantic_zones(GetSemanticZones {
+                    pane_id: remote_pane_id,
+                })
+                .await?;
+            Ok(resp.zones)
+        })
     }
 
     fn get_changed_since(

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -811,6 +811,26 @@ impl SessionHandler {
                 .detach();
             }
 
+            Pdu::GetSemanticZones(GetSemanticZones { pane_id }) => {
+                spawn_into_main_thread(async move {
+                    catch(
+                        move || {
+                            let mux = Mux::get();
+                            let pane = mux
+                                .get_pane(pane_id)
+                                .ok_or_else(|| anyhow!("no such pane {}", pane_id))?;
+                            let zones = pane.get_semantic_zones()?;
+                            Ok(Pdu::GetSemanticZonesResponse(GetSemanticZonesResponse {
+                                pane_id,
+                                zones,
+                            }))
+                        },
+                        send_response,
+                    )
+                })
+                .detach();
+            }
+
             Pdu::GetImageCell(GetImageCell {
                 pane_id,
                 line_idx,
@@ -999,6 +1019,7 @@ impl SessionHandler {
             | Pdu::GetPaneDirectionResponse { .. }
             | Pdu::SearchScrollbackResponse { .. }
             | Pdu::GetLinesResponse { .. }
+            | Pdu::GetSemanticZonesResponse { .. }
             | Pdu::GetCodecVersionResponse { .. }
             | Pdu::WindowWorkspaceChanged { .. }
             | Pdu::GetTlsCredsResponse { .. }


### PR DESCRIPTION
### Summary

Fixes #2880: `ScrollToPrompt` (and other semantic-zone based features) never
worked for panes served by a remote mux domain.

The mux protocol had no way to retrieve semantic zones (OSC 133 prompt/input/
output regions) from the server. `ClientPane` fell back to the `Pane` trait
default implementation of `get_semantic_zones()`, which returns an empty
list, so the GUI's prompt-zone cache was always empty for remote panes and
`ScrollToPrompt` silently did nothing.

This PR adds semantic-zone support to the mux protocol and implements
`Pane::get_semantic_zones` for `ClientPane`, so remote panes behave like
local ones.

### What changed

- **`codec`**: Added `GetSemanticZones` / `GetSemanticZonesResponse` PDUs
  (ids 63/64) and bumped `CODEC_VERSION` from 45 to 46.
- **`wezterm-client`**: Added the `get_semantic_zones` RPC and implemented
  `Pane::get_semantic_zones` on `ClientPane`, issuing a request to the
  server and awaiting the response.
- **`wezterm-mux-server-impl`**: Added a `GetSemanticZones` handler that
  resolves the pane and replies with the zones computed by the server-side
  terminal (reusing the existing `LocalPane::get_semantic_zones`).
- **`docs/changelog.md`**: Added a changelog entry.

### What this fixes

The following now work for panes served by a remote mux domain:

- `ScrollToPrompt` (scroll to previous/next prompt, issue #2880)
- Copy-mode move-by-zone (`MoveForwardSemanticZone` / `MoveBackwardSemanticZone`)
- Selection-by-zone (`SelectTextAtMouseCursor 'SemanticZone'`)
- The Lua `pane:get_semantic_zones()` API