### PR TITLE
termwiz: share the terminfo Database via Arc instead of deep cloning it

### DIFF
--- a/termwiz/src/caps/mod.rs
+++ b/termwiz/src/caps/mod.rs
@@ -54,9 +54,9 @@
 //! implements some heuristics (a fancy word for guessing) to compute
 //! the terminal capabilities, but also offers a `ProbeHints`
 //! that can be used by the embedding application to override those choices.
-use std::sync::Arc;
 use crate::{builder, Result};
 use std::env::var;
+use std::sync::Arc;
 use terminfo::{self, capability as cap};
 
 pub mod probed;

--- a/termwiz/src/caps/mod.rs
+++ b/termwiz/src/caps/mod.rs
@@ -54,6 +54,7 @@
 //! implements some heuristics (a fancy word for guessing) to compute
 //! the terminal capabilities, but also offers a `ProbeHints`
 //! that can be used by the embedding application to override those choices.
+use std::sync::Arc;
 use crate::{builder, Result};
 use std::env::var;
 use terminfo::{self, capability as cap};
@@ -175,7 +176,7 @@ pub struct Capabilities {
     sixel: bool,
     iterm2_image: bool,
     bce: bool,
-    terminfo_db: Option<terminfo::Database>,
+    terminfo_db: Option<Arc<terminfo::Database>>,
     bracketed_paste: bool,
     mouse_reporting: bool,
     force_terminfo_render_to_use_ansi_sgr: bool,
@@ -201,7 +202,7 @@ impl Capabilities {
     pub(crate) fn apply_builtin_terminfo(mut self) -> Self {
         let data = include_bytes!("../../data/xterm-256color");
         let db = terminfo::Database::from_buffer(data.as_ref()).unwrap();
-        self.terminfo_db = Some(db);
+        self.terminfo_db = Some(Arc::new(db));
         self.color_level = ColorLevel::TrueColor;
         self
     }
@@ -319,7 +320,7 @@ impl Capabilities {
             hyperlinks,
             iterm2_image,
             bce,
-            terminfo_db,
+            terminfo_db: terminfo_db.map(Arc::new),
             bracketed_paste,
             mouse_reporting,
             force_terminfo_render_to_use_ansi_sgr,
@@ -356,7 +357,7 @@ impl Capabilities {
 
     /// Returns a reference to the loaded terminfo, if any.
     pub fn terminfo_db(&self) -> Option<&terminfo::Database> {
-        self.terminfo_db.as_ref()
+        self.terminfo_db.as_deref()
     }
 
     /// Whether bracketed paste is supported


### PR DESCRIPTION
## Problem

`Capabilities` owns its terminfo database:

```rust
pub struct Capabilities {
    ...
    terminfo_db: Option<terminfo::Database>,
}
```

So every `Capabilities::clone()` deep copies a
`HashMap<String, terminfo::capability::Value>` holding hundreds of heap allocated keys
and values.

That would be harmless if clones were rare, but `format_as_escapes` builds a fresh
renderer on every call:

```rust
pub fn new_wezterm_terminfo_renderer() -> TerminfoRenderer {
    TerminfoRenderer::new(CAPS.clone())
}
```

and `wezterm-gui/src/tabbar.rs` calls `format_as_escapes` twice per tab, once in the
measure pass and once in the render pass, on every `update_title`. The render pass call
happens for every tab whatever the Lua handler returned, so returning a plain string from
`format-tab-title` doesn't avoid it.

With 13 panes open that's roughly 26 full database clones each time a pane title changes.

## Impact

On Windows this makes `wezterm-gui` stop responding. The main thread pins one core, the
GPU sits idle, page faults are zero, and memory stays flat while CPU climbs. Title change
notifications arrive faster than `update_title` drains them, the `SpawnQueue` grows
without bound, and the message loop never runs again. It doesn't recover, so the process
has to be killed.

Here's the main thread mid-freeze, from a local release build with debug info:

```
ntdll!RtlAllocateHeap
  alloc::string::impl$6::clone
  hashbrown::raw::impl$13::clone<tuple$<String, terminfo::capability::Value>>
  termwiz_funcs::new_wezterm_terminfo_renderer+0x9d
  termwiz_funcs::format_as_escapes+0xf1
  wezterm_gui::tabbar::TabBarState::new+0x10a6
  wezterm_gui::termwindow::TermWindow::update_title_impl+0x9fd
  wezterm_gui::termwindow::TermWindow::update_title+0x40
  wezterm_gui::termwindow::TermWindow::dispatch_notif+0x14f2
  wezterm_gui::termwindow::TermWindow::dispatch_window_event+0xe8d
  window::WindowEventSender::dispatch
  window::spawn::SpawnQueue::run
  window::os::windows::connection::impl$0::run_message_loop
```

Anything that animates a pane title several times a second drives it, and the cost scales
with pane count.

## Change

Store the database behind an `Arc` so cloning `Capabilities` is cheap. The public
`terminfo_db()` accessor still returns `Option<&terminfo::Database>` via `as_deref()`, so
no caller changes.

## Testing

- `cargo test -p termwiz --release`: 33 passed, 0 failed
- Full workspace `cargo build --release`: clean, no new warnings
- Built and exercised on Windows 10 build 26200 with rustc 1.98.0, MSVC toolchain
- I haven't built this on Linux or macOS locally. The change isn't cfg gated apart from
  `apply_builtin_terminfo`, which is already `#[cfg(windows)]`, so I'd expect CI to cover
  the rest.

## Related

This is one of three per-call costs on the same path. #8036 caches the `Config` to Lua
conversion, which is the second. #8086 describes a third, the `tabs` and `panes` userdata
sequences rebuilt on every call. Applying this change and #8036 together removed the
freeze for me; the remaining cost is Lua GC on those per-call userdata objects.
