### PR TITLE
term: add erase_display_scrolls_into_scrollback option

### DIFF
--- a/config/src/config.rs
+++ b/config/src/config.rs
@@ -272,6 +272,14 @@ pub struct Config {
     #[dynamic(default)]
     pub enable_checksum_rectangular_area: bool,
 
+    /// Whether `CSI 2 J` (erase the whole display, as sent by eg: `clear`)
+    /// should scroll the screen contents into the scrollback instead of
+    /// erasing them in place.
+    /// Disabled by default because erasing in place is what the spec
+    /// describes and what xterm does.
+    #[dynamic(default)]
+    pub erase_display_scrolls_into_scrollback: bool,
+
     /// Specifies the width of a new window, expressed in character cells
     #[dynamic(default = "default_initial_cols", validate = "validate_row_or_col")]
     pub initial_cols: u16,

--- a/config/src/terminal.rs
+++ b/config/src/terminal.rs
@@ -86,6 +86,10 @@ impl wezterm_term::TerminalConfiguration for TermConfig {
         self.configuration().enable_checksum_rectangular_area
     }
 
+    fn erase_display_scrolls_into_scrollback(&self) -> bool {
+        self.configuration().erase_display_scrolls_into_scrollback
+    }
+
     fn enable_kitty_keyboard(&self) -> bool {
         self.configuration().enable_kitty_keyboard
     }

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,6 +77,11 @@ As features stabilize some brief notes about them will accumulate here.
   easier to spot the remaining candidates. Thanks to @mr-felixoid and @bew! #7752
 
 #### New
+* [erase_display_scrolls_into_scrollback](config/lua/config/erase_display_scrolls_into_scrollback.md)
+  option to make `CSI 2 J` (as sent by `clear -x` and the shell's `Ctrl-L`)
+  scroll the screen into the scrollback instead of erasing it in place. Off by
+  default, which leaves the spec behavior unchanged. Thanks to @dylanpulver!
+  #8105
 * [command_palette_line_height](config/lua/config/command_palette_line_height.md)
   option to scale the vertical spacing of rows in the command palette,
   independently of [line_height](config/lua/config/line_height.md) which is for terminal cells only.

--- a/docs/config/lua/config/erase_display_scrolls_into_scrollback.md
+++ b/docs/config/lua/config/erase_display_scrolls_into_scrollback.md
@@ -1,0 +1,39 @@
+---
+tags:
+  - scroll_bar
+---
+# `erase_display_scrolls_into_scrollback = false`
+
+{{since('nightly')}}
+
+`CSI 2 J` (*erase in display, all*) erases the whole screen. The spec, and
+xterm, erase it in place: the rows that were on screen are overwritten and
+nothing is added to the scrollback. `clear -x`, and the `clear-screen` binding
+that most shells put on `Ctrl-L`, send `CSI H CSI 2 J`, so by default the
+screen you just cleared is gone rather than scrolled away. (Plain `clear` also
+sends `CSI 3 J`, which erases the scrollback itself.)
+
+When this option is set to `true`, wezterm first scrolls the screen contents
+into the scrollback and then erases the screen, so scrolling up shows what was
+there before the clear.
+
+```lua
+config.erase_display_scrolls_into_scrollback = true
+```
+
+Only the rows up to the last row that holds something are scrolled, so
+clearing a mostly-empty screen doesn't push a screenful of blank rows into the
+scrollback. The option has no effect on the [alternate
+screen](../../../escape-sequences.md), which has no scrollback, and none on
+`CSI 0 J`, `CSI 1 J` or `CSI 3 J`.
+
+This is deliberately not the default: it is a departure from the specified
+behavior of the sequence, and a full-screen application that repaints with
+`CSI 2 J` instead of using the alternate screen will add a copy of each frame
+to your scrollback.
+
+If you would rather not change how the terminal interprets the sequence, you
+can get the same effect from the shell side by having `Ctrl-L` scroll the
+screen before clearing it; see
+[#2405](https://github.com/wezterm/wezterm/issues/2405) for an example that
+works in any terminal.

--- a/term/src/config.rs
+++ b/term/src/config.rs
@@ -224,6 +224,15 @@ pub trait TerminalConfiguration: Downcast + std::fmt::Debug + Send + Sync {
         false
     }
 
+    /// When true, `CSI 2 J` (erase the whole display) on the primary
+    /// screen first scrolls the screen contents into the scrollback,
+    /// rather than erasing them in place.
+    /// This is not the behavior described by the spec, so it is
+    /// disabled by default.
+    fn erase_display_scrolls_into_scrollback(&self) -> bool {
+        false
+    }
+
     fn log_unknown_escape_sequences(&self) -> bool {
         false
     }

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -2119,7 +2119,41 @@ impl TerminalState {
                 self.perform_csi_edit(Edit::EraseInLine(EraseInLine::EraseToStartOfLine));
                 0..cy
             }
-            EraseInDisplay::EraseDisplay => 0..rows,
+            EraseInDisplay::EraseDisplay => {
+                if self.config.erase_display_scrolls_into_scrollback()
+                    && !self.screen.is_alt_screen_active()
+                {
+                    // Move what is on screen into the scrollback before we
+                    // erase it. We only scroll as far as the last row that
+                    // holds something, so that clearing a mostly-empty screen
+                    // doesn't push a screenful of blank lines into the
+                    // scrollback and evict real history.
+                    let num_rows = {
+                        let screen = self.screen();
+                        let phys_range = screen.phys_range(&(0..rows));
+                        let mut num_rows = 0;
+                        screen.with_phys_lines(phys_range, |lines| {
+                            num_rows = lines
+                                .iter()
+                                .rposition(|line| !line.is_whitespace())
+                                .map_or(0, |idx| idx + 1);
+                        });
+                        num_rows
+                    };
+                    if num_rows > 0 {
+                        let bidi_mode = self.get_bidi_mode();
+                        let blank_attr = pen.clone();
+                        self.screen_mut().scroll_up(
+                            &(0..rows),
+                            num_rows,
+                            seqno,
+                            blank_attr,
+                            bidi_mode,
+                        );
+                    }
+                }
+                0..rows
+            }
             EraseInDisplay::EraseScrollback => {
                 self.screen_mut().erase_scrollback();
                 return;

--- a/term/src/test/csi.rs
+++ b/term/src/test/csi.rs
@@ -401,3 +401,135 @@ fn test_ed_erase_scrollback() {
     term.print("b");
     assert_all_contents(&term, file!(), line!(), &["111", "222", "ab"]);
 }
+
+fn ed2_scroll_term(height: usize, width: usize, scrollback: usize) -> TestTerm {
+    TestTerm::new_with_config(
+        height,
+        width,
+        TestTermConfig {
+            scrollback,
+            erase_display_scrolls_into_scrollback: true,
+        },
+    )
+}
+
+/// With erase_display_scrolls_into_scrollback enabled, `CSI 2 J` moves what
+/// was on screen into the scrollback instead of discarding it.
+#[test]
+fn erase_display_scrolls_screen_into_scrollback() {
+    let mut term = ed2_scroll_term(4, 8, 10);
+    term.print("one\r\ntwo\r\nthree\r\n");
+    term.cup(0, 0);
+    let seqno = term.current_seqno();
+    term.erase_in_display(EraseInDisplay::EraseDisplay);
+
+    assert_visible_contents(&term, file!(), line!(), &["", "", "", ""]);
+    assert_all_contents(
+        &term,
+        file!(),
+        line!(),
+        &["one", "two", "three", "", "", "", ""],
+    );
+    term.assert_cursor_pos(0, 0, Some("2J doesn't move the cursor"), Some(seqno));
+}
+
+/// Only the rows up to the last row that holds something are scrolled, so
+/// clearing a mostly-empty screen doesn't push a screenful of blank rows
+/// into the scrollback and evict real history.
+#[test]
+fn erase_display_scroll_does_not_pad_scrollback() {
+    let mut term = ed2_scroll_term(4, 8, 10);
+    term.print("hi");
+    term.erase_in_display(EraseInDisplay::EraseDisplay);
+
+    assert_all_contents(&term, file!(), line!(), &["hi", "", "", "", ""]);
+}
+
+/// Clearing a screen that holds nothing at all adds nothing to the
+/// scrollback.
+#[test]
+fn erase_display_scroll_of_empty_screen_is_a_no_op() {
+    let mut term = ed2_scroll_term(4, 8, 10);
+    term.erase_in_display(EraseInDisplay::EraseDisplay);
+
+    assert_all_contents(&term, file!(), line!(), &["", "", "", ""]);
+}
+
+/// A blank row between two rows that hold something is part of the screen
+/// layout, so it is preserved rather than skipped.
+#[test]
+fn erase_display_scroll_preserves_interior_blank_rows() {
+    let mut term = ed2_scroll_term(4, 8, 10);
+    term.print("one\r\n\r\nthree");
+    term.erase_in_display(EraseInDisplay::EraseDisplay);
+
+    assert_all_contents(
+        &term,
+        file!(),
+        line!(),
+        &["one", "", "three", "", "", "", ""],
+    );
+}
+
+/// `CSI 2 J` erases to the current background colour; scrolling first must
+/// not leave rows painted with the previous attributes.
+#[test]
+fn erase_display_scroll_still_erases_to_current_background() {
+    let mut term = ed2_scroll_term(4, 8, 10);
+    term.print("hi");
+    term.print("\x1b[41m");
+    term.erase_in_display(EraseInDisplay::EraseDisplay);
+
+    let mut cells = 0;
+    for line in term.screen().visible_lines() {
+        for cell in line.visible_cells() {
+            cells += 1;
+            k9::assert_equal!(
+                cell.attrs().background(),
+                wezterm_cell::color::ColorAttribute::PaletteIndex(1),
+                "every erased cell takes the current background"
+            );
+        }
+    }
+    k9::assert_equal!(cells, 4 * 8);
+
+    assert_all_contents(
+        &term,
+        file!(),
+        line!(),
+        &["hi", "        ", "        ", "        ", "        "],
+    );
+}
+
+/// The option only applies to `CSI 2 J`; the other erase-in-display forms
+/// are untouched.
+#[test]
+fn erase_display_scroll_does_not_apply_to_partial_erases() {
+    let mut term = ed2_scroll_term(4, 8, 10);
+    term.print("one\r\ntwo\r\nthree");
+    term.cup(0, 1);
+    term.erase_in_display(EraseInDisplay::EraseToEndOfDisplay);
+
+    assert_all_contents(
+        &term,
+        file!(),
+        line!(),
+        &["one", "        ", "        ", ""],
+    );
+}
+
+/// Regression pin: with the option left at its default, `CSI 2 J` erases in
+/// place, as the spec describes. Passes before and after this change.
+#[test]
+fn erase_display_default_erases_in_place() {
+    let mut term = TestTerm::new(4, 8, 10);
+    term.print("one\r\ntwo\r\nthree");
+    term.erase_in_display(EraseInDisplay::EraseDisplay);
+
+    assert_all_contents(
+        &term,
+        file!(),
+        line!(),
+        &["        ", "        ", "        ", ""],
+    );
+}

--- a/term/src/test/image.rs
+++ b/term/src/test/image.rs
@@ -56,7 +56,10 @@ fn kitty_image_with_zero_pixel_dimensions_does_not_panic() {
             pixel_height: 0,
             dpi: 0,
         },
-        Arc::new(TestTermConfig { scrollback: 0 }),
+        Arc::new(TestTermConfig {
+            scrollback: 0,
+            ..Default::default()
+        }),
         "WezTerm",
         "O_o",
         Box::new(Vec::new()),

--- a/term/src/test/mod.rs
+++ b/term/src/test/mod.rs
@@ -43,9 +43,10 @@ struct TestTerm {
     term: Terminal,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct TestTermConfig {
     scrollback: usize,
+    erase_display_scrolls_into_scrollback: bool,
 }
 impl TerminalConfiguration for TestTermConfig {
     fn scrollback_size(&self) -> usize {
@@ -59,10 +60,25 @@ impl TerminalConfiguration for TestTermConfig {
     fn enable_kitty_graphics(&self) -> bool {
         true
     }
+
+    fn erase_display_scrolls_into_scrollback(&self) -> bool {
+        self.erase_display_scrolls_into_scrollback
+    }
 }
 
 impl TestTerm {
     fn new(height: usize, width: usize, scrollback: usize) -> Self {
+        Self::new_with_config(
+            height,
+            width,
+            TestTermConfig {
+                scrollback,
+                ..Default::default()
+            },
+        )
+    }
+
+    fn new_with_config(height: usize, width: usize, config: TestTermConfig) -> Self {
         let _ = env_logger::Builder::new()
             .is_test(true)
             .filter_level(log::LevelFilter::Trace)
@@ -76,7 +92,7 @@ impl TestTerm {
                 pixel_height: height * 16,
                 dpi: 0,
             },
-            Arc::new(TestTermConfig { scrollback }),
+            Arc::new(config),
             "WezTerm",
             "O_o",
             Box::new(Vec::new()),


### PR DESCRIPTION
Adds an opt-in `erase_display_scrolls_into_scrollback` (default `false`). With it
set, `CSI 2 J` on the primary screen scrolls the screen into the scrollback and
then erases it, instead of erasing in place. Nothing changes for anyone who
doesn't set it, so the conformance position from #2405 still holds by default.

The scroll only covers rows up to the last row that holds something, and that is
the part worth reviewing. Scrolling all `physical_rows` unconditionally is the
obvious implementation, but then every `Ctrl-L` at an empty prompt pushes a
screenful of blanks in and evicts real history, so the option would eat the
scrollback it exists to protect. `erase_display_scroll_does_not_pad_scrollback`
and `..._of_empty_screen_is_a_no_op` both fail against that version.

The scroll happens before the existing erase rather than instead of it, so
`CSI 2 J` still paints the whole screen with the current SGR background. Doing it
as an early return leaves rows that were already blank carrying their old
attributes; `erase_display_scroll_still_erases_to_current_background` covers that.

Seven tests in `term/src/test/csi.rs`. Reverting the source fails four of them;
the other three pin behaviour this must not change (`CSI 0 J`, an already-empty
screen, and the default-off path). `cargo test --all` and `cargo fmt --all` are
clean locally.

Known limits:

- The alternate screen is skipped explicitly. It has no scrollback, so the
  outcome is the same either way and that guard is defensive rather than covered
  by a test.
- "Holds something" means text, so a row of spaces carrying only a background
  colour counts as empty and gets trimmed.
- Plain `clear` also sends `CSI 3 J`, which erases the scrollback, so this is
  visible with `clear -x` and the shell's `Ctrl-L` rather than with `clear`.

Happy to rename the option or move the trimming rule if you'd rather it matched
something else.

AI disclosure, since you ask this on PRs: the implementation, the tests, the docs
page and this description were drafted with Claude Opus 5 via Claude Code.
