### PR TITLE
fix(macos): IME commit being lost when a key ends composition

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -2716,7 +2716,6 @@ impl WindowView {
                 let mut inner = myself.inner.borrow_mut();
                 inner.key_is_down.replace(key_is_down);
                 inner.ime_state = ImeDisposition::None;
-                inner.ime_text.clear();
             }
 
             unsafe {


### PR DESCRIPTION
Fixes #6907

With a third-party Korean IME, pressing an arrow key while a syllable is composing loses the syllable instead of committing it. Space and Return commit fine, which is why this looks like an IME bug rather than a terminal one.

## Cause

`key_common` clears `ime_text` before calling `interpretKeyEvents`, so `hasMarkedText()` answers NO for the whole keystroke, even in the middle of a composition.

When a key ends a composition, the IME calls `insertText(<syllable>)` and returns "not handled". AppKit's `-[NSTextInputContext handleTSMEvent:]` consults the client's `hasMarkedText()` before applying that text: if the client reports no composition and the key is a function key (arrows), the commit is discarded and only `doCommandBySelector(moveRight:)` is delivered. For ordinary text keys (space, Return) AppKit applies the commit regardless — which is why only arrows were broken.

## Why every third-party Korean IME hits this

Ending a composition with "commit, then let the app handle the key" is the normal IMK idiom. I checked five:

| IME | on arrow during composition |
| --- | --- |
| Gureum | `insertText(commit)`, returns not-handled |
| SokIM | `insertText(commit)` |
| NavilIME | `insertText(commit)` |
| PriType | `insertText(commit)` |
| Ongeul | `insertText(commit)` + `setMarkedText("")` |

All of them lose the character in wezterm today. The built-in macOS Korean IME is the exception only by accident: it re-sends `setMarkedText` before its commit within the same keystroke, which happens to leave `ime_text` non-empty just in time for AppKit's check.

## Why not clearing is the correct model

`ime_text` is already maintained by the callbacks themselves — `setMarkedText` sets it, `insertText` and `unmarkText` clear it — so the up-front clear is redundant. Its only real effect is to make `hasMarkedText()` report "no composition" during exactly the window in which AppKit asks, which is when the answer needs to be truthful. Removing it makes the answer honest, and AppKit then delivers the IME's commit.

kitty does the same thing: it keeps its marked-text buffer across the keystroke and snapshots the previous value rather than clearing it (`glfw/cocoa_window.m`), and does not have this bug.

## Testing

I instrumented a copy of this file's `NSTextInputClient` implementation and drove real keystrokes through the real TSM/IMKit pipeline, comparing every client callback before and after the change:

- **Korean, Gureum** — arrow now commits the syllable and then moves the cursor. Space / Return / backspace produce identical call sequences to before.
- **Korean, built-in 2-Set** — identical before and after.
- **Japanese, built-in Kotoeri** — romaji composition, space conversion and candidate updates all produce identical call sequences before and after.
- **Latin dead keys** — unaffected by code path rather than by test: those events have empty `chars` and return earlier via `translate_key_event`, before this block. `use_ime = false` skips the block entirely.

The only other behavioural difference I found: when an IME consumes a key without calling back (`ImeDisposition::None`), the preedit display is now kept rather than cleared, which matches the composition still being active.
