### PR TITLE
chore(deps): upgrade clipboard-win to 5.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,11 +817,11 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clipboard-win"
-version = "2.2.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a093d6fed558e5fe24c3dfc85a68bb68f1c824f440d3ba5aca189e2998786b"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
- "winapi",
+ "error-code",
 ]
 
 [[package]]
@@ -1647,6 +1647,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "euclid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ chrono = {version="0.4", default-features=false, features=["clock", "unstable-lo
 clap = {version="4.0", features=["derive"]}
 clap_complete = "4.4"
 clap_complete_fig = "4.0"
-clipboard-win = "2.2"
+clipboard-win = "5.4.1"
 cocoa = "=0.25.0"
 codec = { path = "codec" }
 color-funcs = { path = "lua-api-crates/color-funcs" }

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -48,7 +48,7 @@ wezterm-font.workspace = true
 wezterm-input-types.workspace = true
 
 [target."cfg(windows)".dependencies]
-clipboard-win.workspace = true
+clipboard-win = { workspace = true, features = ["std"] }
 shared_library.workspace = true
 winapi = { workspace=true, features = [
     "dwmapi",


### PR DESCRIPTION
Drop the transitive `winapi` dependency.
Contributes to #7797 