### PR TITLE
mux: don't echo a focus change back to the client that asked for it

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -154,6 +154,10 @@ As features stabilize some brief notes about them will accumulate here.
   `CTRL-u` to kill back to the start of the line. Thanks to @bew! #8013
 
 #### Fixed
+* mux: switching tabs in a client attached to a remote mux could bounce the
+  active tab back to where it was a moment later, because the server echoed the
+  focus change to the client that had asked for it. Over a slow link that echo
+  arrives after the user has already moved on.
 * perf: Terminal images were hashed three times each on the transmit path; the sha256
   an RGBA image already carries is now reused instead. Thanks to @i-am-logger! #8065
 * `ResetTerminal` (RIS) did not reset the `modifyOtherKeys` state. A program

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -81,7 +81,15 @@ pub enum MuxNotification {
         tab_id: TabId,
         window_id: WindowId,
     },
-    PaneFocused(PaneId),
+    PaneFocused {
+        pane_id: PaneId,
+        /// The client on whose behalf the focus was moved, if any. That
+        /// client asked for this and has already applied it to its own
+        /// view, so there is nothing to be gained by telling it again --
+        /// and a good deal to be lost, because by the time the round trip
+        /// completes the user may well have moved on somewhere else.
+        origin: Option<Arc<ClientId>>,
+    },
     TabResized(TabId),
     TabTitleChanged {
         tab_id: TabId,
@@ -508,6 +516,15 @@ impl Mux {
         if let Some(ident) = self.identity.read().as_ref() {
             self.record_focus_for_client(ident, pane_id);
         }
+    }
+
+    /// Notify subscribers that `pane_id` has gained the focus, attributing
+    /// the change to whichever client we are currently acting on behalf of.
+    /// The mux server uses that attribution to avoid echoing the change back
+    /// to the client that asked for it.
+    pub fn notify_pane_focused(&self, pane_id: PaneId) {
+        let origin = self.identity.read().clone();
+        self.notify(MuxNotification::PaneFocused { pane_id, origin });
     }
 
     pub fn resolve_focused_pane(

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -1779,11 +1779,11 @@ impl TabInner {
             (Some(prior), Some(current)) if prior.pane_id() != current.pane_id() => {
                 prior.focus_changed(false);
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                mux.notify_pane_focused(current.pane_id());
             }
             (None, Some(current)) => {
                 current.focus_changed(true);
-                mux.notify(MuxNotification::PaneFocused(current.pane_id()));
+                mux.notify_pane_focused(current.pane_id());
             }
             (Some(prior), None) => {
                 prior.focus_changed(false);

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -342,7 +342,7 @@ impl TmuxDomainState {
                     match mux.get_tab(local_tab.tab_id) {
                         Some(tab) => {
                             tab.set_active_pane(&local_pane);
-                            mux.notify(MuxNotification::PaneFocused(local_pane.pane_id()));
+                            mux.notify_pane_focused(local_pane.pane_id());
                         }
                         None => {}
                     }
@@ -567,7 +567,7 @@ impl TmuxDomainState {
                 }
 
                 match n {
-                    MuxNotification::PaneFocused(pane_id) => {
+                    MuxNotification::PaneFocused { pane_id, .. } => {
                         let tmux_pane_id = match tmux_domain
                             .inner
                             .remote_panes

--- a/wezterm-client/src/pane/clientpane.rs
+++ b/wezterm-client/src/pane/clientpane.rs
@@ -226,6 +226,17 @@ impl ClientPane {
                 // it here.
                 log::trace!("advised of remote pane focus: {pane_id}");
 
+                // Applying the notification below runs through
+                // Tab::set_active_pane -> Pane::focus_changed -> advise_focus,
+                // which would send a SetFocusedPane telling the server what it
+                // has just told us. Claim the focus up front so that
+                // advise_focus sees no change and stays quiet.
+                self.client
+                    .focused_remote_pane_id
+                    .lock()
+                    .unwrap()
+                    .replace(self.remote_pane_id);
+
                 let mux = Mux::get();
                 if let Err(err) = mux.focus_pane_and_containing_tab(self.local_pane_id) {
                     log::error!("Error reconciling remote PaneFocused notification: {err:#}");
@@ -582,6 +593,10 @@ impl Pane for ClientPane {
             focused_pane.replace(self.remote_pane_id);
             let client = Arc::clone(&self.client);
             let remote_pane_id = self.remote_pane_id;
+            // This tells the server where the focus went; it isn't a request
+            // for permission. We have already moved our own view, and the
+            // server attributes the change to us so that it doesn't come
+            // back to us as a notification.
             promise::spawn::spawn(async move {
                 client
                     .client

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -77,7 +77,7 @@ impl GuiFrontEnd {
                     })
                     .detach();
                 }
-                MuxNotification::PaneFocused(pane_id) => {
+                MuxNotification::PaneFocused { pane_id, .. } => {
                     promise::spawn::spawn_into_main_thread(async move {
                         let mux = Mux::get();
                         if let Err(err) = mux.focus_pane_and_containing_tab(pane_id) {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1301,7 +1301,7 @@ impl TermWindow {
                 MuxNotification::SaveToDownloads { .. } => {
                     // Handled by frontend
                 }
-                MuxNotification::PaneFocused(_) => {
+                MuxNotification::PaneFocused { .. } => {
                     // Also handled by clientpane
                     self.update_title_post_status();
                 }
@@ -1468,7 +1468,7 @@ impl TermWindow {
                     | Alert::SetUserVar { .. }
                     | Alert::Bell,
             }
-            | MuxNotification::PaneFocused(pane_id)
+            | MuxNotification::PaneFocused { pane_id, .. }
             | MuxNotification::PaneRemoved(pane_id)
             | MuxNotification::PaneOutput(pane_id) => {
                 // Check window validity and propagate to the window event handler

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -3,9 +3,11 @@ use anyhow::Context;
 use async_ossl::AsyncSslStream;
 use codec::{DecodedPdu, Pdu};
 use futures::FutureExt;
+use mux::client::ClientId;
 use mux::{Mux, MuxNotification};
 use smol::prelude::*;
 use smol::Async;
+use std::sync::Arc;
 use wezterm_uds::UnixStream;
 
 #[cfg(unix)]
@@ -15,6 +17,26 @@ pub trait AsRawDesc: std::os::windows::io::AsRawSocket + std::os::windows::io::A
 
 impl AsRawDesc for UnixStream {}
 impl AsRawDesc for AsyncSslStream {}
+
+/// Should a PaneFocused notification attributed to `origin` be sent to the
+/// client on the other end of this session?
+///
+/// Not if that client is the one who asked for it: it moved its own view the
+/// moment the user pressed the key and doesn't need our permission. Telling it
+/// again would be worse than redundant, because over a slow link the user has
+/// often moved on to another tab by the time the notification lands, and
+/// applying it would drag them back to where they were.
+fn should_forward_pane_focused(
+    origin: &Option<Arc<ClientId>>,
+    session_client_id: &Option<Arc<ClientId>>,
+) -> bool {
+    match (origin, session_client_id) {
+        (Some(origin), Some(session_client_id)) => origin != session_client_id,
+        // A change the mux made by itself, or a session that hasn't told us
+        // who it is yet: nobody here is responsible for it, so pass it on.
+        _ => true,
+    }
+}
 
 #[derive(Debug)]
 enum Item {
@@ -166,7 +188,10 @@ where
                     stream.flush().await.context("flushing PDU to client")?;
                 }
             }
-            Ok(Item::Notif(MuxNotification::PaneFocused(pane_id))) => {
+            Ok(Item::Notif(MuxNotification::PaneFocused { pane_id, origin })) => {
+                if !should_forward_pane_focused(&origin, &handler.client_id()) {
+                    continue;
+                }
                 Pdu::PaneFocused(codec::PaneFocused { pane_id })
                     .encode_async(&mut stream, 0)
                     .await?;
@@ -209,5 +234,42 @@ where
                 return Ok(());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A client that asks the mux to move the focus has already moved its own
+    /// view to match, so the notification that results from its request must
+    /// not be sent back to it. Everyone else still needs to hear about it.
+    #[test]
+    fn pane_focused_is_not_echoed_to_the_client_that_asked() {
+        let me = Arc::new(ClientId::new());
+        let someone_else = Arc::new(ClientId::new());
+
+        // The echo of our own request.
+        assert!(!should_forward_pane_focused(
+            &Some(me.clone()),
+            &Some(me.clone())
+        ));
+
+        // Another attached client, or a `wezterm cli activate-pane` run by
+        // some script: this is news to us and we want it.
+        assert!(should_forward_pane_focused(
+            &Some(someone_else),
+            &Some(me.clone())
+        ));
+
+        // A focus change the mux made by itself, on nobody's behalf.
+        assert!(should_forward_pane_focused(&None, &Some(me)));
+
+        // A session that hasn't identified itself yet can't be the one that
+        // asked, so it hears about everything.
+        assert!(should_forward_pane_focused(
+            &Some(Arc::new(ClientId::new())),
+            &None
+        ));
     }
 }

--- a/wezterm-mux-server-impl/src/sessionhandler.rs
+++ b/wezterm-mux-server-impl/src/sessionhandler.rs
@@ -222,6 +222,12 @@ impl SessionHandler {
         }
     }
 
+    /// The identity of the client on the other end of this session, once
+    /// they have told us who they are.
+    pub fn client_id(&self) -> Option<Arc<ClientId>> {
+        self.client_id.clone()
+    }
+
     pub(crate) fn per_pane(&mut self, pane_id: PaneId) -> Arc<Mutex<PerPane>> {
         Arc::clone(
             self.per_pane
@@ -343,7 +349,7 @@ impl SessionHandler {
                             let (_domain_id, window_id, tab_id) = mux
                                 .resolve_pane_id(pane_id)
                                 .ok_or_else(|| anyhow::anyhow!("pane {pane_id} not found"))?;
-                            {
+                            let tab_changed = {
                                 let mut window =
                                     mux.get_window_mut(window_id).ok_or_else(|| {
                                         anyhow::anyhow!("window {window_id} not found")
@@ -353,15 +359,27 @@ impl SessionHandler {
                                         "tab {tab_id} isn't really in window {window_id}!?"
                                     )
                                 })?;
+                                let changed = window.get_active_idx() != tab_idx;
                                 window.save_and_then_set_active(tab_idx);
-                            }
+                                changed
+                            };
                             let tab = mux
                                 .get_tab(tab_id)
                                 .ok_or_else(|| anyhow::anyhow!("tab {tab_id} not found"))?;
+                            let pane_changed =
+                                tab.get_active_pane().map(|p| p.pane_id()) != Some(pane_id);
                             tab.set_active_pane(&pane);
 
                             mux.record_focus_for_current_identity(pane_id);
-                            mux.notify(mux::MuxNotification::PaneFocused(pane_id));
+                            // Tab::set_active_pane has already notified if the
+                            // active pane changed, so only speak up for a plain
+                            // tab switch, and stay silent when nothing moved at
+                            // all. Either way the notification is attributed to
+                            // the requesting client, so it doesn't come back to
+                            // them.
+                            if tab_changed && !pane_changed {
+                                mux.notify_pane_focused(pane_id);
+                            }
 
                             Ok(Pdu::UnitResponse(UnitResponse {}))
                         },


### PR DESCRIPTION
A client attached to a remote mux switches tabs locally and immediately; the switch is its own to make. It tells the server so that the server can deliver focus reporting to the program in the pane, track unseen output, and answer "which pane is this client looking at" — but that is a notification, not a request for permission.

The server nevertheless sent the resulting `PaneFocused` notification to *every* session, including the one that had just asked for the change.

### Symptom

The client applies what it receives, so over a slow link the echo lands after the user has moved on and drags the active tab back to where it was. Holding down an `ActivateTabRelative` key over a `wezterm connect` session makes the selection visibly bounce around before settling. It converges on its own once both ends agree on a pane, which is why it reads as a transient glitch rather than a loop.

### The fix

Carry the originating client on `MuxNotification::PaneFocused`, stamped from the identity the mux is acting on behalf of, and have the dispatch loop skip the session it came from. Focus changes made by another client, or by `wezterm cli activate-pane`, carry a different origin — or none at all, for changes the mux makes by itself — and are delivered as before.

Two smaller things fall out of the same problem:

- The server now only notifies for a plain tab switch, since `Tab::set_active_pane` has already notified if the active pane changed, and nothing needs saying when nothing moved.
- A client applying a `PaneFocused` notification claims the focus before doing so, so the `set_active_pane` → `focus_changed` → `advise_focus` path doesn't send the server back the very change it has just described.

### Compatibility

`MuxNotification` is internal to the mux, so the wire protocol is unchanged. A new client talking to an old server simply won't see the benefit.

### Tests

The dispatch filter is factored out as `should_forward_pane_focused(origin, session_client_id)` with a unit test covering: the originating client (suppressed), another client (delivered), a mux-originated change with no origin (delivered), and a session that hasn't identified itself yet (delivered). `cargo test -p wezterm-mux-server-impl -p mux -p wezterm-client` passes; `cargo check --workspace` and `cargo fmt --all --check` are clean.

Changelog entry included.
