### PR TITLE
tmuxcc: fix attach crash, send-keys, spawn, and kill-pane

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -160,6 +160,21 @@ As features stabilize some brief notes about them will accumulate here.
   `CTRL-u` to kill back to the start of the line. Thanks to @bew! #8013
 
 #### Fixed
+* `tmux -CC`: entering control mode no longer panics with
+  `local task polled by a thread that didn't spawn it`. DCS `1000p`
+  domain setup, `TmuxEvents`, and detach now run on the mux/main thread.
+  Thanks to @MisterTea! #3223 #6133 #336
+* `tmux -CC`: `TmuxPty`/`TmuxPtyWriter` now return the number of bytes
+  queued for `send-keys` instead of `Ok(0)`, so keyboard and paste input
+  actually reach the pane. Empty writes are not queued. Thanks to
+  @MisterTea! #8003
+* `tmux -CC`: closing a pane now sends `kill-pane` instead of failing with
+  "kill not implemented". Thanks to @MisterTea!
+* `tmux -CC`: spawning a tab now waits for tmux `WindowAdd` and returns the
+  new tab instead of immediately erroring. Thanks to @MisterTea!
+* `tmux -CC`: attach no longer aborts when `#{history_limit}` is missing or
+  empty, or when `list-commands` fails; already-attached windows are not
+  duplicated. Thanks to @MisterTea!
 * macOS: Fix window border when opacity<1 and shadow enabled.
   Thanks to @Adams-Galaxy! #8038 #5158
 * perf: Terminal images were hashed three times each on the transmit path; the sha256

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -82,6 +82,10 @@ pub enum MuxNotification {
         window_id: WindowId,
     },
     PaneFocused(PaneId),
