### PR TITLE
gui: add workspace-changed event

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,6 +77,9 @@ As features stabilize some brief notes about them will accumulate here.
   easier to spot the remaining candidates. Thanks to @mr-felixoid and @bew! #7752
 
 #### New
+* [workspace-changed](config/lua/window-events/workspace-changed.md) event, emitted
+  when the active workspace changes, carrying both the new and the previous
+  workspace name. #4938
 * [command_palette_line_height](config/lua/config/command_palette_line_height.md)
   option to scale the vertical spacing of rows in the command palette,
   independently of [line_height](config/lua/config/line_height.md) which is for terminal cells only.

--- a/docs/config/lua/window-events/workspace-changed.md
+++ b/docs/config/lua/window-events/workspace-changed.md
@@ -1,0 +1,76 @@
+# `workspace-changed`
+
+{{since('nightly')}}
+
+The `workspace-changed` event is emitted when the active workspace changes.
+
+It fires for every kind of switch, whether it came from a key assignment such
+as [SwitchToWorkspace](../keyassignment/SwitchToWorkspace.md), from
+[wezterm.mux.set_active_workspace](../wezterm.mux/set_active_workspace.md), from
+renaming the workspace that is in front, or from wezterm itself moving you off
+a workspace whose last window has just been closed.
+
+This event is fire-and-forget from the perspective of wezterm; it fires the
+event to advise of the change, but has no other expectations.
+
+The first event parameter is a [`window` object](../window/index.md) that
+represents the gui window.
+
+The second event parameter is a [`pane` object](../pane/index.md) that
+represents the active pane in that window.
+
+The third parameter is the name of the workspace that is now active. It is the
+same value that [window:active_workspace()](../window/active_workspace.md)
+returns.
+
+The fourth parameter is the name of the workspace that was active before the
+change, or `nil` if there wasn't one. This is the only place that name is
+available, as the mux has already replaced it by the time the event is
+delivered.
+
+Like [window-config-reloaded](window-config-reloaded.md), this event is emitted
+once per gui window. It is emitted before those windows have been reconciled
+against the new workspace, so the window passed to the callback may be one that
+is about to be repurposed for a different mux window, or closed.
+
+```lua
+local wezterm = require 'wezterm'
+
+wezterm.on('workspace-changed', function(window, pane, workspace, prior)
+  wezterm.log_info(
+    'workspace is now ' .. workspace .. ', was ' .. tostring(prior)
+  )
+end)
+```
+
+The `prior` parameter makes it possible to build a "switch back to where I just
+was" key assignment, in the spirit of
+[ActivateLastTab](../keyassignment/ActivateLastTab.md):
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+
+wezterm.on('workspace-changed', function(window, pane, workspace, prior)
+  if prior then
+    -- Note that only scalars survive a round trip through wezterm.GLOBAL
+    wezterm.GLOBAL.previous_workspace = prior
+  end
+end)
+
+config.keys = {
+  {
+    key = 'l',
+    mods = 'ALT',
+    action = wezterm.action_callback(function(window, pane)
+      local previous = wezterm.GLOBAL.previous_workspace
+      if previous then
+        window:perform_action(
+          act.SwitchToWorkspace { name = previous },
+          pane
+        )
+      end
+    end),
+  },
+}
+```

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -62,7 +62,12 @@ pub enum MuxNotification {
     WindowRemoved(WindowId),
     WindowInvalidated(WindowId),
     WindowWorkspaceChanged(WindowId),
-    ActiveWorkspaceChanged(Arc<ClientId>),
+    ActiveWorkspaceChanged {
+        client_id: Arc<ClientId>,
+        /// The workspace that was active before the change. `None` when the
+        /// client had no active workspace yet.
+        old_workspace: Option<String>,
+    },
     Alert {
         pane_id: PaneId,
         alert: wezterm_term::Alert,
@@ -637,8 +642,17 @@ impl Mux {
     pub fn set_active_workspace_for_client(&self, ident: &Arc<ClientId>, workspace: &str) {
         let mut clients = self.clients.write();
         if let Some(info) = clients.get_mut(&ident) {
-            info.active_workspace.replace(workspace.to_string());
-            self.notify(MuxNotification::ActiveWorkspaceChanged(ident.clone()));
+            let old_workspace = info.active_workspace.replace(workspace.to_string());
+            if old_workspace.as_deref() == Some(workspace) {
+                // Re-asserting the workspace that is already active is not a
+                // change; notifying would make subscribers reconcile, and would
+                // make the workspace-changed event fire, for nothing.
+                return;
+            }
+            self.notify(MuxNotification::ActiveWorkspaceChanged {
+                client_id: ident.clone(),
+                old_workspace,
+            });
         }
     }
 
@@ -666,10 +680,11 @@ impl Mux {
         self.recompute_pane_count();
         for client in self.clients.write().values_mut() {
             if client.active_workspace.as_deref() == Some(old_workspace) {
-                client.active_workspace.replace(new_workspace.to_string());
-                self.notify(MuxNotification::ActiveWorkspaceChanged(
-                    client.client_id.clone(),
-                ));
+                let old_workspace = client.active_workspace.replace(new_workspace.to_string());
+                self.notify(MuxNotification::ActiveWorkspaceChanged {
+                    client_id: client.client_id.clone(),
+                    old_workspace,
+                });
             }
         }
     }

--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -278,7 +278,7 @@ fn mux_notify_client_domain(local_domain_id: DomainId, notif: MuxNotification) -
     };
 
     match notif {
-        MuxNotification::ActiveWorkspaceChanged(_client_id) => {
+        MuxNotification::ActiveWorkspaceChanged { .. } => {
             // TODO: advice remote host of interesting workspaces
         }
         MuxNotification::WorkspaceRenamed {

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -66,7 +66,7 @@ impl GuiFrontEnd {
                     }
                 }
                 MuxNotification::WindowWorkspaceChanged(_)
-                | MuxNotification::ActiveWorkspaceChanged(_)
+                | MuxNotification::ActiveWorkspaceChanged { .. }
                 | MuxNotification::WindowCreated(_)
                 | MuxNotification::WindowRemoved(_) => {
                     promise::spawn::spawn_into_main_thread(async move {
@@ -470,6 +470,14 @@ impl GuiFrontEnd {
 
     pub fn is_switching_workspace(&self) -> bool {
         *self.switching_workspaces.borrow()
+    }
+
+    /// The identity this gui uses with the mux. Other clients of the same mux
+    /// (`wezterm cli`, for instance) have their own identity and their own
+    /// active workspace, so notifications have to be matched against this
+    /// before they are treated as ours.
+    pub fn client_id(&self) -> &Arc<ClientId> {
+        &self.client_id
     }
 
     pub fn gui_window_for_mux_window(&self, mux_window_id: MuxWindowId) -> Option<GuiWin> {

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1312,11 +1312,13 @@ impl TermWindow {
                 MuxNotification::TabTitleChanged { .. } => {
                     self.update_title_post_status();
                 }
+                MuxNotification::ActiveWorkspaceChanged { old_workspace, .. } => {
+                    self.emit_workspace_changed_event(old_workspace);
+                }
                 MuxNotification::PaneAdded(_)
                 | MuxNotification::WorkspaceRenamed { .. }
                 | MuxNotification::PaneRemoved(_)
                 | MuxNotification::WindowWorkspaceChanged(_)
-                | MuxNotification::ActiveWorkspaceChanged(_)
                 | MuxNotification::Empty
                 | MuxNotification::WindowCreated(_) => {}
             },
@@ -1521,10 +1523,18 @@ impl TermWindow {
             | MuxNotification::AssignClipboard { .. }
             | MuxNotification::SaveToDownloads { .. }
             | MuxNotification::WindowCreated(_)
-            | MuxNotification::ActiveWorkspaceChanged(_)
             | MuxNotification::WorkspaceRenamed { .. }
             | MuxNotification::Empty
             | MuxNotification::WindowWorkspaceChanged(_) => return true,
+            MuxNotification::ActiveWorkspaceChanged { ref client_id, .. } => {
+                // Other clients of this mux (`wezterm cli`) have their own
+                // active workspace; only our own switch is worth waking the
+                // window up for. Falls through to dispatch when it is ours.
+                match crate::frontend::try_front_end() {
+                    Some(fe) if *client_id == *fe.client_id() => {}
+                    _ => return true,
+                }
+            }
             MuxNotification::Alert {
                 alert: Alert::PaletteChanged { .. },
                 ..
@@ -1907,6 +1917,54 @@ impl TermWindow {
         };
 
         return window_id == self.mux_window_id;
+    }
+
+    /// Advise the config that the active workspace changed.
+    ///
+    /// The name now in front is reachable from the handler as
+    /// `window:active_workspace()`, so what is passed here is the name that
+    /// was in front before, which is otherwise impossible to recover once the
+    /// switch has happened.
+    ///
+    /// This fires per gui window, in the same way as `window-config-reloaded`,
+    /// and it fires before the windows have been reconciled against the new
+    /// workspace, so the window handed to the callback may be one that is about
+    /// to be repurposed or closed.
+    fn emit_workspace_changed_event(&mut self, old_workspace: Option<String>) {
+        // Not mux.active_workspace(): that resolves through the mux identity,
+        // which is temporarily reassigned while dispatching for other clients.
+        let workspace = match crate::frontend::try_front_end() {
+            Some(fe) => Mux::get().active_workspace_for_client(fe.client_id()),
+            None => return,
+        };
+        let window = GuiWin::new(self);
+        let pane = match self.get_active_pane_or_overlay() {
+            Some(pane) => MuxPane(pane.pane_id()),
+            None => return,
+        };
+
+        async fn do_event(
+            lua: Option<Rc<mlua::Lua>>,
+            workspace: String,
+            old_workspace: Option<String>,
+            window: GuiWin,
+            pane: MuxPane,
+        ) -> anyhow::Result<()> {
+            if let Some(lua) = lua {
+                let args = lua.pack_multi((window, pane, workspace, old_workspace))?;
+                if let Err(err) =
+                    config::lua::emit_event(&lua, ("workspace-changed".to_string(), args)).await
+                {
+                    log::error!("while processing workspace-changed event: {:#}", err);
+                }
+            }
+            Ok(())
+        }
+
+        promise::spawn::spawn(config::with_lua_config_on_main_thread(move |lua| {
+            do_event(lua, workspace, old_workspace, window, pane)
+        }))
+        .detach();
     }
 
     fn emit_user_var_event(&mut self, pane_id: PaneId, name: String, value: String) {

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -202,7 +202,7 @@ where
                 .await?;
                 stream.flush().await.context("flushing PDU to client")?;
             }
-            Ok(Item::Notif(MuxNotification::ActiveWorkspaceChanged(_))) => {}
+            Ok(Item::Notif(MuxNotification::ActiveWorkspaceChanged { .. })) => {}
             Ok(Item::Notif(MuxNotification::Empty)) => {}
             Err(err) => {
                 log::error!("process_async Err {}", err);


### PR DESCRIPTION
Adds a `workspace-changed` event, so a config can react when the active workspace changes. Motivation and detail in #8126.

```lua
wezterm.on('workspace-changed', function(window, pane, workspace, prior)
  -- prior is the workspace that was active before, or nil
end)
```

`prior` is already computed and thrown away today in `Mux::set_active_workspace_for_client`, and is unrecoverable once the switch has happened.

Additive: a new event, nothing renamed or removed, no config or protocol changes. The one exception worth a look is that the mux no longer notifies subscribers when the active workspace is set to the value it already has, without which the event would fire for switches that did not happen.

Docs page and changelog entry included. `cargo test --all` passes. Verified by hand that the event fires on a deliberate switch, fires when the last window of the active workspace is closed, and does not fire on a no-op set.

