### PR TITLE
term: keep the cursor on its own line when a rewrap lands it in column 0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -154,6 +154,9 @@ As features stabilize some brief notes about them will accumulate here.
   `CTRL-u` to kill back to the start of the line. Thanks to @bew! #8013
 
 #### Fixed
+* Resizing the window could pull the cursor up onto the previous line when it
+  was resting at the start of an otherwise empty line, so that the next thing
+  written overwrote that line.
 * perf: Terminal images were hashed three times each on the transmit path; the sha256
   an RGBA image already carries is now reused instead. Thanks to @i-am-logger! #8065
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program

--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -149,7 +149,15 @@ impl Screen {
                 // line and it won't resize with the line correctly.
                 // Put it back on the prior line. The cursor is now
                 // technically outside of the viewport width.
-                if adjusted_cursor.0 == 0 && adjusted_cursor.1 > 0 {
+                //
+                // Only when the rewrap is what put it there. `num_lines == 0`
+                // means the cursor sits at the start of its own logical line
+                // rather than at the head of a continuation of the one above,
+                // so the row above is a different line and moving onto it
+                // would leave the next thing written on top of it. That is
+                // the common case for a cursor resting on the empty line
+                // below a shell's prompt.
+                if num_lines > 0 && adjusted_cursor.0 == 0 {
                     if physical_cols < self.physical_cols {
                         // getting smaller: preserve its original position
                         // on the prior line

--- a/term/src/test/mod.rs
+++ b/term/src/test/mod.rs
@@ -1378,3 +1378,36 @@ fn test_hyperlinks() {
         Compare::TEXT | Compare::ATTRS,
     );
 }
+
+#[test]
+fn resize_taller_and_narrower_keeps_cursor_below_the_output() {
+    // The Android window is always bigger than the 24x80 the first pane is
+    // spawned at, so the very first thing that happens to it is a resize that
+    // grows the rows and shrinks the columns. Anything already printed must
+    // stay put, and the cursor must stay on the line below it -- otherwise the
+    // next write lands on top of the shell's first prompt and erases it.
+    let mut term = TestTerm::new(24, 80, 0);
+    term.print("M1_BEFORE\r\n");
+    assert_eq!(term.cursor_pos().y, 1, "cursor starts below the output");
+
+    term.resize(TerminalSize {
+        rows: 46,
+        cols: 52,
+        pixel_width: 52 * 8,
+        pixel_height: 46 * 16,
+        dpi: 0,
+    });
+
+    let lines = term.screen().visible_lines();
+    assert_eq!(lines[0].as_str(), "M1_BEFORE", "the output survives");
+    assert_eq!(
+        term.cursor_pos().y,
+        1,
+        "the cursor is still below the output"
+    );
+
+    term.print("M2_AFTER\r\n");
+    let lines = term.screen().visible_lines();
+    assert_eq!(lines[0].as_str(), "M1_BEFORE");
+    assert_eq!(lines[1].as_str(), "M2_AFTER");
+}


### PR DESCRIPTION
`rewrap_lines` moves a cursor that ends up in column zero back onto the end of the previous row, because a cursor there has usually been carried onto a continuation of a wrapped line and would otherwise lose its association with it.

But the test for "usually" was only that the cursor is not on the topmost row, which is also true of a cursor resting at the start of its own logical line — the common case for the empty line below a shell prompt. Such a cursor gets pulled up onto the prompt, and the next thing written lands on top of it.

### Reproducing

Widening the window is enough to see it: print a line, resize the terminal, print another, and the second overwrites the first. It shows up reliably wherever a pane is spawned at one size and resized straight away.

### The fix

Test for what the special case is actually about — the rewrap having pushed the cursor onto a continuation row, which is `num_lines > 0` — rather than for the cursor merely not being on row 0.

### Tests

New test in `term/src/test/mod.rs` covering a cursor at column 0 of its own logical line across a widening resize. `cargo test -p wezterm-term`: 54 passed.

Changelog entry included.
