### PR TITLE
wezterm-escape-parser: fix aliasing violation

### DIFF
--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -424,6 +424,7 @@ mod win {
             size = size.min(val as usize);
         }
 
+        // Shared memory can technically be edited by any process, so we copy the data out.
         let mut data = Vec::with_capacity(size);
         if size > 0 {
             let src = unsafe { shm.buf.Value.cast::<u8>().add(offset) };

--- a/wezterm-escape-parser/src/apc.rs
+++ b/wezterm-escape-parser/src/apc.rs
@@ -423,9 +423,18 @@ mod win {
         if let Some(val) = data_size {
             size = size.min(val as usize);
         }
-        let buf_slice =
-            unsafe { std::slice::from_raw_parts(shm.buf.Value.cast::<u8>().add(offset), size) };
-        let data = buf_slice.to_vec();
+
+        let mut data = Vec::with_capacity(size);
+        if size > 0 {
+            let src = unsafe { shm.buf.Value.cast::<u8>().add(offset) };
+
+            // SAFETY: We have allocated a vector with enough capacity to hold `size` bytes,
+            // and we are copying from a valid memory region (`src`) into that vector.
+            unsafe {
+                src.copy_to_nonoverlapping(data.as_mut_ptr(), size);
+                data.set_len(size);
+            }
+        }
 
         Ok(data)
     }


### PR DESCRIPTION
Avoid creating a `&[u8]` reference over shared memory. Copy the mapped data directly with `ptr::copy_nonoverlapping`, preventing aliasing violations.

Contributes to https://github.com/wezterm/wezterm/issues/8051#issue-5145217015:

<details>
<summary>Aliasing and Immutability Violation on Windows Shared Memory Slices</summary>

> ### 2. Aliasing and Immutability Violation on Windows Shared Memory Slices (`src/escape/apc.rs:428`) 🔴 🚨
> 
> -   **Priority**: 🔴 High
> - **Threat Vector**: 🚨 Untrusted Input
> -   **Bug Type**: Aliasing Violation
> 
> In `read_shared_memory_data`, Windows shared memory for Kitty Image Protocol IPC is opened via `OpenFileMappingW` and mapped into memory via `MapViewOfFile` with `FILE_MAP_ALL_ACCESS`. The code constructs a shared reference slice `&[u8]` over this memory via `std::slice::from_raw_parts` and copies it:
> 
> ```rust
> 
> let buf_slice = unsafe { std::slice::from_raw_parts(shm.buf.add(offset), size) };
> let data = buf_slice.to_vec();
> 
> ```
> 
> Because the shared memory mapping is accessible by external processes or concurrent threads with write permissions, external modification of the shared memory during the lifetime of the `&[u8]` slice violates Rust's aliasing rules (shared references `&T` require that the underlying memory is not mutated for their duration). Furthermore, if the mapped memory pages were allocated by an untrusted external process and left uninitialized, reading them through `&[u8]` causes immediate Undefined Behavior due to reading uninitialized memory.

</details>
