### PR TITLE
Update Homebrew upgrade command for wezterm

### DIFF
--- a/docs/install/macos.md
+++ b/docs/install/macos.md
@@ -47,7 +47,7 @@ $ brew install --cask wezterm@nightly
 to upgrade to a newer nightly (normal `brew upgrade` will not upgrade it!):
 
 ```console
-$ brew upgrade --cask wezterm@nightly --no-quarantine --greedy-latest
+$ brew upgrade --cask wezterm@nightly --greedy-latest
 ```
 
 !!! note


### PR DESCRIPTION
Remove the '--no-quarantine' option from the brew upgrade command. It is no longer a valid option.
Closes #7522  
