### PR TITLE
wezterm-client: specify winapi features to fix compilation error

### DIFF
--- a/wezterm-client/Cargo.toml
+++ b/wezterm-client/Cargo.toml
@@ -40,6 +40,6 @@ wezterm-term = { workspace=true, features=["use_serde"] }
 wezterm-uds.workspace = true
 
 [target."cfg(windows)".dependencies]
-winapi = { workspace=true, features = [
-    "winuser",
-]}
+winapi = { workspace = true, features = [
+    "synchapi",
+] }


### PR DESCRIPTION
Addresses https://github.com/wezterm/wezterm/pull/8107#issuecomment-5542651784.

```console
$ cargo check -q -p wezterm-client --all-targets --all-features --target x86_64-pc-windows-gnu
error[E0432]: unresolved import `winapi::um::synchapi`
   --> wezterm-client\src\discovery.rs:27:21
    |
 27 |     use winapi::um::synchapi::{CreateMutexW, ReleaseMutex, WaitForSingleObject};
    |                     ^^^^^^^^ could not find `synchapi` in `um`
    |
note: found an item that was configured out
   --> D:\a\wezterm\wezterm\vendor\winapi-0.3.9\src\um\mod.rs:235:38
    |
235 | #[cfg(feature = "synchapi")] pub mod synchapi;
    |       --------------------           ^^^^^^^^
    |       |
    |       the item is gated behind the `synchapi` feature
```