### PR TITLE
chore(cargo): remove deprecated package authors field

### DIFF
--- a/async_ossl/Cargo.toml
+++ b/async_ossl/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "async_ossl"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 resolver = "2"
 publish = false

--- a/base91/Cargo.toml
+++ b/base91/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "base91"
 version = "0.1.0"
 edition = "2018"

--- a/bintree/Cargo.toml
+++ b/bintree/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "bintree"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/codec/Cargo.toml
+++ b/codec/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "codec"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/color-types/Cargo.toml
+++ b/color-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-color-types"
 version = "0.3.0"
-authors = ["Wez Furlong"]
 edition = "2018"
 repository = "https://github.com/wezterm/wezterm"
 description = "Types for working with colors"

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "config"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/deps/cairo/Cargo.toml
+++ b/deps/cairo/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "cairo-sys-rs"
 license = "MIT"
-authors = ["The gtk-rs Project Developers"]
 homepage = "https://gtk-rs.org/"
 description = "FFI bindings to libcairo"
 version = "0.18.0"

--- a/deps/fontconfig/Cargo.toml
+++ b/deps/fontconfig/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "fontconfig"
 version = "0.1.0"
 edition = "2018"

--- a/deps/freetype/Cargo.toml
+++ b/deps/freetype/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "freetype"
 version = "0.1.0"
 edition = "2018"

--- a/deps/harfbuzz/Cargo.toml
+++ b/deps/harfbuzz/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "harfbuzz"
 version = "0.1.0"
 edition = "2018"

--- a/env-bootstrap/Cargo.toml
+++ b/env-bootstrap/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "env-bootstrap"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/filedescriptor/Cargo.toml
+++ b/filedescriptor/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "filedescriptor"
 version = "0.8.3"
-authors = ["Wez Furlong"]
 edition = "2018"
 repository = "https://github.com/wezterm/wezterm"
 description = "More ergonomic wrappers around RawFd and RawHandle"

--- a/luahelper/Cargo.toml
+++ b/luahelper/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "luahelper"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/mux/Cargo.toml
+++ b/mux/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "mux"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/promise/Cargo.toml
+++ b/promise/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "promise"
 version = "0.2.0"
 edition = "2018"

--- a/pty/Cargo.toml
+++ b/pty/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "portable-pty"
 version = "0.9.0"
-authors = ["Wez Furlong"]
 edition = "2018"
 repository = "https://github.com/wezterm/wezterm"
 description = "Cross platform pty interface"

--- a/pty/src/cmdbuilder.rs
+++ b/pty/src/cmdbuilder.rs
@@ -787,9 +787,6 @@ mod tests {
     #[test]
     fn test_env() {
         let mut cmd = CommandBuilder::new("dummy");
-        let package_authors = cmd.get_env("CARGO_PKG_AUTHORS");
-        println!("package_authors: {:?}", package_authors);
-        assert!(package_authors == Some(OsStr::new("Wez Furlong")));
 
         cmd.env("foo key", "foo value");
         cmd.env("bar key", "bar value");

--- a/rangeset/Cargo.toml
+++ b/rangeset/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "rangeset"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/ratelim/Cargo.toml
+++ b/ratelim/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "ratelim"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/strip-ansi-escapes/Cargo.toml
+++ b/strip-ansi-escapes/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "strip-ansi-escapes"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/tabout/Cargo.toml
+++ b/tabout/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tabout"
 version = "0.3.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 repository = "https://github.com/wezterm/wezterm"
 description = "Tabulate output for CLI programs"

--- a/term/Cargo.toml
+++ b/term/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "wezterm-term"
 version = "0.1.0"
 edition = "2018"

--- a/termwiz/Cargo.toml
+++ b/termwiz/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong"]
 name = "termwiz"
 version = "0.24.0"
 edition = "2018"

--- a/umask/Cargo.toml
+++ b/umask/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "umask"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/vtparse/Cargo.toml
+++ b/vtparse/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 name = "vtparse"
 version = "0.7.0"
 edition = "2018"

--- a/wezterm-cell/Cargo.toml
+++ b/wezterm-cell/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong"]
 name = "wezterm-cell"
 version = "0.1.0"
 edition = "2024"

--- a/wezterm-char-props/Cargo.toml
+++ b/wezterm-char-props/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong"]
 name = "wezterm-char-props"
 version = "0.1.3"
 edition = "2021"

--- a/wezterm-client/Cargo.toml
+++ b/wezterm-client/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-client"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/wezterm-gui-subcommands/Cargo.toml
+++ b/wezterm-gui-subcommands/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-gui-subcommands"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/wezterm-gui/Cargo.toml
+++ b/wezterm-gui/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-gui"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 build = "build.rs"
 resolver = "2"

--- a/wezterm-input-types/Cargo.toml
+++ b/wezterm-input-types/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-input-types"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2021"
 repository = "https://github.com/wezterm/wezterm"
 description = "config serialization for wezterm via dynamic json-like data values"

--- a/wezterm-mux-server-impl/Cargo.toml
+++ b/wezterm-mux-server-impl/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-mux-server-impl"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/wezterm-mux-server/Cargo.toml
+++ b/wezterm-mux-server/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-mux-server"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 resolver = "2"
 publish = false

--- a/wezterm-ssh/Cargo.toml
+++ b/wezterm-ssh/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-ssh"
 version = "0.4.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 repository = "https://github.com/wezterm/wezterm"
 description = "More convenient higher level wrapper around libssh2"

--- a/wezterm-surface/Cargo.toml
+++ b/wezterm-surface/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Wez Furlong"]
 name = "wezterm-surface"
 version = "0.1.0"
 edition = "2018"

--- a/wezterm-toast-notification/Cargo.toml
+++ b/wezterm-toast-notification/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm-toast-notification"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 build = "build.rs"
 publish = false

--- a/wezterm/Cargo.toml
+++ b/wezterm/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "wezterm"
 version = "0.1.0"
-authors = ["Wez Furlong <wez@wezfurlong.org>"]
 edition = "2018"
 publish = false
 

--- a/window/Cargo.toml
+++ b/window/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "window"
 version = "0.1.0"
-authors = ["Wez Furlong"]
 edition = "2018"
 repository = "https://github.com/wezterm/wezterm"
 description = "Cross platform window setup and render"


### PR DESCRIPTION
`package.authors` is deprecated: https://github.com/rust-lang/cargo/pull/15068