### PR TITLE
gui: Add ShowContextMenu action with a native Windows context menu

### DIFF
--- a/config/src/keyassignment.rs
+++ b/config/src/keyassignment.rs
@@ -591,6 +591,7 @@ pub enum KeyAssignment {
     ExtendSelectionToMouseCursor(SelectionMode),
     OpenLinkAtMouseCursor,
     ClearSelection,
+    ShowContextMenu,
     CompleteSelection(ClipboardCopyDestination),
     CompleteSelectionOrOpenLinkAtMouseCursor(ClipboardCopyDestination),
     StartWindowDrag,

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,6 +77,8 @@ As features stabilize some brief notes about them will accumulate here.
   easier to spot the remaining candidates. Thanks to @mr-felixoid and @bew! #7752
 
 #### New
+* [ShowContextMenu](config/lua/keyassignment/ShowContextMenu.md) key
+  assignment to show a Copy/Paste context menu. Currently Windows only.
 * [command_palette_line_height](config/lua/config/command_palette_line_height.md)
   option to scale the vertical spacing of rows in the command palette,
   independently of [line_height](config/lua/config/line_height.md) which is for terminal cells only.

--- a/docs/config/lua/keyassignment/ShowContextMenu.md
+++ b/docs/config/lua/keyassignment/ShowContextMenu.md
@@ -1,0 +1,28 @@
+# `ShowContextMenu`
+
+{{since('nightly')}}
+
+Pops up a context menu at the current mouse position, offering Copy and
+Paste actions for the current pane.
+
+The Copy entry is disabled when there is no selection, and the Paste
+entry is disabled when the clipboard doesn't contain text. The menu
+follows the OS light/dark appearance.
+
+Currently only the Windows backend shows a menu; the action is ignored
+on other platforms.
+
+This example shows how to bind the right mouse button to show the menu:
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+
+config.mouse_bindings = {
+  {
+    event = { Down = { streak = 1, button = 'Right' } },
+    mods = 'NONE',
+    action = act.ShowContextMenu,
+  },
+}
+```

--- a/wezterm-gui/src/commands.rs
+++ b/wezterm-gui/src/commands.rs
@@ -1785,6 +1785,14 @@ pub fn derive_command_from_key_assignment(action: &KeyAssignment) -> Option<Comm
             menubar: &[],
             icon: None,
         },
+        ShowContextMenu => CommandDef {
+            brief: "Show the context menu".into(),
+            doc: "Pop up the context menu (Copy/Paste) at the mouse position".into(),
+            keys: vec![],
+            args: &[],
+            menubar: &[],
+            icon: None,
+        },
         CompleteSelection(destination) => CommandDef {
             brief: format!("Completes selection, and copy {destination:?}").into(),
             doc: format!(
@@ -2047,6 +2055,10 @@ fn compute_default_actions() -> Vec<KeyAssignment> {
         CopyTo(ClipboardCopyDestination::PrimarySelection),
         CopyTo(ClipboardCopyDestination::Clipboard),
         PasteFrom(ClipboardPasteSource::Clipboard),
+        // Only the Windows backend implements show_context_menu, so only
+        // advertise the command there.
+        #[cfg(windows)]
+        ShowContextMenu,
         ClearScrollback(ScrollbackEraseMode::ScrollbackOnly),
         ClearScrollback(ScrollbackEraseMode::ScrollbackAndViewport),
         QuickSelect,

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -2580,6 +2580,32 @@ impl TermWindow {
         self.move_tab(tab)
     }
 
+    /// Pop up the Copy/Paste context menu for the pane.
+    fn show_context_menu(&mut self, pane: &Arc<dyn Pane>) {
+        use config::keyassignment::{ClipboardCopyDestination, ClipboardPasteSource};
+
+        let window = match self.window.as_ref() {
+            Some(window) => window.clone(),
+            None => return,
+        };
+
+        let has_selection = !self.selection_text(pane).is_empty();
+
+        let items = vec![
+            ContextMenuItem::new(
+                "Copy",
+                KeyAssignment::CopyTo(ClipboardCopyDestination::Clipboard),
+            )
+            .enabled(has_selection),
+            ContextMenuItem::new(
+                "Paste",
+                KeyAssignment::PasteFrom(ClipboardPasteSource::Clipboard),
+            ),
+        ];
+
+        window.show_context_menu(items);
+    }
+
     pub fn perform_key_assignment(
         &mut self,
         pane: &Arc<dyn Pane>,
@@ -2824,6 +2850,9 @@ impl TermWindow {
             }
             ClearSelection => {
                 self.clear_selection(pane);
+            }
+            ShowContextMenu => {
+                self.show_context_menu(pane);
             }
             StartWindowDrag => {
                 self.window_drag_position = self.current_mouse_event.clone();

--- a/window/src/lib.rs
+++ b/window/src/lib.rs
@@ -210,6 +210,148 @@ pub enum WindowEvent {
     AdviseModifiersLedStatus(Modifiers, KeyboardLedStatus),
 }
 
+/// A single entry in a context menu requested via WindowOps::show_context_menu.
+/// When the user activates an item, the backend dispatches a
+/// WindowEvent::PerformKeyAssignment carrying its action.
+#[derive(Clone, Debug)]
+pub struct ContextMenuItem {
+    /// The text shown for this item.
+    pub label: String,
+    /// The action to perform when the item is activated.
+    pub action: config::keyassignment::KeyAssignment,
+    /// Whether the item is selectable. Disabled items are shown greyed out.
+    pub enabled: bool,
+}
+
+impl ContextMenuItem {
+    /// Create an enabled menu item bound to the given action.
+    pub fn new<S: Into<String>>(label: S, action: config::keyassignment::KeyAssignment) -> Self {
+        Self {
+            label: label.into(),
+            action,
+            enabled: true,
+        }
+    }
+
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+}
+
+/// A ContextMenuItem with a command id assigned. Ids start at 1 because some
+/// native APIs return 0 to mean nothing was selected (e.g. Win32
+/// TrackPopupMenu with TPM_RETURNCMD).
+#[derive(Clone, Debug)]
+pub struct ResolvedMenuItem {
+    pub command_id: usize,
+    pub label: String,
+    pub enabled: bool,
+    pub action: config::keyassignment::KeyAssignment,
+}
+
+/// Assign 1-based command ids to menu items so a backend can render them and map
+/// a chosen id back to its action.
+pub fn resolve_context_menu(items: Vec<ContextMenuItem>) -> Vec<ResolvedMenuItem> {
+    items
+        .into_iter()
+        .enumerate()
+        .map(|(index, item)| ResolvedMenuItem {
+            command_id: index + 1,
+            label: item.label,
+            enabled: item.enabled,
+            action: item.action,
+        })
+        .collect()
+}
+
+/// Recover the action bound to command_id, as returned by a native menu.
+/// Returns None for an unknown id or a disabled entry, so a backend that
+/// forwards a raw click cannot fire a greyed-out item.
+pub fn menu_action_for_command_id(
+    entries: &[ResolvedMenuItem],
+    command_id: usize,
+) -> Option<config::keyassignment::KeyAssignment> {
+    entries
+        .iter()
+        .find(|item| item.command_id == command_id && item.enabled)
+        .map(|item| item.action.clone())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use config::keyassignment::{ClipboardCopyDestination, ClipboardPasteSource, KeyAssignment};
+
+    #[test]
+    fn assigns_one_based_command_ids() {
+        let items = vec![
+            ContextMenuItem::new(
+                "Copy",
+                KeyAssignment::CopyTo(ClipboardCopyDestination::Clipboard),
+            )
+            .enabled(false),
+            ContextMenuItem::new(
+                "Paste",
+                KeyAssignment::PasteFrom(ClipboardPasteSource::Clipboard),
+            ),
+        ];
+
+        let resolved = resolve_context_menu(items);
+        assert_eq!(resolved.len(), 2);
+
+        assert_eq!(resolved[0].command_id, 1);
+        assert_eq!(resolved[0].label, "Copy");
+        assert!(!resolved[0].enabled);
+
+        assert_eq!(resolved[1].command_id, 2);
+        assert_eq!(resolved[1].label, "Paste");
+        assert!(resolved[1].enabled);
+    }
+
+    #[test]
+    fn command_id_round_trips_to_action() {
+        let items = vec![
+            ContextMenuItem::new(
+                "Copy",
+                KeyAssignment::CopyTo(ClipboardCopyDestination::Clipboard),
+            ),
+            ContextMenuItem::new(
+                "Paste",
+                KeyAssignment::PasteFrom(ClipboardPasteSource::Clipboard),
+            ),
+        ];
+
+        let resolved = resolve_context_menu(items);
+
+        assert!(matches!(
+            menu_action_for_command_id(&resolved, 1),
+            Some(KeyAssignment::CopyTo(ClipboardCopyDestination::Clipboard))
+        ));
+        assert!(matches!(
+            menu_action_for_command_id(&resolved, 2),
+            Some(KeyAssignment::PasteFrom(ClipboardPasteSource::Clipboard))
+        ));
+        // 0 is "no selection"; there is no id 3.
+        assert!(menu_action_for_command_id(&resolved, 0).is_none());
+        assert!(menu_action_for_command_id(&resolved, 3).is_none());
+    }
+
+    #[test]
+    fn disabled_items_do_not_resolve_to_an_action() {
+        let items = vec![ContextMenuItem::new(
+            "Copy",
+            KeyAssignment::CopyTo(ClipboardCopyDestination::Clipboard),
+        )
+        .enabled(false)];
+
+        let resolved = resolve_context_menu(items);
+
+        // The id exists in the menu, but a disabled entry must never fire.
+        assert!(menu_action_for_command_id(&resolved, 1).is_none());
+    }
+}
+
 pub struct WindowEventSender {
     handler: Box<dyn FnMut(WindowEvent, &Window)>,
     window: Option<Window>,
@@ -310,6 +452,16 @@ pub trait WindowOps {
 
     /// Set some text in the clipboard
     fn set_clipboard(&self, clipboard: Clipboard, text: String);
+
+    /// Pop up a context menu at the current mouse position, built from the
+    /// supplied items. When the user picks an item, the backend dispatches a
+    /// WindowEvent::PerformKeyAssignment with that item's action.
+    ///
+    /// The default implementation only logs a warning; backends that support
+    /// a context menu override this.
+    fn show_context_menu(&self, _items: Vec<ContextMenuItem>) {
+        log::warn!("show_context_menu is not implemented by this window backend");
+    }
 
     /// Set window level. Depending on the environment and user preferences
     fn set_window_level(&self, _level: WindowLevel) {}

--- a/window/src/os/windows/window.rs
+++ b/window/src/os/windows/window.rs
@@ -2,13 +2,15 @@ use super::*;
 use crate::connection::ConnectionOps;
 use crate::parameters::{self, Parameters};
 use crate::{
-    Appearance, Clipboard, CursorIcon, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent,
-    Modifiers, MouseButtons, MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect,
-    RequestedWindowGeometry, ResolvedGeometry, ScreenPoint, ScreenRect, ULength, WindowDecorations,
-    WindowEvent, WindowEventSender, WindowOps, WindowState,
+    menu_action_for_command_id, resolve_context_menu, Appearance, Clipboard, ContextMenuItem,
+    CursorIcon, DeadKeyStatus, Dimensions, Handled, KeyCode, KeyEvent, Modifiers, MouseButtons,
+    MouseEvent, MouseEventKind, MousePress, Point, RawKeyEvent, Rect, RequestedWindowGeometry,
+    ResolvedGeometry, ScreenPoint, ScreenRect, ULength, WindowDecorations, WindowEvent,
+    WindowEventSender, WindowOps, WindowState,
 };
 use anyhow::{bail, Context};
 use async_trait::async_trait;
+use config::keyassignment::KeyAssignment;
 use config::{ConfigHandle, ImePreeditRendering, SystemBackdrop};
 use lazy_static::lazy_static;
 use promise::Future;
@@ -92,6 +94,19 @@ lazy_static! {
 
         if unsafe { GetVersionExW(&osver as *const _ as _) } == winapi::shared::minwindef::TRUE {
             osver.dwBuildNumber >= 22621
+        } else {
+            true
+        }
+    };
+    // The uxtheme dark-mode ordinals only exist from Windows 10 1809 (17763).
+    static ref IS_WIN10_1809: bool = {
+        let osver = OSVERSIONINFOW {
+            dwOSVersionInfoSize: std::mem::size_of::<OSVERSIONINFOW>() as _,
+            ..Default::default()
+        };
+
+        if unsafe { GetVersionExW(&osver as *const _ as _) } == winapi::shared::minwindef::TRUE {
+            osver.dwBuildNumber >= 17763
         } else {
             true
         }
@@ -969,6 +984,86 @@ impl WindowOps for Window {
         clipboard_win::set_clipboard_string(&text).ok();
     }
 
+    fn show_context_menu(&self, items: Vec<ContextMenuItem>) {
+        let handle = self.0;
+        let hwnd = handle.0;
+        if hwnd.is_null() {
+            return;
+        }
+
+        let entries = resolve_context_menu(items);
+
+        // TrackPopupMenu pumps a modal message loop that re-enters the window
+        // proc; defer so that the caller's borrow of the window inner state
+        // is released before any re-entrant message is dispatched.
+        promise::spawn::spawn(async move {
+            let mut point = POINT { x: 0, y: 0 };
+            if unsafe { GetCursorPos(&mut point) } == 0 {
+                return;
+            }
+
+            sync_menu_theme_with_os();
+
+            let hmenu = unsafe { CreatePopupMenu() };
+            if hmenu.is_null() {
+                return;
+            }
+
+            // A paste action is only useful when the clipboard holds text; grey
+            // it out otherwise.
+            let clipboard_has_text = unsafe { IsClipboardFormatAvailable(CF_UNICODETEXT) } != 0;
+
+            for item in &entries {
+                let mut enabled = item.enabled;
+                if matches!(item.action, KeyAssignment::PasteFrom(_)) {
+                    enabled = enabled && clipboard_has_text;
+                }
+
+                let mut flags = MF_STRING;
+                if !enabled {
+                    flags |= MF_GRAYED;
+                }
+                let wide = wide_string(&item.label);
+                unsafe { AppendMenuW(hmenu, flags, item.command_id, wide.as_ptr()) };
+            }
+
+            // Unless the owning window is the foreground window, the menu
+            // won't close when the user clicks outside of it.
+            unsafe { SetForegroundWindow(hwnd) };
+
+            let chosen = unsafe {
+                TrackPopupMenu(
+                    hmenu,
+                    TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_LEFTALIGN | TPM_TOPALIGN,
+                    point.x,
+                    point.y,
+                    0,
+                    hwnd,
+                    null(),
+                )
+            };
+
+            unsafe {
+                // Without a message posted here, the next menu shown can
+                // dismiss itself immediately.
+                PostMessageW(hwnd, WM_NULL, 0, 0);
+                DestroyMenu(hmenu);
+            }
+
+            if chosen > 0 {
+                if let Some(action) = menu_action_for_command_id(&entries, chosen as usize) {
+                    Connection::with_window_inner(handle, move |inner| {
+                        inner
+                            .events
+                            .dispatch(WindowEvent::PerformKeyAssignment(action));
+                        Ok(())
+                    });
+                }
+            }
+        })
+        .detach();
+    }
+
     fn set_window_drag_position(&self, coords: ScreenPoint) {
         Connection::with_window_inner(self.0, move |inner| {
             inner.window_drag_position = Some(coords);
@@ -1336,6 +1431,36 @@ fn enable_blur_behind(hwnd: HWND) {
         DwmEnableBlurBehindWindow(hwnd, &bb);
 
         DeleteObject(region as _);
+    }
+}
+
+/// Make popup menus follow the OS light/dark theme, using the undocumented
+/// uxtheme dark-mode ordinals available from Windows 10 1809.
+fn sync_menu_theme_with_os() {
+    use winapi::um::libloaderapi::{GetModuleHandleW, GetProcAddress};
+
+    if !*IS_WIN10_1809 {
+        return;
+    }
+
+    unsafe {
+        let uxtheme = GetModuleHandleW(wide_string("uxtheme.dll").as_ptr());
+        if uxtheme.is_null() {
+            return;
+        }
+        // 135 is SetPreferredAppMode (1903+) / AllowDarkModeForApp (1809+);
+        // an argument of 1 selects AllowDark under either signature.
+        let set_app_mode: Option<extern "system" fn(i32) -> i32> =
+            std::mem::transmute(GetProcAddress(uxtheme, 135 as _));
+        if let Some(set_app_mode) = set_app_mode {
+            set_app_mode(1);
+        }
+        // 136 is FlushMenuThemes.
+        let flush_menu_themes: Option<extern "system" fn()> =
+            std::mem::transmute(GetProcAddress(uxtheme, 136 as _));
+        if let Some(flush_menu_themes) = flush_menu_themes {
+            flush_menu_themes();
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds a platform-neutral framework and a Windows implementation of the right-click native OS context menu.

The framework is a new `ShowContextMenu` key assignment and a `show_context_menu` method on `WindowOps`. `wezterm-gui` handles the assignment by building a list of menu items and passing it to the window. Currently the list includes Copy and Paste. Copy action is disabled when nothing is selected. A menu item is linked to a label with a `KeyAssignment`. Picking an item dispatches `WindowEvent::PerformKeyAssignment`, so an item can trigger anything a key binding could trigger. This part is unit tested. 

The Windows implementation adds a native Win32 popup menu. It uses the OS' light/dark mode and disables Paste when the clipboard has no text.

On a backend that does not implement `show_context_menu` the action just logs a warning and is not listed in the command palette.

Related issues: #1485, #1352.