### PR TITLE
Remove deprecated `macro_use`

### DIFF
--- a/luahelper/src/lib.rs
+++ b/luahelper/src/lib.rs
@@ -1,5 +1,3 @@
-#![macro_use]
-
 pub use mlua;
 use mlua::{IntoLua, Value as LuaValue};
 use std::cell::RefCell;

--- a/wezterm-dynamic/src/lib.rs
+++ b/wezterm-dynamic/src/lib.rs
@@ -2,7 +2,6 @@
 //! that is similar to JSON or Lua values.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), macro_use)]
 
 extern crate alloc;
 

--- a/wezterm-escape-parser/src/color.rs
+++ b/wezterm-escape-parser/src/color.rs
@@ -1,3 +1,5 @@
+#[cfg(not(feature = "std"))]
+use alloc::format;
 use num_derive::FromPrimitive;
 #[cfg(feature = "use_serde")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/wezterm-escape-parser/src/csi.rs
+++ b/wezterm-escape-parser/src/csi.rs
@@ -1,5 +1,7 @@
 use super::OneBased;
 use crate::color::{AnsiColor, ColorSpec, RgbColor, SrgbaTuple};
+#[cfg(not(feature = "std"))]
+use alloc::{format, vec};
 use bitflags::bitflags;
 use core::convert::TryInto;
 use core::fmt::{Display, Error as FmtError, Formatter};

--- a/wezterm-escape-parser/src/error.rs
+++ b/wezterm-escape-parser/src/error.rs
@@ -96,10 +96,10 @@ macro_rules! format_err {
         return $crate::error::Error::from($crate::error::StringWrap($msg.to_string()))
     };
     ($err:expr $(,)?) => {
-        return $crate::error::Error::from($crate::error::StringWrap(format!($err)))
+        return $crate::error::Error::from($crate::error::StringWrap(crate::format!($err)))
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return $crate::error::Error::from($crate::error::StringWrap(format!($fmt, $($arg)*)))
+        return $crate::error::Error::from($crate::error::StringWrap(crate::format!($fmt, $($arg)*)))
     };
 }
 
@@ -109,10 +109,10 @@ macro_rules! bail {
         return Err($crate::error::StringWrap($msg.to_string()).into())
     };
     ($err:expr $(,)?) => {
-        return Err($crate::error::StringWrap(format!($err)).into())
+        return Err($crate::error::StringWrap(crate::format!($err)).into())
     };
     ($fmt:expr, $($arg:tt)*) => {
-        return Err($crate::error::StringWrap(format!($fmt, $($arg)*)).into())
+        return Err($crate::error::StringWrap(crate::format!($fmt, $($arg)*)).into())
     };
 }
 
@@ -120,17 +120,17 @@ macro_rules! bail {
 macro_rules! ensure {
     ($cond:expr, $msg:literal $(,)?) => {
         if !$cond {
-            return Err($crate::error::StringWrap(format!($msg)).into());
+            return Err($crate::error::StringWrap(crate::format!($msg)).into());
         }
     };
     ($cond:expr, $err:expr $(,)?) => {
         if !$cond {
-            return Err($crate::error::StringWrap(format!($err)).into());
+            return Err($crate::error::StringWrap(crate::format!($err)).into());
         }
     };
     ($cond:expr, $fmt:expr, $($arg:tt)*) => {
         if !$cond {
-            return Err($crate::error::StringWrap(format!($fmt, $($arg)*)).into());
+            return Err($crate::error::StringWrap(crate::format!($fmt, $($arg)*)).into());
         }
     };
 }

--- a/wezterm-escape-parser/src/lib.rs
+++ b/wezterm-escape-parser/src/lib.rs
@@ -15,8 +15,11 @@ use core::fmt::{Display, Formatter, Result as FmtResult, Write as FmtWrite};
 use num_derive::*;
 use wezterm_color_types::LinearRgba;
 
-#[cfg_attr(not(feature = "std"), macro_use)]
 extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::format;
+#[cfg(feature = "std")]
+use std::format;
 
 mod allocate;
 use allocate::*;

--- a/wezterm-escape-parser/src/osc.rs
+++ b/wezterm-escape-parser/src/osc.rs
@@ -1,6 +1,8 @@
 use crate::color::SrgbaTuple;
 pub use crate::hyperlink::Hyperlink;
 use crate::{Result, bail, ensure, format_err};
+#[cfg(not(feature = "std"))]
+use alloc::{format, vec};
 use base64::Engine;
 use bitflags::bitflags;
 use core::fmt::{Display, Error as FmtError, Formatter, Result as FmtResult};

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -6,6 +6,8 @@ use crate::{
     Action, CSI, DeviceControlMode, EnterDeviceControlMode, Esc, OperatingSystemCommand,
     ShortDeviceControl,
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec;
 #[cfg(feature = "tmux_cc")]
 use core::borrow::BorrowMut;
 use core::cell::RefCell;

--- a/wezterm-escape-parser/src/parser/sixel.rs
+++ b/wezterm-escape-parser/src/parser/sixel.rs
@@ -1,5 +1,7 @@
 use crate::color::RgbColor;
 use crate::{Sixel, SixelData};
+#[cfg(not(feature = "std"))]
+use alloc::vec;
 
 const MAX_PARAMS: usize = 5;
 const MAX_SIXEL_SIZE: usize = 100_000_000;


### PR DESCRIPTION
Seeing deprecation warning each time building this crate was annoying:
```
warning: `#[macro_use]` attribute cannot be used on crates
 --> luahelper/src/lib.rs:1:1
  |
1 | #![macro_use]
  | ^^^^^^^^^^^^^
  |
  = help: `#[macro_use]` can be applied to extern crates and modules
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: `#[warn(unused_attributes)]` (part of `#[warn(unused)]`) on by default
```

Overall, changes aren't bad, but I'm not proud of `wezterm-escape-parser/src/error.rs` part. Although I don't see a cleaner way while avoiding duplicating the code there.