### PR TITLE
fix: skip libpng ARM asm files under MSVC so Windows ARM64 builds

### DIFF
--- a/deps/freetype/build.rs
+++ b/deps/freetype/build.rs
@@ -77,10 +77,18 @@ fn libpng() {
     if let Ok(arch) = env::var("CARGO_CFG_TARGET_ARCH") {
         match arch.as_str() {
             "aarch64" | "arm" => {
-                cfg.file("libpng/arm/arm_init.c")
-                    .file("libpng/arm/filter_neon.S")
-                    .file("libpng/arm/filter_neon_intrinsics.c")
-                    .file("libpng/arm/palette_neon_intrinsics.c");
+                // MSVC cannot assemble the GNU-syntax filter_neon.S, and this
+                // libpng only enables NEON under __ARM_NEON__ (GCC/Clang) —
+                // under MSVC (_M_ARM64) PNG_ARM_NEON_OPT defaults to 0 and the
+                // arm/*.c files compile to empty objects anyway. Skip the whole
+                // set there; NEON filter optimizations are simply off, exactly
+                // as upstream libpng behaves when built with MSVC on ARM64.
+                if env::var("CARGO_CFG_TARGET_ENV").as_deref() != Ok("msvc") {
+                    cfg.file("libpng/arm/arm_init.c")
+                        .file("libpng/arm/filter_neon.S")
+                        .file("libpng/arm/filter_neon_intrinsics.c")
+                        .file("libpng/arm/palette_neon_intrinsics.c");
+                }
             }
             _ => {}
         }


### PR DESCRIPTION
## Problem

`cargo build` for `aarch64-pc-windows-msvc` fails in `deps/freetype`'s build script:

```
LINK : fatal error LNK1181: cannot open input file '...filter_neon.o'
error occurred in cc-rs: command did not execute successfully (status code exit code: 1181): lib.exe ...
```

`deps/freetype/build.rs` adds `libpng/arm/filter_neon.S` for every `aarch64`/`arm` target, but that file is GNU-syntax assembly — MSVC cannot assemble it, so its object is never produced and the archive step fails on the missing input.

## Fix

Skip the `libpng/arm/*` file set when `CARGO_CFG_TARGET_ENV == "msvc"`.

This matches what the vendored libpng does with itself under MSVC: its NEON gate checks `__ARM_NEON__`/`__ARM_NEON` (GCC/Clang defines), which MSVC does not define, so `PNG_ARM_NEON_OPT` already defaults to 0 there and the `arm/*.c` files would compile to empty objects anyway. NEON filter optimizations are simply off for MSVC ARM64, exactly as upstream libpng behaves for that toolchain — no behavior change on any currently-building target.

## Tested

Native `aarch64-pc-windows-msvc` build on a Snapdragon Surface Pro 11 (Windows on ARM): fails with LNK1181 before, builds and runs cleanly after (wezterm, wezterm-gui, wezterm-mux-server). `x86_64-pc-windows-msvc` cross-build from the same machine unaffected.