### PR TITLE
Add command_palette_line_height config option

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -164,7 +164,7 @@ pub struct Config {
 
     #[dynamic(
         default = "default_one_point_oh_f64",
-        validate = "validate_command_palette_line_height"
+        validate = "validate_line_height"
     )]
     pub command_palette_line_height: f64,
 
@@ -2183,17 +2183,7 @@ fn validate_row_or_col(value: &u16) -> Result<(), String> {
 fn validate_line_height(value: &f64) -> Result<(), String> {
     if *value <= 0.0 {
         Err(format!(
-            "Illegal value {value} for line_height; it must be positive and greater than zero!"
-        ))
-    } else {
-        Ok(())
-    }
-}
-
-fn validate_command_palette_line_height(value: &f64) -> Result<(), String> {
-    if *value <= 0.0 {
-        Err(format!(
-            "Illegal value {value} for command_palette_line_height; it must be positive and greater than zero!"
+            "Illegal value {value}; it must be positive and greater than zero!"
         ))
     } else {
         Ok(())

--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -162,6 +162,12 @@ pub struct Config {
     #[dynamic(default = "default_command_palette_font_size")]
     pub command_palette_font_size: f64,
 
+    #[dynamic(
+        default = "default_one_point_oh_f64",
+        validate = "validate_command_palette_line_height"
+    )]
+    pub command_palette_line_height: f64,
+
     pub command_palette_rows: Option<usize>,
     #[dynamic(default = "default_command_palette_fg_color")]
     pub command_palette_fg_color: RgbaColor,
@@ -2178,6 +2184,16 @@ fn validate_line_height(value: &f64) -> Result<(), String> {
     if *value <= 0.0 {
         Err(format!(
             "Illegal value {value} for line_height; it must be positive and greater than zero!"
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn validate_command_palette_line_height(value: &f64) -> Result<(), String> {
+    if *value <= 0.0 {
+        Err(format!(
+            "Illegal value {value} for command_palette_line_height; it must be positive and greater than zero!"
         ))
     } else {
         Ok(())

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,8 +77,8 @@ As features stabilize some brief notes about them will accumulate here.
 #### New
 * [command_palette_line_height](config/lua/config/command_palette_line_height.md)
   option to scale the vertical spacing of rows in the command palette,
-  independently of the global [line_height](config/lua/config/line_height.md)
-  setting.
+  independently of [line_height](config/lua/config/line_height.md) which is for terminal cells only.
+  Thanks to @rafaelsteil! #8096
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -75,6 +75,10 @@ As features stabilize some brief notes about them will accumulate here.
   easier to spot the remaining candidates. Thanks to @mr-felixoid and @bew! #7752
 
 #### New
+* [command_palette_line_height](config/lua/config/command_palette_line_height.md)
+  option to scale the vertical spacing of rows in the command palette,
+  independently of the global [line_height](config/lua/config/line_height.md)
+  setting.
 * [wezterm.serde](config/lua/wezterm.serde/index.md) module for serialization
   and deserialization of JSON, TOML and YAML. Thanks to @expnn! #4969
 * `wezterm ssh` now supports agent forwarding. Thanks to @Riatre! #5345

--- a/docs/config/lua/config/command_palette_line_height.md
+++ b/docs/config/lua/config/command_palette_line_height.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - font
+  - command_palette
+---
+# `command_palette_line_height = 1.0`
+
+{{since('nightly')}}
+
+Scales the computed line height used by
+[ActivateCommandPalette](../keyassignment/ActivateCommandPalette.md).
+The default is `1.0`, which uses the font-specified metrics.
+
+If the command palette feels too vertically cramped then you can set
+`command_palette_line_height = 1.2` to increase the vertical spacing by 20%.
+Conversely, setting `command_palette_line_height = 0.9` will decrease the
+vertical spacing by 10%.
+
+This option is independent of the global
+[line_height](line_height.md) setting, which applies only to terminal cells.
+
+```lua
+config.command_palette_line_height = 1.2
+```

--- a/docs/config/lua/config/command_palette_line_height.md
+++ b/docs/config/lua/config/command_palette_line_height.md
@@ -16,9 +16,8 @@ If the command palette feels too vertically cramped then you can set
 Conversely, setting `command_palette_line_height = 0.9` will decrease the
 vertical spacing by 10%.
 
-This option is independent of the global
-[line_height](line_height.md) setting, which applies only to terminal cells.
-
 ```lua
 config.command_palette_line_height = 1.2
 ```
+
+See [line_height](line_height.md), which only applies to terminal cells.

--- a/docs/config/lua/config/command_palette_line_height.md
+++ b/docs/config/lua/config/command_palette_line_height.md
@@ -20,4 +20,4 @@ vertical spacing by 10%.
 config.command_palette_line_height = 1.2
 ```
 
-See [line_height](line_height.md), which only applies to terminal cells.
+See also [line_height](line_height.md), which only applies to terminal cells.

--- a/docs/config/lua/keyassignment/ActivateCommandPalette.md
+++ b/docs/config/lua/keyassignment/ActivateCommandPalette.md
@@ -43,6 +43,7 @@ See also:
 
  * [command_palette_font](../config/command_palette_font.md)
  * [command_palette_font_size](../config/command_palette_font_size.md)
+ * [command_palette_line_height](../config/command_palette_line_height.md)
  * [command_palette_fg_color](../config/command_palette_fg_color.md)
  * [command_palette_bg_color](../config/command_palette_bg_color.md)
  * [ui_key_cap_rendering](../config/ui_key_cap_rendering.md)

--- a/wezterm-gui/src/termwindow/palette.rs
+++ b/wezterm-gui/src/termwindow/palette.rs
@@ -258,7 +258,8 @@ impl CommandPalette {
             .fonts
             .command_palette_font()
             .expect("to resolve command palette font");
-        let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+        let metrics = RenderMetrics::with_font_metrics(&font.metrics())
+            .scale_line_height(term_window.config.command_palette_line_height);
 
         let top_bar_height = if term_window.show_tab_bar && !term_window.config.tab_bar_at_bottom {
             term_window.tab_bar_pixel_height().unwrap()
@@ -661,7 +662,8 @@ impl Modal for CommandPalette {
             .fonts
             .command_palette_font()
             .expect("to resolve char selection font");
-        let metrics = RenderMetrics::with_font_metrics(&font.metrics());
+        let metrics = RenderMetrics::with_font_metrics(&font.metrics())
+            .scale_line_height(term_window.config.command_palette_line_height);
 
         let mut max_rows_on_screen = ((term_window.dimensions.pixel_height * 8 / 10)
             / metrics.cell_size.height as usize)


### PR DESCRIPTION
## Summary
- Add `command_palette_line_height` (default `1.0`) so command palette row spacing can be scaled independently of global `line_height`.
- Apply the scale in both palette layout paths so row height and `max_rows_on_screen` stay consistent.
- Related: https://github.com/wezterm/wezterm/discussions/6615

#### Example of height `2.0`
<img width="800" alt="image" src="https://github.com/user-attachments/assets/21cc4eb3-51a1-40ce-ac83-b2d779c5f5d9" />


## Test plan
- [ ] Open the command palette with default config and confirm spacing is unchanged
- [ ] Set `config.command_palette_line_height = 1.3` and confirm taller rows
- [ ] Confirm global `line_height` does not affect the palette unless this option is set

## Disclosure of AI usage
Planning and implementation made with the help of AI. Code reviewed by me, and UI manually tested and validated.  