### PR TITLE
fonts: Improve default weights: normal→dim/bold is more visible

### DIFF
--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -201,6 +201,12 @@ impl Default for FontWeight {
 }
 
 impl FontWeight {
+    /// Amount by which `lighter()` / `bolder()` shift the weight when
+    /// synthesizing dim / bold variants. Chosen large enough that bold
+    /// is clearly distinct from regular by default.
+    /// See issue #8049 for examples.
+    const WEIGHT_STEP: u16 = 300;
+
     pub const fn from_opentype_weight(w: u16) -> Self {
         Self(w)
     }
@@ -210,15 +216,11 @@ impl FontWeight {
     }
 
     pub fn lighter(self) -> Self {
-        // -200 used initially was too subtle to distinguish any difference from e.g. normal & bold
-        // See issue #8049 for examples.
-        Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(300))
+        Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(Self::WEIGHT_STEP))
     }
 
     pub fn bolder(self) -> Self {
-        // +200 used initially was too subtle to distinguish any difference from e.g. normal & bold
-        // See issue #8049 for examples.
-        Self::from_opentype_weight(self.to_opentype_weight() + 300)
+        Self::from_opentype_weight(self.to_opentype_weight() + Self::WEIGHT_STEP)
     }
 }
 

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -210,13 +210,15 @@ impl FontWeight {
     }
 
     pub fn lighter(self) -> Self {
-        Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(200))
+        // -200 used initially was too subtle to distinguish any difference from e.g. normal & bold
+        // See issue #8049 for examples.
+        Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(300))
     }
 
     pub fn bolder(self) -> Self {
         // +200 used initially was too subtle to distinguish any difference from e.g. normal & bold
         // See issue #8049 for examples.
-        Self::from_opentype_weight(self.to_opentype_weight() + 400)
+        Self::from_opentype_weight(self.to_opentype_weight() + 300)
     }
 }
 

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -214,7 +214,8 @@ impl FontWeight {
     }
 
     pub fn bolder(self) -> Self {
-        // +200 was too subtle to distinguish from normal; see issue #8049
+        // +200 used initially was too subtle to distinguish any difference from e.g. normal & bold
+        // See issue #8049 for examples.
         Self::from_opentype_weight(self.to_opentype_weight() + 400)
     }
 }

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -213,6 +213,8 @@ impl FontWeight {
         Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(200))
     }
 
+    /// increase (+400) for the weight
+    /// +200 was too subtle to distinguish from normal; see issue #8049
     pub fn bolder(self) -> Self {
         Self::from_opentype_weight(self.to_opentype_weight() + 400)
     }

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -201,11 +201,14 @@ impl Default for FontWeight {
 }
 
 impl FontWeight {
-    /// Amount by which `lighter()` / `bolder()` shift the weight when
-    /// synthesizing dim / bold variants. Chosen large enough that bold
-    /// is clearly distinct from regular by default.
+    /// The amount by which to shift the weight when synthesizing dim font variant.
     /// See issue #8049 for examples.
-    const WEIGHT_STEP: u16 = 300;
+    const WEIGHT_STEP_LIGHTER: u16 = 300;
+    /// The amount by which to shift the weight when synthesizing bold font variant.
+    /// For 'bolder' we use a bigger step because 'regular vs bold' is usually less
+    /// obvious than 'regular vs light' (above) at the same step differences.
+    /// See issue #8049 for examples.
+    const WEIGHT_STEP_BOLDER: u16 = 400;
 
     pub const fn from_opentype_weight(w: u16) -> Self {
         Self(w)
@@ -216,11 +219,11 @@ impl FontWeight {
     }
 
     pub fn lighter(self) -> Self {
-        Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(Self::WEIGHT_STEP))
+        Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(Self::WEIGHT_STEP_LIGHTER))
     }
 
     pub fn bolder(self) -> Self {
-        Self::from_opentype_weight(self.to_opentype_weight() + Self::WEIGHT_STEP)
+        Self::from_opentype_weight(self.to_opentype_weight() + Self::WEIGHT_STEP_BOLDER)
     }
 }
 

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -214,7 +214,7 @@ impl FontWeight {
     }
 
     pub fn bolder(self) -> Self {
-        Self::from_opentype_weight(self.to_opentype_weight() + 200)
+        Self::from_opentype_weight(self.to_opentype_weight() + 400)
     }
 }
 

--- a/config/src/font.rs
+++ b/config/src/font.rs
@@ -213,9 +213,8 @@ impl FontWeight {
         Self::from_opentype_weight(self.to_opentype_weight().saturating_sub(200))
     }
 
-    /// increase (+400) for the weight
-    /// +200 was too subtle to distinguish from normal; see issue #8049
     pub fn bolder(self) -> Self {
+        // +200 was too subtle to distinguish from normal; see issue #8049
         Self::from_opentype_weight(self.to_opentype_weight() + 400)
     }
 }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -22,6 +22,8 @@ usually the best available version.
 As features stabilize some brief notes about them will accumulate here.
 
 #### Changed
+* fonts: Default dim/bold text now looks more contrasting, see #8049 for examples.
+  Thanks to @bfoersterling (testing) & @hphng for his first OSS contribution! #8097
 * DECRQCRA is now disabled by default to prevent silent screen scraping.
   Set `enable_checksum_rectangular_area = true` to re-enable it.
   Thanks to @jquast! #7701


### PR DESCRIPTION
we have a discussion why need to change at #8049 

As the title say, change the increasing bolder value from 200 to 400