### PR TITLE
style: Add newline after inner attribute for readability

### DIFF
--- a/bidi/src/lib.rs
+++ b/bidi/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+
 use alloc::borrow::Cow;
 use core::ops::Range;
 use level::MAX_DEPTH;

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -8,6 +8,7 @@
 //! client and server instances that are built from different versions
 //! of this code; in this way the client and server can more gracefully
 //! manage unknown enum variants.
+
 #![allow(dead_code)]
 #![allow(clippy::range_plus_one)]
 

--- a/deps/freetype/regenerate.sh
+++ b/deps/freetype/regenerate.sh
@@ -19,8 +19,10 @@ bindgen bindings.h -o src/lib.rs \
   --raw-line "#![allow(non_upper_case_globals)]" \
   --raw-line "#![allow(clippy::unreadable_literal)]" \
   --raw-line "#![allow(clippy::upper_case_acronyms)]" \
-  --raw-line "mod types;" \
+  --raw-line "" \
   --raw-line "mod fixed_point;" \
+  --raw-line "mod types;" \
+  --raw-line "" \
   --raw-line "pub use fixed_point::*;" \
   --raw-line "pub type FT_Int16 = i16;" \
   --raw-line "pub type FT_UInt16 = u16;" \

--- a/deps/freetype/src/lib.rs
+++ b/deps/freetype/src/lib.rs
@@ -5,8 +5,10 @@
 #![allow(non_upper_case_globals)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::upper_case_acronyms)]
+
 mod fixed_point;
 mod types;
+
 pub use fixed_point::*;
 pub type FT_Int16 = i16;
 pub type FT_UInt16 = u16;

--- a/procinfo/src/linux.rs
+++ b/procinfo/src/linux.rs
@@ -1,4 +1,5 @@
 #![cfg(target_os = "linux")]
+
 use super::*;
 
 impl From<&str> for LocalProcessStatus {

--- a/procinfo/src/macos.rs
+++ b/procinfo/src/macos.rs
@@ -1,4 +1,5 @@
 #![cfg(target_os = "macos")]
+
 use super::*;
 use std::ffi::{OsStr, OsString};
 use std::os::unix::ffi::{OsStrExt, OsStringExt};

--- a/procinfo/src/windows.rs
+++ b/procinfo/src/windows.rs
@@ -1,4 +1,5 @@
 #![cfg(windows)]
+
 use super::*;
 use ntapi::ntpebteb::PEB;
 use ntapi::ntpsapi::{

--- a/term/src/screen.rs
+++ b/term/src/screen.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::range_plus_one)]
+
 use super::*;
 use crate::config::BidiMode;
 use log::debug;

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -1,6 +1,7 @@
 // The range_plus_one lint can't see when the LHS is not compatible with
 // and inclusive range
 #![allow(clippy::range_plus_one)]
+
 use super::*;
 use crate::color::{ColorPalette, RgbColor};
 use crate::config::{BidiMode, NewlineCanon};

--- a/termwiz/examples/widgets_basic.rs
+++ b/termwiz/examples/widgets_basic.rs
@@ -1,6 +1,8 @@
 //! This example shows how to make a basic widget that accumulates
 //! text input and renders it to the screen
+
 #![allow(unused)]
+
 use termwiz::caps::Capabilities;
 use termwiz::cell::AttributeChange;
 use termwiz::color::{AnsiColor, ColorAttribute};

--- a/termwiz/src/widgets/mod.rs
+++ b/termwiz/src/widgets/mod.rs
@@ -1,6 +1,3 @@
-// Ideally this would be scoped to WidgetId, but I can't seem to find the
-// right place for it to take effect
-#![allow(clippy::new_without_default)]
 use crate::color::ColorAttribute;
 use crate::input::InputEvent;
 use crate::surface::{Change, CursorShape, CursorVisibility, Position, SequenceNo, Surface};

--- a/vtparse/src/lib.rs
+++ b/vtparse/src/lib.rs
@@ -10,8 +10,10 @@
 //! You may wish to use `termwiz::escape::parser::Parser` in the
 //! [termwiz](https://docs.rs/termwiz/) crate if you don't want to have to research
 //! all those possible escape sequences for yourself.
+
 #![allow(clippy::upper_case_acronyms)]
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use utf8parse::Parser as Utf8Parser;
 mod enums;
 use crate::enums::*;

--- a/wezterm-cell/src/color.rs
+++ b/wezterm-cell/src/color.rs
@@ -1,4 +1,5 @@
 //! Colors for attributes
+
 // for FromPrimitive
 #![allow(clippy::useless_attribute)]
 

--- a/wezterm-cell/src/lib.rs
+++ b/wezterm-cell/src/lib.rs
@@ -1,5 +1,7 @@
-#![cfg_attr(not(feature = "std"), no_std)]
 //! Model a cell in the terminal display
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use crate::color::{ColorAttribute, PaletteIndex};
 #[cfg(feature = "use_image")]
 use crate::image::ImageCell;

--- a/wezterm-char-props/src/lib.rs
+++ b/wezterm-char-props/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod emoji;
 pub mod emoji_presentation;
 pub mod emoji_variation;

--- a/wezterm-dynamic/src/lib.rs
+++ b/wezterm-dynamic/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), macro_use)]
+
 extern crate alloc;
 
 mod array;