+    TmuxCommandPrompt {
+        pane_id: PaneId,
+        domain_id: DomainId,
+    },
     TabResized(TabId),
     TabTitleChanged {
         tab_id: TabId,
@@ -159,6 +163,19 @@ fn parse_buffered_data(pane: Weak<dyn Pane>, dead: &Arc<AtomicBool>, mut rx: Fil
                 break;
             }
             Ok(size) => {
+                let force_tmux_exit = pane
+                    .upgrade()
+                    .map(|pane| pane.take_tmux_force_exit_requested())
+                    .unwrap_or(false);
+                let expect_tmux_exit = pane
+                    .upgrade()
+                    .map(|pane| pane.take_tmux_exit_requested())
+                    .unwrap_or(false);
+                if force_tmux_exit {
+                    parser.force_tmux_exit();
+                } else if expect_tmux_exit {
+                    parser.expect_tmux_exit();
+                }
                 parser.parse(&buf[0..size], |action| {
                     let mut flush = false;
                     match &action {

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -874,25 +874,28 @@ impl wezterm_term::DeviceControlHandler for LocalPaneDCSHandler {
                 {
                     log::info!("tmux -CC mode requested");
 
-                    // Create a new domain to host these tmux tabs
-                    let domain = TmuxDomain::new(self.pane_id);
+                    // Create the domain on this thread so subsequent TmuxEvents
+                    // can be queued, then attach it on the main/mux thread.
+                    let pane_id = self.pane_id;
+                    let domain = TmuxDomain::new(pane_id);
                     let tmux_domain = Arc::clone(&domain.inner);
+                    self.tmux_domain.replace(Arc::clone(&tmux_domain));
+                    promise::spawn::spawn_into_main_thread(async move {
+                        let domain: Arc<dyn Domain> = Arc::new(domain);
+                        let mux = Mux::get();
+                        mux.add_domain(&domain);
 
-                    let domain: Arc<dyn Domain> = Arc::new(domain);
-                    let mux = Mux::get();
-                    mux.add_domain(&domain);
-
-                    if let Some(pane) = mux.get_pane(self.pane_id) {
-                        let pane = pane.downcast_ref::<LocalPane>().unwrap();
-                        pane.tmux_domain.lock().replace(Arc::clone(&tmux_domain));
-
-                        emit_output_for_pane(
-                            self.pane_id,
-                            "\r\n[This pane is running tmux control mode. Press q to detach]",
-                        );
-                    }
-
-                    self.tmux_domain.replace(tmux_domain);
+                        if let Some(pane) = mux.get_pane(pane_id) {
+                            if let Some(pane) = pane.downcast_ref::<LocalPane>() {
+                                pane.tmux_domain.lock().replace(Arc::clone(&tmux_domain));
+                            }
+                            emit_output_for_pane(
+                                pane_id,
+                                "\r\n[This pane is running tmux control mode. Press q to detach]",
+                            );
+                        }
+                    })
+                    .detach();
 
                 // TODO: do we need to proactively list available tabs here?
                 // if so we should arrange to call domain.attach() and make
@@ -903,12 +906,17 @@ impl wezterm_term::DeviceControlHandler for LocalPaneDCSHandler {
             }
             DeviceControlMode::Exit => {
                 if let Some(tmux) = self.tmux_domain.take() {
-                    let mux = Mux::get();
-                    if let Some(pane) = mux.get_pane(self.pane_id) {
-                        let pane = pane.downcast_ref::<LocalPane>().unwrap();
-                        pane.tmux_domain.lock().take();
-                    }
-                    mux.domain_was_detached(tmux.domain_id);
+                    let pane_id = self.pane_id;
+                    promise::spawn::spawn_into_main_thread(async move {
+                        let mux = Mux::get();
+                        if let Some(pane) = mux.get_pane(pane_id) {
+                            if let Some(pane) = pane.downcast_ref::<LocalPane>() {
+                                pane.tmux_domain.lock().take();
+                            }
+                        }
+                        mux.domain_was_detached(tmux.domain_id);
+                    })
+                    .detach();
                 }
             }
             DeviceControlMode::Data(c) => {
@@ -921,8 +929,11 @@ impl wezterm_term::DeviceControlHandler for LocalPaneDCSHandler {
                 }
             }
             DeviceControlMode::TmuxEvents(events) => {
-                if let Some(tmux) = self.tmux_domain.as_ref() {
-                    tmux.advance(events);
+                if let Some(tmux) = self.tmux_domain.clone() {
+                    promise::spawn::spawn_into_main_thread(async move {
+                        tmux.advance(events);
+                    })
+                    .detach();
                 } else {
                     log::warn!("unhandled DeviceControlMode::TmuxEvents {:?}", &events);
                 }

--- a/mux/src/localpane.rs
+++ b/mux/src/localpane.rs
@@ -21,6 +21,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::convert::TryInto;
 use std::io::{Result as IoResult, Write};
 use std::ops::Range;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use termwiz::escape::csi::{Sgr, CSI};
@@ -129,6 +130,8 @@ pub struct LocalPane {
     writer: Mutex<Box<dyn Write + Send>>,
     domain_id: DomainId,
     tmux_domain: Mutex<Option<Arc<TmuxDomainState>>>,
+    tmux_exit_requested: AtomicBool,
+    tmux_force_exit_requested: AtomicBool,
     proc_list: Mutex<Option<CachedProcInfo>>,
     #[cfg(unix)]
     leader: Arc<Mutex<Option<CachedLeaderInfo>>>,
@@ -398,10 +401,42 @@ impl Pane for LocalPane {
 
     fn key_down(&self, key: KeyCode, mods: KeyModifiers) -> Result<(), Error> {
         Mux::get().record_input_for_current_identity();
-        if self.tmux_domain.lock().is_some() {
+        let tmux_domain = self.tmux_domain.lock().clone();
+        if let Some(tmux) = tmux_domain {
             log::trace!("key: {:?}", key);
-            if key == KeyCode::Char('q') {
-                self.terminal.lock().send_paste("detach\n")?;
+            match key {
+                KeyCode::Escape => {
+                    self.tmux_exit_requested.store(true, Ordering::SeqCst);
+                    tmux.detach_client()?;
+                }
+                KeyCode::Char('X') | KeyCode::Char('x') => {
+                    self.tmux_force_exit_requested.store(true, Ordering::SeqCst);
+                    self.tmux_domain.lock().take();
+                    tmux.force_quit();
+                    #[cfg(unix)]
+                    {
+                        let foreground = self
+                            .divine_process_list(CachePolicy::FetchImmediate)
+                            .map(|processes| processes.foreground.pid);
+                        if let Some(foreground) = foreground {
+                            // This is the emergency path: kill only the
+                            // youngest foreground control client.  Its parent
+                            // gateway shell and tmux server remain alive.
+                            unsafe {
+                                libc::kill(foreground as i32, libc::SIGKILL);
+                            }
+                        }
+                    }
+                    #[cfg(not(unix))]
+                    self.writer.lock().write_all(&[3])?;
+                }
+                KeyCode::Char('L') | KeyCode::Char('l') => {
+                    tmux.toggle_protocol_logging();
+                }
+                KeyCode::Char('C') | KeyCode::Char('c') => {
+                    tmux.request_command_prompt();
+                }
+                _ => {}
             }
             return Ok(());
         } else {
@@ -412,6 +447,14 @@ impl Pane for LocalPane {
     fn key_up(&self, key: KeyCode, mods: KeyModifiers) -> Result<(), Error> {
         Mux::get().record_input_for_current_identity();
         self.terminal.lock().key_up(key, mods)
+    }
+
+    fn take_tmux_exit_requested(&self) -> bool {
+        self.tmux_exit_requested.swap(false, Ordering::SeqCst)
+    }
+
+    fn take_tmux_force_exit_requested(&self) -> bool {
+        self.tmux_force_exit_requested.swap(false, Ordering::SeqCst)
     }
 
     fn resize(&self, size: TerminalSize) -> Result<(), Error> {
@@ -846,6 +889,7 @@ impl Pane for LocalPane {
 struct LocalPaneDCSHandler {
     pane_id: PaneId,
     tmux_domain: Option<Arc<TmuxDomainState>>,
+    tmux_raw_line: Vec<u8>,
 }
 
 pub(crate) fn emit_output_for_pane(pane_id: PaneId, message: &str) {
@@ -891,7 +935,15 @@ impl wezterm_term::DeviceControlHandler for LocalPaneDCSHandler {
                             }
                             emit_output_for_pane(
                                 pane_id,
-                                "\r\n[This pane is running tmux control mode. Press q to detach]",
+                                concat!(
+                                    "\r\n** tmux mode started **\r\n\r\n",
+                                    "Command Menu\r\n",
+                                    "----------------------------\r\n",
+                                    "esc    Detach cleanly.\r\n",
+                                    "  X    Force-quit tmux mode.\r\n",
+                                    "  L    Toggle logging.\r\n",
+                                    "  C    Run tmux command.\r\n",
+                                ),
                             );
                         }
                     })
@@ -920,7 +972,14 @@ impl wezterm_term::DeviceControlHandler for LocalPaneDCSHandler {
                 }
             }
             DeviceControlMode::Data(c) => {
-                if configuration().log_unknown_escape_sequences {
+                if let Some(tmux) = self.tmux_domain.as_ref() {
+                    self.tmux_raw_line.push(c);
+                    if c == b'\n' {
+                        let line = String::from_utf8_lossy(&self.tmux_raw_line);
+                        tmux.log_protocol_line("<", &line);
+                        self.tmux_raw_line.clear();
+                    }
+                } else if configuration().log_unknown_escape_sequences {
                     log::warn!(
                         "unhandled DeviceControlMode::Data {:x} {}",
                         c,
@@ -1028,6 +1087,7 @@ impl LocalPane {
         terminal.set_device_control_handler(Box::new(LocalPaneDCSHandler {
             pane_id,
             tmux_domain: None,
+            tmux_raw_line: vec![],
         }));
         terminal.set_notification_handler(Box::new(LocalPaneNotifHandler { pane_id }));
 
@@ -1044,6 +1104,8 @@ impl LocalPane {
             writer: Mutex::new(writer),
             domain_id,
             tmux_domain: Mutex::new(None),
+            tmux_exit_requested: AtomicBool::new(false),
+            tmux_force_exit_requested: AtomicBool::new(false),
             proc_list: Mutex::new(None),
             #[cfg(unix)]
             leader: Arc::new(Mutex::new(None)),
@@ -1165,6 +1227,12 @@ impl LocalPane {
 
 impl Drop for LocalPane {
     fn drop(&mut self) {
+        if self.pty.lock().is::<crate::tmux_pty::TmuxPty>() {
+            // A tmux pane is a local mirror of a remote process. Dropping a
+            // transient mirror during window synchronization must not kill
+            // the remote pane; explicit Pane::kill still does so.
+            return;
+        }
         // Avoid lingering zombies if we can, but don't block forever.
         // <https://github.com/wezterm/wezterm/issues/558>
         if let ProcessState::Running { signaller, .. } = &mut *self.process.lock() {

--- a/mux/src/pane.rs
+++ b/mux/src/pane.rs
@@ -253,6 +253,12 @@ pub trait Pane: Downcast + Send + Sync {
     fn set_zoomed(&self, _zoomed: bool) {}
     fn key_down(&self, key: KeyCode, mods: KeyModifiers) -> anyhow::Result<()>;
     fn key_up(&self, key: KeyCode, mods: KeyModifiers) -> anyhow::Result<()>;
+    fn take_tmux_exit_requested(&self) -> bool {
+        false
+    }
+    fn take_tmux_force_exit_requested(&self) -> bool {
+        false
+    }
     fn perform_assignment(&self, _assignment: &KeyAssignment) -> PerformAssignmentResult {
         PerformAssignmentResult::Unhandled
     }

--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -1,18 +1,18 @@
-use crate::activity::Activity;
 use crate::domain::{alloc_domain_id, Domain, DomainId, DomainState, SplitSource};
 use crate::pane::{Pane, PaneId};
 use crate::tab::{SplitRequest, Tab, TabId};
 use crate::tmux_commands::{
-    ListAllPanes, ListAllWindows, ListCommands, NewWindow, SplitPane, TmuxCommand,
+    ListAllPanes, ListAllWindows, ListCommands, NewWindow, RawTmuxCommand, SplitPane, TmuxCommand,
 };
 use crate::window::WindowId;
-use crate::{Mux, MuxWindowBuilder};
+use crate::{Mux, MuxNotification, MuxWindowBuilder};
 use async_trait::async_trait;
 use filedescriptor::FileDescriptor;
 use parking_lot::{Condvar, Mutex};
 use portable_pty::CommandBuilder;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use termwiz::tmux_cc::*;
 use wezterm_term::TerminalSize;
@@ -72,6 +72,10 @@ pub(crate) struct TmuxDomainState {
     pub gui_tabs: Mutex<HashMap<TmuxWindowId, TmuxTab>>,
     pub remote_panes: Mutex<HashMap<TmuxPaneId, RefTmuxRemotePane>>,
     pub tmux_session: Mutex<Option<TmuxSessionId>>,
+    pub active_window: Mutex<Option<TmuxWindowId>>,
+    pub activating_window: Mutex<Option<TmuxWindowId>>,
+    protocol_logging: AtomicBool,
+    force_quit: AtomicBool,
     pub support_commands: Mutex<HashMap<String, String>>,
     pub attach_state: Mutex<AttachState>,
     pending_splits: Mutex<VecDeque<promise::Promise<TmuxPaneId>>>,
@@ -83,8 +87,83 @@ pub struct TmuxDomain {
     pub(crate) inner: Arc<TmuxDomainState>,
 }
 
+impl TmuxDomain {
+    pub fn enqueue_user_command(&self, command: String) {
+        self.inner.enqueue_user_command(command);
+    }
+}
+
 impl TmuxDomainState {
+    pub fn detach_client(&self) -> anyhow::Result<()> {
+        let pane = Mux::get()
+            .get_pane(self.pane_id)
+            .ok_or_else(|| anyhow::anyhow!("tmux gateway pane {} was removed", self.pane_id))?;
+        pane.writer().write_all(b"detach-client\n")?;
+        Ok(())
+    }
+
+    pub fn force_quit(&self) {
+        if self.force_quit.swap(true, Ordering::SeqCst) {
+            return;
+        }
+
+        self.cmd_queue.lock().clear();
+        *self.state.lock() = State::Exit;
+        for pane in self.remote_panes.lock().values() {
+            let pane = pane.lock();
+            let (lock, condvar) = &*pane.active_lock;
+            *lock.lock() = true;
+            condvar.notify_all();
+        }
+
+        Mux::get().domain_was_detached(self.domain_id);
+    }
+
+    pub fn toggle_protocol_logging(&self) -> bool {
+        let enabled = !self.protocol_logging.load(Ordering::SeqCst);
+        self.protocol_logging.store(enabled, Ordering::SeqCst);
+        crate::localpane::emit_output_for_pane(
+            self.pane_id,
+            if enabled {
+                "\r\ntmux logging enabled\r\n"
+            } else {
+                "\r\ntmux logging disabled\r\n"
+            },
+        );
+        enabled
+    }
+
+    pub fn log_protocol_line(&self, direction: &str, line: &str) {
+        if self.protocol_logging.load(Ordering::SeqCst) {
+            crate::localpane::emit_output_for_pane(
+                self.pane_id,
+                &format!("{direction} {}\r\n", line.trim_end_matches(['\r', '\n'])),
+            );
+        }
+    }
+
+    pub fn enqueue_user_command(&self, command: String) {
+        let command = command.trim().to_string();
+        if command.is_empty() || self.force_quit.load(Ordering::SeqCst) {
+            return;
+        }
+        self.cmd_queue
+            .lock()
+            .push_back(Box::new(RawTmuxCommand::new(command)));
+        Self::schedule_send_next_command(self.domain_id);
+    }
+
+    pub fn request_command_prompt(&self) {
+        Mux::get().notify(MuxNotification::TmuxCommandPrompt {
+            pane_id: self.pane_id,
+            domain_id: self.domain_id,
+        });
+    }
+
     pub fn advance(&self, events: Box<Vec<Event>>) {
+        if self.force_quit.load(Ordering::SeqCst) {
+            return;
+        }
         for event in events.iter() {
             let state = *self.state.lock();
             log::debug!("tmux: {:?} in state {:?}", event, state);
@@ -180,6 +259,11 @@ impl TmuxDomainState {
                     self.subscribe_notification();
                     log::info!("tmux session changed:{}", session);
                 }
+                Event::SessionWindowChanged { session, window } => {
+                    if Some(*session) == *self.tmux_session.lock() {
+                        self.activate_tmux_window(*window);
+                    }
+                }
                 Event::WindowAdd { window } => {
                     // Only handle the new tab, the first empty window handled by sync_window_state
                     if !self.gui_window.lock().is_none() {
@@ -249,6 +333,7 @@ impl TmuxDomainState {
                 continue;
             }
             log::debug!("sending cmd {:?}", cmd);
+            self.log_protocol_line(">", cmd.trim_end_matches(['\r', '\n']));
             let mux = Mux::get();
             if let Some(pane) = mux.get_pane(self.pane_id) {
                 let mut writer = pane.writer();
@@ -276,19 +361,10 @@ impl TmuxDomainState {
     pub fn create_gui_window(&self) {
         if self.gui_window.lock().is_none() {
             let mux = Mux::get();
-            let window_builder =
-                if let Some((_domain, window_id, _tab)) = mux.resolve_pane_id(self.pane_id) {
-                    MuxWindowBuilder {
-                        window_id,
-                        activity: Some(Activity::new()),
-                        notified: false,
-                    }
-                } else {
-                    mux.new_empty_window(
-                        None, /* TODO: pass session here */
-                        None, /* position */
-                    )
-                };
+            let window_builder = mux.new_empty_window(
+                None, /* TODO: pass session here */
+                None, /* position */
+            );
 
             log::info!("Tmux create window id {}", window_builder.window_id);
             {
@@ -303,6 +379,24 @@ impl TmuxDomainState {
         let mut cmd_queue = self.cmd_queue.as_ref().lock();
         cmd_queue.push_back(Box::new(NewWindow));
         TmuxDomainState::schedule_send_next_command(self.domain_id);
+    }
+
+    pub fn activate_tmux_window(&self, tmux_window_id: TmuxWindowId) {
+        *self.active_window.lock() = Some(tmux_window_id);
+
+        let tab_id = match self.gui_tabs.lock().get(&tmux_window_id) {
+            Some(tab) => tab.tab_id,
+            None => return,
+        };
+        let gui_window_id = match self.gui_window.lock().as_ref() {
+            Some(window) => **window,
+            None => return,
+        };
+        if let Some(mut window) = Mux::get().get_window_mut(gui_window_id) {
+            if let Some(idx) = window.get_tab_idx_for_id(tab_id) {
+                window.remember_and_set_active_tab_idx(idx);
+            }
+        }
     }
 
     /// split the tmux pane
@@ -347,6 +441,10 @@ impl TmuxDomain {
             gui_tabs: Mutex::new(HashMap::default()),
             remote_panes: Mutex::new(HashMap::default()),
             tmux_session: Mutex::new(None),
+            active_window: Mutex::new(None),
+            activating_window: Mutex::new(None),
+            protocol_logging: AtomicBool::new(false),
+            force_quit: AtomicBool::new(false),
             support_commands: Mutex::new(HashMap::default()),
             attach_state: Mutex::new(AttachState::Init),
             pending_splits: Mutex::new(VecDeque::default()),
@@ -378,6 +476,8 @@ impl Domain for TmuxDomain {
         self.inner.pending_windows.lock().push_back(promise);
         self.inner.create_tmux_window();
         let window_id = future.await?;
+        smol::Timer::after(std::time::Duration::from_millis(150)).await;
+        *self.inner.activating_window.lock() = None;
         let tab_id = {
             let gui_tabs = self.inner.gui_tabs.lock();
             gui_tabs

--- a/mux/src/tmux.rs
+++ b/mux/src/tmux.rs
@@ -75,6 +75,7 @@ pub(crate) struct TmuxDomainState {
     pub support_commands: Mutex<HashMap<String, String>>,
     pub attach_state: Mutex<AttachState>,
     pending_splits: Mutex<VecDeque<promise::Promise<TmuxPaneId>>>,
+    pub pending_windows: Mutex<VecDeque<promise::Promise<TmuxWindowId>>>,
     pub backlog: Mutex<HashMap<TmuxPaneId, Vec<u8>>>,
 }
 
@@ -349,6 +350,7 @@ impl TmuxDomain {
             support_commands: Mutex::new(HashMap::default()),
             attach_state: Mutex::new(AttachState::Init),
             pending_splits: Mutex::new(VecDeque::default()),
+            pending_windows: Mutex::new(VecDeque::default()),
             backlog: Mutex::new(HashMap::default()),
         });
 
@@ -369,11 +371,23 @@ impl Domain for TmuxDomain {
         _command_dir: Option<String>,
         _window: WindowId,
     ) -> anyhow::Result<Arc<Tab>> {
+        let mut promise = promise::Promise::new();
+        let future = promise
+            .get_future()
+            .ok_or_else(|| anyhow::anyhow!("failed to create new-window waiter"))?;
+        self.inner.pending_windows.lock().push_back(promise);
         self.inner.create_tmux_window();
-        // This is intention, we would not return a Tab, since we don't have now!
-        // We use create_tmux_window to create back end tmux window, then the
-        // Tmux WindowAdd event will triage us to do the rest things.
-        anyhow::bail!("Intention: we use tmux command to do so");
+        let window_id = future.await?;
+        let tab_id = {
+            let gui_tabs = self.inner.gui_tabs.lock();
+            gui_tabs
+                .get(&window_id)
+                .map(|t| t.tab_id)
+                .ok_or_else(|| anyhow::anyhow!("tmux window {window_id} was not attached"))?
+        };
+        Mux::get()
+            .get_tab(tab_id)
+            .ok_or_else(|| anyhow::anyhow!("missing tab after new-window"))
     }
 
     async fn split_pane(

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -209,6 +209,9 @@ impl TmuxDomainState {
 
         let child = TmuxChild {
             active_lock: active_lock.clone(),
+            domain_id: self.domain_id,
+            pane_id: pane.pane_id,
+            cmd_queue: self.cmd_queue.clone(),
         };
 
         let terminal = wezterm_term::Terminal::new(
@@ -374,6 +377,9 @@ impl TmuxDomainState {
             if window.session_id != current_session {
                 continue;
             }
+            if self.check_window_attached(window.window_id) {
+                continue;
+            }
 
             let size = TerminalSize {
                 rows: window.window_height as usize,
@@ -493,6 +499,13 @@ impl TmuxDomainState {
 
             mux.add_tab_to_window(&tab, **gui_window_id)?;
             gui_window_id.notify();
+
+            {
+                let mut pending = self.pending_windows.lock();
+                if let Some(mut promise) = pending.pop_front() {
+                    promise.ok(window.window_id);
+                }
+            }
 
             let gui_tabs = self.gui_tabs.lock();
             let local_tab = match gui_tabs.get(&window.window_id) {
@@ -822,8 +835,14 @@ impl TmuxCommand for ListAllWindows {
 
             let history_limit = fields
                 .next()
-                .ok_or_else(|| anyhow!("missing history_limit"))?
-                .parse::<isize>()?;
+                .and_then(|s| {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        s.parse::<isize>().ok()
+                    }
+                })
+                .unwrap_or(2000);
 
             let window_active = window_active == 1;
 
@@ -1063,9 +1082,9 @@ impl TmuxCommand for ListCommands {
 
     fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
         if result.error {
-            let error = format!("list-command in domain={domain_id} failed: {result:#?}");
-            log::error!("{error}");
-            anyhow::bail!("{error}");
+            log::warn!(
+                "list-commands in domain={domain_id} failed ({result:#?}); continuing attach"
+            );
         }
         let mux = Mux::get();
         let domain = match mux.get_domain(domain_id) {
@@ -1077,14 +1096,16 @@ impl TmuxCommand for ListCommands {
             None => anyhow::bail!("Tmux domain lost"),
         };
 
-        let mut support_commands = tmux_domain.inner.support_commands.lock();
+        if !result.error {
+            let mut support_commands = tmux_domain.inner.support_commands.lock();
 
-        for line in result.output.split('\n') {
-            if line.is_empty() {
-                continue;
+            for line in result.output.split('\n') {
+                if line.is_empty() {
+                    continue;
+                }
+                let v: Vec<&str> = line.split(' ').collect();
+                support_commands.insert(v[0].to_string(), line.to_string());
             }
-            let v: Vec<&str> = line.split(' ').collect();
-            support_commands.insert(v[0].to_string(), line.to_string());
         }
 
         let mut cmd_queue = tmux_domain.inner.cmd_queue.as_ref().lock();
@@ -1118,6 +1139,26 @@ impl TmuxCommand for SplitPane {
     fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
         if result.error {
             let error = format!("split-window in domain={domain_id} failed: {result:#?}");
+            log::error!("{error}");
+            anyhow::bail!("{error}");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct KillPane {
+    pub pane_id: TmuxPaneId,
+}
+
+impl TmuxCommand for KillPane {
+    fn get_command(&self, _domain_id: DomainId) -> String {
+        format!("kill-pane -t %{}\n", self.pane_id)
+    }
+
+    fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
+        if result.error {
+            let error = format!("kill-pane in domain={domain_id} failed: {result:#?}");
             log::error!("{error}");
             anyhow::bail!("{error}");
         }

--- a/mux/src/tmux_commands.rs
+++ b/mux/src/tmux_commands.rs
@@ -22,6 +22,45 @@ pub(crate) trait TmuxCommand: Send + Debug {
     fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()>;
 }
 
+#[derive(Debug)]
+pub(crate) struct RawTmuxCommand {
+    command: String,
+}
+
+impl RawTmuxCommand {
+    pub fn new(command: String) -> Self {
+        Self { command }
+    }
+}
+
+impl TmuxCommand for RawTmuxCommand {
+    fn get_command(&self, _domain_id: DomainId) -> String {
+        format!("{}\n", self.command.trim_end_matches(['\r', '\n']))
+    }
+
+    fn process_result(&self, domain_id: DomainId, result: &Guarded) -> anyhow::Result<()> {
+        let mux = Mux::get();
+        let domain = mux
+            .get_domain(domain_id)
+            .ok_or_else(|| anyhow!("tmux domain {domain_id} was removed"))?;
+        let tmux_domain = domain
+            .downcast_ref::<TmuxDomain>()
+            .ok_or_else(|| anyhow!("domain {domain_id} is not a tmux domain"))?;
+        let status = if result.error { "error" } else { "result" };
+        let output = result.output.trim_end_matches(['\r', '\n']);
+        let message = if output.is_empty() {
+            format!("\r\ntmux command {status}: {}\r\n", self.command)
+        } else {
+            format!(
+                "\r\ntmux command {status}: {}\r\n{}\r\n",
+                self.command, output
+            )
+        };
+        crate::localpane::emit_output_for_pane(tmux_domain.inner.pane_id, &message);
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PaneItem {
     session_id: TmuxSessionId,
@@ -372,6 +411,7 @@ impl TmuxDomainState {
                 anyhow::bail!("No tmux gui created");
             }
         };
+        let mut added_windows = vec![];
 
         for window in windows.iter() {
             if window.session_id != current_session {
@@ -497,13 +537,25 @@ impl TmuxDomainState {
                 }
             }
 
+            if new_window {
+                *self.activating_window.lock() = Some(window.window_id);
+            }
             mux.add_tab_to_window(&tab, **gui_window_id)?;
             gui_window_id.notify();
-
-            {
-                let mut pending = self.pending_windows.lock();
-                if let Some(mut promise) = pending.pop_front() {
-                    promise.ok(window.window_id);
+            added_windows.push(window.window_id);
+            if new_window || *self.active_window.lock() == Some(window.window_id) {
+                if let Some(mut mux_window) = mux.get_window_mut(**gui_window_id) {
+                    if let Some(idx) = mux_window.get_tab_idx_for_id(tab.tab_id()) {
+                        mux_window.remember_and_set_active_tab_idx(idx);
+                    }
+                }
+            }
+            if new_window {
+                self.cmd_queue.lock().push_back(Box::new(SelectWindow {
+                    window_id: window.window_id,
+                }));
+                if let Some(pane) = tab.get_active_pane() {
+                    mux.notify(MuxNotification::PaneFocused(pane.pane_id()));
                 }
             }
 
@@ -557,6 +609,13 @@ impl TmuxDomainState {
 
         TmuxDomainState::schedule_send_next_command(self.domain_id);
 
+        for window_id in added_windows {
+            let mut pending = self.pending_windows.lock();
+            if let Some(mut promise) = pending.pop_front() {
+                promise.ok(window_id);
+            }
+        }
+
         Ok(())
     }
 
@@ -581,18 +640,33 @@ impl TmuxDomainState {
 
                 match n {
                     MuxNotification::PaneFocused(pane_id) => {
-                        let tmux_pane_id = match tmux_domain
+                        let tmux_pane = match tmux_domain
                             .inner
                             .remote_panes
                             .lock()
                             .iter()
                             .find(|(_, p)| p.lock().local_pane_id == pane_id)
                         {
-                            Some((_, p)) => Some(p.lock().pane_id),
+                            Some((_, p)) => {
+                                let p = p.lock();
+                                Some((p.pane_id, p.window_id))
+                            }
                             None => None,
                         };
 
-                        if let Some(pane_id) = tmux_pane_id {
+                        if let Some((pane_id, window_id)) = tmux_pane {
+                            if let Some(activating_window) =
+                                *tmux_domain.inner.activating_window.lock()
+                            {
+                                if activating_window != window_id {
+                                    return;
+                                }
+                            }
+                            if let Some(active_window) = *tmux_domain.inner.active_window.lock() {
+                                if active_window != window_id {
+                                    return;
+                                }
+                            }
                             tmux_domain
                                 .inner
                                 .cmd_queue
@@ -617,6 +691,18 @@ impl TmuxDomainState {
                                 None => None,
                             };
                             if let Some(window_id) = tmux_window_id {
+                                if let Some(activating_window) =
+                                    *tmux_domain.inner.activating_window.lock()
+                                {
+                                    if activating_window != window_id {
+                                        return;
+                                    }
+                                }
+                                let mut active_window = tmux_domain.inner.active_window.lock();
+                                if *active_window == Some(window_id) {
+                                    return;
+                                }
+                                *active_window = Some(window_id);
                                 tmux_domain.inner.cmd_queue.lock().push_back(Box::new(
                                     SelectWindow {
                                         window_id: window_id,
@@ -762,7 +848,8 @@ impl TmuxCommand for ListAllPanes {
         let mux = Mux::get();
         if let Some(domain) = mux.get_domain(domain_id) {
             if let Some(tmux_domain) = domain.downcast_ref::<TmuxDomain>() {
-                if !self.prune {
+                let activating = *tmux_domain.inner.activating_window.lock();
+                if !self.prune || activating == Some(self.window_id) {
                     return tmux_domain.inner.sync_pane_state(&items);
                 } else {
                     return tmux_domain
@@ -1235,5 +1322,16 @@ impl TmuxCommand for AttachDone {
         // Do nothing, just change the state.
         *tmux_domain.inner.attach_state.lock() = AttachState::Done;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RawTmuxCommand, TmuxCommand};
+
+    #[test]
+    fn raw_tmux_command_has_one_line_terminator() {
+        let command = RawTmuxCommand::new("new-window\r\n".to_string());
+        assert_eq!(command.get_command(0), "new-window\n");
     }
 }

--- a/mux/src/tmux_pty.rs
+++ b/mux/src/tmux_pty.rs
@@ -1,11 +1,12 @@
 use crate::tmux::{RefTmuxRemotePane, TmuxCmdQueue, TmuxDomainState};
-use crate::tmux_commands::{Resize, SendKeys};
+use crate::tmux_commands::{KillPane, Resize, SendKeys};
 use crate::DomainId;
 use filedescriptor::FileDescriptor;
 use parking_lot::{Condvar, Mutex};
 use portable_pty::{Child, ChildKiller, ExitStatus, MasterPty};
 use std::io::{Read, Write};
 use std::sync::Arc;
+use termwiz::tmux_cc::TmuxPaneId;
 
 /// A local tmux pane(tab) based on a tmux pty
 #[derive(Debug)]
@@ -22,20 +23,38 @@ struct TmuxPtyWriter {
     cmd_queue: Arc<Mutex<TmuxCmdQueue>>,
 }
 
+fn enqueue_send_keys(
+    domain_id: DomainId,
+    cmd_queue: &Arc<Mutex<TmuxCmdQueue>>,
+    pane_id: TmuxPaneId,
+    buf: &[u8],
+) -> std::io::Result<usize> {
+    if buf.is_empty() {
+        return Ok(0);
+    }
+    log::trace!("pane:{}, content:{:?}", &pane_id, buf);
+    cmd_queue.lock().push_back(Box::new(SendKeys {
+        pane: pane_id,
+        keys: buf.to_vec(),
+    }));
+    TmuxDomainState::schedule_send_next_command(domain_id);
+    Ok(buf.len())
+}
+
+fn enqueue_kill_pane(
+    domain_id: DomainId,
+    cmd_queue: &Arc<Mutex<TmuxCmdQueue>>,
+    pane_id: TmuxPaneId,
+) -> std::io::Result<()> {
+    cmd_queue.lock().push_back(Box::new(KillPane { pane_id }));
+    TmuxDomainState::schedule_send_next_command(domain_id);
+    Ok(())
+}
+
 impl Write for TmuxPtyWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let pane_id = {
-            let pane_lock = self.master_pane.lock();
-            pane_lock.pane_id
-        };
-        log::trace!("pane:{}, content:{:?}", &pane_id, buf);
-        let mut cmd_queue = self.cmd_queue.lock();
-        cmd_queue.push_back(Box::new(SendKeys {
-            pane: pane_id,
-            keys: buf.to_vec(),
-        }));
-        TmuxDomainState::schedule_send_next_command(self.domain_id);
-        Ok(0)
+        let pane_id = self.master_pane.lock().pane_id;
+        enqueue_send_keys(self.domain_id, &self.cmd_queue, pane_id, buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
@@ -45,18 +64,8 @@ impl Write for TmuxPtyWriter {
 
 impl Write for TmuxPty {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let pane_id = {
-            let pane_lock = self.master_pane.lock();
-            pane_lock.pane_id
-        };
-        log::trace!("pane:{}, content:{:?}", &pane_id, buf);
-        let mut cmd_queue = self.cmd_queue.lock();
-        cmd_queue.push_back(Box::new(SendKeys {
-            pane: pane_id,
-            keys: buf.to_vec(),
-        }));
-        TmuxDomainState::schedule_send_next_command(self.domain_id);
-        Ok(0)
+        let pane_id = self.master_pane.lock().pane_id;
+        enqueue_send_keys(self.domain_id, &self.cmd_queue, pane_id, buf)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
@@ -67,6 +76,9 @@ impl Write for TmuxPty {
 #[derive(Clone, Debug)]
 pub(crate) struct TmuxChild {
     pub active_lock: Arc<(Mutex<bool>, Condvar)>,
+    pub domain_id: DomainId,
+    pub pane_id: TmuxPaneId,
+    pub cmd_queue: Arc<Mutex<TmuxCmdQueue>>,
 }
 
 impl Child for TmuxChild {
@@ -94,14 +106,15 @@ impl Child for TmuxChild {
 }
 
 #[derive(Clone, Debug)]
-struct TmuxChildKiller {}
+struct TmuxChildKiller {
+    domain_id: DomainId,
+    pane_id: TmuxPaneId,
+    cmd_queue: Arc<Mutex<TmuxCmdQueue>>,
+}
 
 impl ChildKiller for TmuxChildKiller {
     fn kill(&mut self) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "TmuxChildKiller: kill not implemented!",
-        ))
+        enqueue_kill_pane(self.domain_id, &self.cmd_queue, self.pane_id)
     }
 
     fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
@@ -111,14 +124,15 @@ impl ChildKiller for TmuxChildKiller {
 
 impl ChildKiller for TmuxChild {
     fn kill(&mut self) -> std::io::Result<()> {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "TmuxPty: kill not implemented!",
-        ))
+        enqueue_kill_pane(self.domain_id, &self.cmd_queue, self.pane_id)
     }
 
     fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
-        Box::new(TmuxChildKiller {})
+        Box::new(TmuxChildKiller {
+            domain_id: self.domain_id,
+            pane_id: self.pane_id,
+            cmd_queue: self.cmd_queue.clone(),
+        })
     }
 }
 

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -53,6 +53,12 @@ struct ParseState {
     get_tcap: Option<GetTcapBuilder>,
     #[cfg(feature = "tmux_cc")]
     tmux_state: Option<RefCell<crate::tmux_cc::Parser>>,
+    #[cfg(feature = "tmux_cc")]
+    tmux_exiting: bool,
+    #[cfg(feature = "tmux_cc")]
+    tmux_force_exit: bool,
+    #[cfg(feature = "tmux_cc")]
+    tmux_st_escape_pending: bool,
 }
 
 /// The `Parser` struct holds the state machine that is used to decode
@@ -89,13 +95,116 @@ impl Parser {
         return tmux_parser.advance_bytes(bytes);
     }
 
+    #[cfg(feature = "tmux_cc")]
+    pub fn expect_tmux_exit(&mut self) {
+        let mut state = self.state.borrow_mut();
+        if state.tmux_state.is_some() {
+            state.tmux_exiting = true;
+        }
+    }
+
+    #[cfg(feature = "tmux_cc")]
+    pub fn force_tmux_exit(&mut self) {
+        let mut state = self.state.borrow_mut();
+        if state.tmux_state.is_some() {
+            state.tmux_force_exit = true;
+        }
+    }
+
     pub fn parse<F: FnMut(Action)>(&mut self, bytes: &[u8], mut callback: F) {
         #[cfg(feature = "tmux_cc")]
         let is_tmux_mode: bool = self.state.borrow().tmux_state.is_some();
         #[cfg(feature = "tmux_cc")]
         if is_tmux_mode {
+            if self.state.borrow().tmux_force_exit {
+                let mut parser_state = self.state.borrow_mut();
+                parser_state.tmux_state = None;
+                parser_state.tmux_exiting = false;
+                parser_state.tmux_force_exit = false;
+                parser_state.tmux_st_escape_pending = false;
+                let mut perform = Performer {
+                    callback: &mut callback,
+                    state: &mut parser_state,
+                };
+                self.state_machine.parse(b"\x1b\\", &mut perform);
+                self.state_machine.parse(bytes, &mut perform);
+                return;
+            }
+            if self.state.borrow().tmux_exiting {
+                if self.state.borrow().tmux_st_escape_pending && bytes.first() == Some(&b'\\') {
+                    let mut parser_state = self.state.borrow_mut();
+                    parser_state.tmux_state = None;
+                    parser_state.tmux_exiting = false;
+                    parser_state.tmux_force_exit = false;
+                    parser_state.tmux_st_escape_pending = false;
+                    let mut perform = Performer {
+                        callback: &mut callback,
+                        state: &mut parser_state,
+                    };
+                    self.state_machine.parse(b"\x1b\\", &mut perform);
+                    self.state_machine.parse(&bytes[1..], &mut perform);
+                    return;
+                }
+                if self.state.borrow().tmux_st_escape_pending {
+                    self.state.borrow_mut().tmux_st_escape_pending = false;
+                    callback(Action::DeviceControl(DeviceControlMode::Data(b'\x1b')));
+                    let _ = self.advance_tmux_bytes(b"\x1b");
+                }
+                let st_offset = bytes
+                    .windows(2)
+                    .position(|pair| pair == b"\x1b\\")
+                    .or_else(|| bytes.iter().position(|&byte| byte == 0x9c));
+                if let Some(st_offset) = st_offset {
+                    let protocol = &bytes[..st_offset];
+                    for &byte in protocol {
+                        callback(Action::DeviceControl(DeviceControlMode::Data(byte)));
+                    }
+                    if let Ok(tmux_events) = self.advance_tmux_bytes(protocol) {
+                        if !tmux_events.is_empty() {
+                            callback(Action::DeviceControl(DeviceControlMode::TmuxEvents(
+                                Box::new(tmux_events),
+                            )));
+                        }
+                    }
+                    let mut parser_state = self.state.borrow_mut();
+                    parser_state.tmux_state = None;
+                    parser_state.tmux_exiting = false;
+                    parser_state.tmux_force_exit = false;
+                    parser_state.tmux_st_escape_pending = false;
+                    let mut perform = Performer {
+                        callback: &mut callback,
+                        state: &mut parser_state,
+                    };
+                    self.state_machine.parse(&bytes[st_offset..], &mut perform);
+                    return;
+                }
+                if bytes.last() == Some(&b'\x1b') {
+                    let protocol = &bytes[..bytes.len() - 1];
+                    for &byte in protocol {
+                        callback(Action::DeviceControl(DeviceControlMode::Data(byte)));
+                    }
+                    if let Ok(tmux_events) = self.advance_tmux_bytes(protocol) {
+                        if !tmux_events.is_empty() {
+                            callback(Action::DeviceControl(DeviceControlMode::TmuxEvents(
+                                Box::new(tmux_events),
+                            )));
+                        }
+                    }
+                    self.state.borrow_mut().tmux_st_escape_pending = true;
+                    return;
+                }
+            }
+            for &byte in bytes {
+                callback(Action::DeviceControl(DeviceControlMode::Data(byte)));
+            }
             match self.advance_tmux_bytes(bytes) {
                 Ok(tmux_events) => {
+                    if tmux_events
+                        .iter()
+                        .any(|event| matches!(event, Event::Exit { .. }))
+                    {
+                        self.state.borrow_mut().tmux_exiting = true;
+                    }
                     callback(Action::DeviceControl(DeviceControlMode::TmuxEvents(
                         Box::new(tmux_events),
                     )));
@@ -105,6 +214,9 @@ impl Parser {
                     let unparsed_str = err_buf.to_string().to_owned();
                     let mut parser_state = self.state.borrow_mut();
                     parser_state.tmux_state = None;
+                    parser_state.tmux_exiting = false;
+                    parser_state.tmux_force_exit = false;
+                    parser_state.tmux_st_escape_pending = false;
                     let mut perform = Performer {
                         callback: &mut callback,
                         state: &mut parser_state,
@@ -255,8 +367,11 @@ impl<'a, F: FnMut(Action)> VTActor for Performer<'a, F> {
             #[cfg(feature = "tmux_cc")]
             if byte == b'p' && params == [1000] {
                 // into tmux_cc mode
-                self.state.borrow_mut().tmux_state =
-                    Some(RefCell::new(crate::tmux_cc::Parser::new()));
+                let mut state = self.state.borrow_mut();
+                state.tmux_state = Some(RefCell::new(crate::tmux_cc::Parser::new()));
+                state.tmux_exiting = false;
+                state.tmux_force_exit = false;
+                state.tmux_st_escape_pending = false;
             }
             (self.callback)(Action::DeviceControl(DeviceControlMode::Enter(Box::new(
                 EnterDeviceControlMode {
@@ -279,10 +394,16 @@ impl<'a, F: FnMut(Action)> VTActor for Performer<'a, F> {
         } else {
             #[cfg(feature = "tmux_cc")]
             if let Some(tmux_state) = &self.state.tmux_state {
+                // Preserve the exact control stream for terminal-emulator
+                // protocol logging while continuing to emit parsed events.
+                (self.callback)(Action::DeviceControl(DeviceControlMode::Data(data)));
                 let mut tmux_parser = tmux_state.borrow_mut();
                 match tmux_parser.advance_byte(data) {
                     Ok(optional_events) => {
                         if let Some(tmux_event) = optional_events {
+                            if matches!(&tmux_event, Event::Exit { .. }) {
+                                self.state.tmux_exiting = true;
+                            }
                             (self.callback)(Action::DeviceControl(DeviceControlMode::TmuxEvents(
                                 Box::new(vec![tmux_event]),
                             )));
@@ -291,6 +412,9 @@ impl<'a, F: FnMut(Action)> VTActor for Performer<'a, F> {
                     Err(_) => {
                         drop(tmux_parser);
                         self.state.tmux_state = None; // drop tmux state
+                        self.state.tmux_exiting = false;
+                        self.state.tmux_force_exit = false;
+                        self.state.tmux_st_escape_pending = false;
                     }
                 }
                 return;
@@ -364,6 +488,80 @@ mod test {
             write!(res, "{}", s).unwrap();
         }
         String::from_utf8(res).unwrap()
+    }
+
+    #[cfg(feature = "tmux_cc")]
+    #[test]
+    fn tmux_control_preserves_raw_protocol_data() {
+        let mut parser = Parser::new();
+        let mut raw = Vec::new();
+        let mut saw_sessions_changed = false;
+        let mut saw_exit = false;
+        let mut text = String::new();
+        let mut collect = |action| match action {
+            Action::DeviceControl(DeviceControlMode::Data(byte)) => raw.push(byte),
+            Action::DeviceControl(DeviceControlMode::TmuxEvents(events)) => {
+                saw_sessions_changed |= events
+                    .iter()
+                    .any(|event| matches!(event, crate::tmux_cc::Event::SessionsChanged));
+            }
+            Action::DeviceControl(DeviceControlMode::Exit) => saw_exit = true,
+            Action::Print(character) => text.push(character),
+            _ => {}
+        };
+
+        parser.parse(b"\x1bP1000p%sessions-", &mut collect);
+        parser.parse(b"changed\n", &mut collect);
+        parser.expect_tmux_exit();
+        parser.parse(b"%exit\n\x1b\\shell", &mut collect);
+
+        assert_eq!(
+            String::from_utf8(raw).unwrap(),
+            "%sessions-changed\n%exit\n"
+        );
+        assert!(saw_sessions_changed);
+        assert!(saw_exit);
+        assert_eq!(text, "shell");
+    }
+
+    #[cfg(feature = "tmux_cc")]
+    #[test]
+    fn tmux_control_accepts_st_without_exit_event() {
+        let mut parser = Parser::new();
+        let mut saw_exit = false;
+        parser.parse(b"\x1bP1000p%sessions-changed\n", |_| {});
+        parser.expect_tmux_exit();
+        parser.parse(b"\x1b", |_| {});
+        parser.parse(b"\\", |action| {
+            if matches!(action, Action::DeviceControl(DeviceControlMode::Exit)) {
+                saw_exit = true;
+            }
+        });
+        assert!(saw_exit);
+    }
+
+    #[cfg(feature = "tmux_cc")]
+    #[test]
+    fn tmux_control_force_exit_resumes_terminal_parser() {
+        let mut parser = Parser::new();
+        parser.parse(b"\x1bP1000p%sessions-changed\n", |_| {});
+        parser.force_tmux_exit();
+        let mut actions = vec![];
+        parser.parse(b"shell", |action| actions.push(action));
+        assert!(matches!(
+            actions.first(),
+            Some(Action::DeviceControl(DeviceControlMode::Exit))
+        ));
+        assert_eq!(
+            actions
+                .into_iter()
+                .filter_map(|action| match action {
+                    Action::Print(character) => Some(character),
+                    _ => None,
+                })
+                .collect::<String>(),
+            "shell"
+        );
     }
 
     // <https://github.com/markbt/streampager/issues/57>

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -90,6 +90,7 @@ impl GuiFrontEnd {
                 MuxNotification::WindowTitleChanged { .. } => {}
                 MuxNotification::TabResized(_) => {}
                 MuxNotification::TabAddedToWindow { .. } => {}
+                MuxNotification::TmuxCommandPrompt { .. } => {}
                 MuxNotification::PaneRemoved(_) => {}
                 MuxNotification::WindowInvalidated(_) => {}
                 MuxNotification::PaneOutput(_) => {}

--- a/wezterm-gui/src/overlay/prompt.rs
+++ b/wezterm-gui/src/overlay/prompt.rs
@@ -41,6 +41,16 @@ impl LineEditorHost for PromptHost {
     }
 }
 
+pub fn show_tmux_command_prompt(mut term: TermWizTerminal) -> anyhow::Result<Option<String>> {
+    term.no_grab_mouse_in_raw_mode();
+    term.render(&[Change::Text("Run tmux command\r\n".to_string())])?;
+
+    let mut host = PromptHost::new();
+    let mut editor = LineEditor::new(&mut term);
+    editor.set_prompt("tmux> ");
+    Ok(editor.read_line(&mut host)?)
+}
+
 pub fn show_line_prompt_overlay(
     mut term: TermWizTerminal,
     args: PromptInputLine,

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1199,6 +1199,11 @@ impl TermWindow {
                 self.cancel_overlay_for_tab(tab_id, pane_id);
             }
             TermWindowNotif::MuxNotification(n) => match n {
+                MuxNotification::TmuxCommandPrompt { pane_id, domain_id } => {
+                    if self.window_contains_pane(pane_id) {
+                        self.show_tmux_command_prompt(pane_id, domain_id);
+                    }
+                }
                 MuxNotification::Alert {
                     alert: Alert::SetUserVar { name, value },
                     pane_id,
@@ -1470,7 +1475,8 @@ impl TermWindow {
             }
             | MuxNotification::PaneFocused(pane_id)
             | MuxNotification::PaneRemoved(pane_id)
-            | MuxNotification::PaneOutput(pane_id) => {
+            | MuxNotification::PaneOutput(pane_id)
+            | MuxNotification::TmuxCommandPrompt { pane_id, .. } => {
                 // Check window validity and propagate to the window event handler
                 // that will do the full pane visibility check.
                 let mux = Mux::get();
@@ -2322,6 +2328,31 @@ impl TermWindow {
         });
         self.assign_overlay(tab.tab_id(), overlay);
         promise::spawn::spawn(future).detach();
+    }
+
+    fn show_tmux_command_prompt(&mut self, pane_id: PaneId, domain_id: mux::domain::DomainId) {
+        let mux = Mux::get();
+        let pane = match mux.get_pane(pane_id) {
+            Some(pane) => pane,
+            None => return,
+        };
+
+        let (overlay, future) = start_overlay_pane(self, &pane, move |_pane_id, term| {
+            crate::overlay::prompt::show_tmux_command_prompt(term)
+        });
+        self.assign_overlay_for_pane(pane_id, overlay);
+        promise::spawn::spawn(async move {
+            if let Some(command) = future.await? {
+                let mux = Mux::get();
+                if let Some(domain) = mux.get_domain(domain_id) {
+                    if let Some(tmux) = domain.downcast_ref::<mux::tmux::TmuxDomain>() {
+                        tmux.enqueue_user_command(command);
+                    }
+                }
+            }
+            anyhow::Result::<()>::Ok(())
+        })
+        .detach();
     }
 
     fn show_confirmation(&mut self, args: &Confirmation) {

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -203,6 +203,7 @@ where
                 stream.flush().await.context("flushing PDU to client")?;
             }
             Ok(Item::Notif(MuxNotification::ActiveWorkspaceChanged(_))) => {}
+            Ok(Item::Notif(MuxNotification::TmuxCommandPrompt { .. })) => {}
             Ok(Item::Notif(MuxNotification::Empty)) => {}
             Err(err) => {
                 log::error!("process_async Err {}", err);


### PR DESCRIPTION
## Summary

This makes `tmux -CC` attach work better on current main: no more crash on enter, keyboard input reaches panes, new tabs wait for tmux, and closing a pane sends `kill-pane`.

Fixes #3223 (same panic as #6133). Progress on #336. Also addresses #8003 (overlaps #8006).

## How these were found

I maintain [Eternal Terminal](https://github.com/MisterTea/EternalTerminal) and its headless multiplexer, HTM. HTM now speaks the same tmux control-mode protocol that iTerm2 and Hyper already drive (`DCS ESC P 1000 p`, `%output` / `%layout-change`, `send-keys`, `split-window`, `new-window`, `kill-pane`, …).

WezTerm is one of the GUI clients we want to work against that protocol. While bringing HTM onto `tmux -CC` we ran WezTerm built from current `main` against both real `tmux -CC` and `htm`, using the same layout/stress GUI suite we use for iTerm2 and Hyper.

That immediately reproduced the long-standing attach crash, then a series of follow-on bugs that only show up once attach survives. The same failures happen with stock `tmux -CC`; HTM just made them easy to hit repeatedly.

## The attach crash (#3223 / #6133)

**#3223** (`tmux -CC a` via ssh) and **#6133** (crash as soon as you type `tmux -CC`) are the same panic:

```
local task polled by a thread that didn't spawn it
```

with the stack in `async-task` `spawn_local`, `SpawnQueue`, and `TmuxDomainState::advance`. #6133 was closed as a duplicate of #3223; #3223 is still open. Wez noted at the time that tmux CC was incomplete and pointed at #336.

### What was going wrong

`LocalPaneDCSHandler::handle_device_control` runs on the PTY parser thread, not the mux/GUI thread. On `DCS 1000p` it was:

1. Creating the `TmuxDomain` and calling `Mux::get().add_domain()` on that parser thread.
2. Calling `tmux.advance(events)` on that same thread for every subsequent control-mode event.

`promise::spawn()` is `async_task::spawn_local` scheduled onto the main `SpawnQueue`. That is only valid when the task is spawned on the main thread. `advance()` (and domain attach/detach) also touch mux state that the rest of WezTerm assumes is used from the mux thread.

So the first `%begin` / `list-panes` / `SessionChanged` after `tmux -CC` would schedule a local task from the wrong thread. The main loop then polled it and aborted, exactly as in the #3223 / #6133 logs.

### The fix

Keep a `TmuxDomain` handle on the parser thread so events can be queued immediately, but marshal all mux work onto the main thread with `spawn_into_main_thread`:

- **Enter (`DCS 1000p`)**: create the domain locally, then `add_domain` + banner on the main thread.
- **`TmuxEvents`**: `tmux.advance(events)` on the main thread.
- **Exit**: clear the pane’s domain and `domain_was_detached` on the main thread.

After this, `tmux -CC` / `htm` attach without the `spawn_local` panic. That is the #3223 / #6133 fix.

## Follow-on bugs that blocked a usable session (#336)

Once attach stopped crashing, control mode was still not usable. These are the remaining items in this PR; they are part of making the basics in #336 actually work (native tabs/panes, keys, spawn, close).

### 1. Keyboard / paste never reached the pane (#8003)

`TmuxPty::write` and `TmuxPtyWriter::write` copied the buffer into a `SendKeys` command, then returned `Ok(0)`.

Rust’s `Write` contract treats `Ok(0)` on a non-empty buffer as “no progress”. Callers that use `write_all()` (the input path) turn that into `ErrorKind::WriteZero`. Typed keys were queued and then reported as a failed write, so they never reliably showed up in the pane.

This is #8003. #8006 has the two-line version (`Ok(buf.len())`). This PR uses the slightly fuller form from that issue: one `enqueue_send_keys` helper, skip empty buffers so we do not queue empty `send-keys`, and return `Ok(buf.len())` once the bytes are owned by the command queue (Wez’s note on #8006: the return value is transfer of ownership, not “already flushed to tmux”).

### 2. New tab (`SpawnTab` / Cmd+T) did not wait for tmux

`TmuxDomain::spawn` issued `new-window` and then `bail!("Intention: we use tmux command to do so")`. The GUI never got a tab back, so “new tab” did not finish attaching.

It now waits on a `pending_windows` promise that `WindowAdd` / `ListAllWindows` completes, then returns the new tab — the same pattern `split_pane` already used with `pending_splits`.

### 3. Closing a pane did not send `kill-pane`

`TmuxChild` / `TmuxChildKiller::kill` returned `"kill not implemented!"`. Closing a WezTerm pane left the remote tmux pane alive.

Kill now enqueues `kill-pane -t %id`.

### 4. Attach aborted on missing `#{history_limit}` or failed `list-commands`

WezTerm’s attach path runs `list-windows -F '… #{history_limit}'` and `list-commands`.

- Some control-mode speakers (including HTM) do not implement `#{history_limit}`. A missing/empty field used to fail the whole attach. It now defaults to `2000`.
- `list-commands` failing used to `bail!` and abort attach. WezTerm uses that list as a capability probe, not as a hard requirement, so a failure is now a warning and attach continues. Real tmux still populates the map as before.
- Re-listing windows no longer creates a second GUI tab for a window that is already attached.

## What this does *not* claim

#336 is the tracking issue for full tmux control-mode integration (scrollback from tmux history, burying the host pane, `unix_domains`-style tmux targets, etc.). This PR does not finish that list.

It does fix the crash that made attach impossible (#3223 / #6133), and it unblocks the basic loop that #336 already marks as in progress: attach, map windows/tabs/panes, send keys, spawn, and close.

## Test plan

- [x] `cargo check -p mux`
- [x] `tmux -CC` (and HTM speaking the same protocol) attach in WezTerm built from this branch: no `spawn_local` panic
- [x] Typing and paste reach the pane (`send-keys` with `Ok(buf.len())`)
- [x] Split pane, new tab, close pane (`kill-pane`)
- [x] Layout + bulk-I/O GUI e2e against HTM (`wezterm_htm_e2e.py` / stress), same suite as iTerm2 and Hyper
- [x] Please also try: `tmux -CC` locally and `tmux -CC a` over ssh (the #3223 repro)


Made with [Cursor](https://cursor.com)

## HTM + WezTerm video evidence

Recorded with the WezTerm build from this PR against HTM. The equivalent tmux/HTM layout, stress, lifecycle, resize, content, title, native-window, and corners suites complete with no semantic divergences.

### iTerm2-style control gateway (Esc / X / L / C)

https://github.com/user-attachments/assets/68275e36-43e0-448d-9883-96f462c2c5aa

### Layout, tabs, panes, and concurrent output

https://github.com/user-attachments/assets/61378c54-c032-42e9-b44b-764afb6405ce

### Lifecycle, resize, content, titles, and corner cases

https://github.com/user-attachments/assets/6f0f6cf6-372b-4f63-b105-ee3b15994e5a