### PR TITLE
lint: fix mismatched_lifetime_syntaxes lint

### DIFF
--- a/lfucache/src/lib.rs
+++ b/lfucache/src/lib.rs
@@ -348,7 +348,7 @@ mod test {
         }
     }
 
-    fn frequency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<K, V>> {
+    fn frequency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<'_, K, V>> {
         let mut entries = vec![];
         for item in cache.frequency_index.iter() {
             entries.push(EntryData::new(item));
@@ -356,7 +356,7 @@ mod test {
         entries
     }
 
-    fn recency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<K, V>> {
+    fn recency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<'_, K, V>> {
         let mut entries = vec![];
         for item in cache.recency_index.iter() {
             entries.push(EntryData::new(item));

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -2279,7 +2279,7 @@ mod test {
         fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
             Ok(None)
         }
-        fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+        fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
             unimplemented!()
         }
         fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {


### PR DESCRIPTION
https://doc.rust-lang.org/beta/nightly-rustc/rustc_lint/lifetime_syntax/static.MISMATCHED_LIFETIME_SYNTAXES.html