--- a/wezterm-escape-parser/src/lib.rs
+++ b/wezterm-escape-parser/src/lib.rs
@@ -1,12 +1,14 @@
+//! This module provides the ability to parse escape sequences and attach
+//! semantic meaning to them.  It can also encode the semantic values as
+//! escape sequences.  It provides encoding and decoding functionality
+//! only; it does not provide terminal emulation facilities itself.
+
 // suppress inscrutable useless_attribute clippy that shows up when
 // using derive(FromPrimitive)
 #![allow(clippy::useless_attribute)]
 #![allow(clippy::upper_case_acronyms)]
 #![cfg_attr(not(feature = "std"), no_std)]
-//! This module provides the ability to parse escape sequences and attach
-//! semantic meaning to them.  It can also encode the semantic values as
-//! escape sequences.  It provides encoding and decoding functionality
-//! only; it does not provide terminal emulation facilities itself.
+
 #[cfg(feature = "tmux_cc")]
 use crate::tmux_cc::Event;
 use core::fmt::{Display, Formatter, Result as FmtResult, Write as FmtWrite};

--- a/wezterm-escape-parser/src/parser/mod.rs
+++ b/wezterm-escape-parser/src/parser/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::many_single_char_names)]
+
 #[cfg(feature = "tmux_cc")]
 use crate::tmux_cc::Event;
 use crate::{

--- a/wezterm-font/src/fcwrap.rs
+++ b/wezterm-font/src/fcwrap.rs
@@ -1,4 +1,5 @@
 //! Slightly higher level helper for fontconfig
+
 #![allow(clippy::mutex_atomic)]
 
 use anyhow::{anyhow, ensure, Error};

--- a/wezterm-gui/src/selection.rs
+++ b/wezterm-gui/src/selection.rs
@@ -1,6 +1,7 @@
 // The range_plus_one lint can't see when the LHS is not compatible with
 // and inclusive range
 #![allow(clippy::range_plus_one)]
+
 use mux::pane::Pane;
 use std::cmp::Ordering;
 use std::ops::Range;

--- a/wezterm-gui/src/termwindow/box_model.rs
+++ b/wezterm-gui/src/termwindow/box_model.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+
 use crate::color::LinearRgba;
 use crate::customglyph::{BlockKey, Poly};
 use crate::glyphcache::CachedGlyph;

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::range_plus_one)]
+
 use super::renderstate::*;
 use super::utilsprites::RenderMetrics;
 use crate::colorease::ColorEase;

--- a/wezterm-mux-server/src/daemonize.rs
+++ b/wezterm-mux-server/src/daemonize.rs
@@ -1,4 +1,5 @@
 #![cfg(unix)]
+
 use anyhow::Context;
 use libc::pid_t;
 use std::io::Write;

--- a/wezterm-surface/src/lib.rs
+++ b/wezterm-surface/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+
 use crate::line::CellRef;
 use alloc::borrow::Cow;
 use core::cmp::min;

--- a/wezterm-toast-notification/src/dbus.rs
+++ b/wezterm-toast-notification/src/dbus.rs
@@ -1,5 +1,6 @@
-#![cfg(all(not(target_os = "macos"), not(windows)))]
 //! See <https://developer.gnome.org/notification-spec/>
+
+#![cfg(all(not(target_os = "macos"), not(windows)))]
 
 use crate::ToastNotification;
 use futures_util::stream::{abortable, StreamExt};

--- a/wezterm-toast-notification/src/macos.rs
+++ b/wezterm-toast-notification/src/macos.rs
@@ -1,4 +1,5 @@
 #![cfg(target_os = "macos")]
+
 use crate::ToastNotification;
 use block2::{Block, RcBlock};
 use objc2::rc::Retained;

--- a/window/src/os/macos/keycodes.rs
+++ b/window/src/os/macos/keycodes.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(dead_code)]
+
 use std::collections::HashMap;
 use wezterm_input_types::PhysKeyCode;
 

--- a/window/src/os/macos/mod.rs
+++ b/window/src/os/macos/mod.rs
@@ -1,4 +1,5 @@
 #![allow(unexpected_cfgs)] // <https://github.com/SSheldon/rust-objc/issues/125>
+
 use cocoa::base::{id, nil};
 use cocoa::foundation::NSString;
 use objc::rc::StrongPtr;

--- a/window/src/os/x11/mod.rs
+++ b/window/src/os/x11/mod.rs
@@ -1,4 +1,5 @@
 #![cfg(all(unix, not(target_os = "macos")))]
+
 pub mod connection;
 pub mod cursor;
 pub mod keyboard;

--- a/window/src/os/x11/xcb_util.rs
+++ b/window/src/os/x11/xcb_util.rs
@@ -1,4 +1,5 @@
 #![allow(non_camel_case_types)]
+
 use libc::c_void;
 use xcb::ffi::*;
 

--- a/window/src/os/xdg_desktop_portal.rs
+++ b/window/src/os/xdg_desktop_portal.rs
@@ -1,6 +1,6 @@
-#![cfg(all(unix, not(target_os = "macos")))]
-
 //! <https://github.com/flatpak/xdg-desktop-portal/blob/main/data/org.freedesktop.portal.Settings.xml>
+
+#![cfg(all(unix, not(target_os = "macos")))]
 
 use crate::{Appearance, Connection, ConnectionOps};
 use anyhow::Context;


### PR DESCRIPTION
Add a newline after inner attributes to make it clear that the attribute applies to the enclosing item rather than the following item.