### PR TITLE
mux: don't spin forever when shrinking a split below its minimum

### DIFF
--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -383,20 +383,34 @@ fn adjust_x_size(tree: &mut Tree, mut x_adjust: isize, cell_dimensions: &Termina
                         }
                     }
                     SplitDirection::Horizontal => {
-                        // x_adjust is negative
-                        if data.first.cols > 1 {
+                        // x_adjust is negative.
+                        // Each child can only shrink down to the minimum
+                        // size of the panes it contains. The sizes recorded
+                        // in `data` may disagree with the children (they are
+                        // synced independently from a mux server), so we
+                        // must stop as soon as neither side can give up a
+                        // column rather than loop until `x_adjust` is zero.
+                        let (first_min, _) = compute_min_size(&mut *left);
+                        let (second_min, _) = compute_min_size(&mut *right);
+                        let mut shrunk = false;
+                        if data.first.cols > first_min {
                             adjust_x_size(&mut *left, -1, cell_dimensions);
                             data.first.cols -= 1;
                             data.first.pixel_width =
                                 data.first.cols.saturating_mul(cell_dimensions.pixel_width);
                             x_adjust += 1;
+                            shrunk = true;
                         }
-                        if x_adjust < 0 && data.second.cols > 1 {
+                        if x_adjust < 0 && data.second.cols > second_min {
                             adjust_x_size(&mut *right, -1, cell_dimensions);
                             data.second.cols -= 1;
                             data.second.pixel_width =
                                 data.second.cols.saturating_mul(cell_dimensions.pixel_width);
                             x_adjust += 1;
+                            shrunk = true;
+                        }
+                        if !shrunk {
+                            return;
                         }
                     }
                 }
@@ -454,15 +468,20 @@ fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &Termina
                         }
                     }
                     SplitDirection::Vertical => {
-                        // y_adjust is negative
-                        if data.first.rows > 1 {
+                        // y_adjust is negative; see adjust_x_size for why
+                        // we bail out when neither child can shrink.
+                        let (_, first_min) = compute_min_size(&mut *left);
+                        let (_, second_min) = compute_min_size(&mut *right);
+                        let mut shrunk = false;
+                        if data.first.rows > first_min {
                             adjust_y_size(&mut *left, -1, cell_dimensions);
                             data.first.rows -= 1;
                             data.first.pixel_height =
                                 data.first.rows.saturating_mul(cell_dimensions.pixel_height);
                             y_adjust += 1;
+                            shrunk = true;
                         }
-                        if y_adjust < 0 && data.second.rows > 1 {
+                        if y_adjust < 0 && data.second.rows > second_min {
                             adjust_y_size(&mut *right, -1, cell_dimensions);
                             data.second.rows -= 1;
                             data.second.pixel_height = data
@@ -470,6 +489,10 @@ fn adjust_y_size(tree: &mut Tree, mut y_adjust: isize, cell_dimensions: &Termina
                                 .rows
                                 .saturating_mul(cell_dimensions.pixel_height);
                             y_adjust += 1;
+                            shrunk = true;
+                        }
+                        if !shrunk {
+                            return;
                         }
                     }
                 }
@@ -2515,6 +2538,168 @@ mod test {
         assert_eq!(24, panes[2].height);
         assert_eq!(400, panes[2].pixel_width);
         assert_eq!(600, panes[2].pixel_height);
+    }
+
+    fn cols(cols: usize, rows: usize) -> TerminalSize {
+        TerminalSize {
+            rows,
+            cols,
+            pixel_width: cols * 10,
+            pixel_height: rows * 25,
+            dpi: 96,
+        }
+    }
+
+    fn leaf(pane_id: PaneId, size: TerminalSize) -> PaneNode {
+        PaneNode::Leaf(PaneEntry {
+            window_id: 0,
+            tab_id: 0,
+            pane_id,
+            title: String::new(),
+            size,
+            working_dir: None,
+            is_active_pane: pane_id == 1,
+            is_zoomed_pane: false,
+            workspace: "default".to_string(),
+            cursor_pos: StableCursorPosition::default(),
+            physical_top: 0,
+            top_row: 0,
+            left_col: 0,
+            tty_name: None,
+        })
+    }
+
+    fn split(
+        direction: SplitDirection,
+        first: TerminalSize,
+        second: TerminalSize,
+        left: PaneNode,
+        right: PaneNode,
+    ) -> PaneNode {
+        PaneNode::Split {
+            left: Box::new(left),
+            right: Box::new(right),
+            node: SplitDirectionAndSize {
+                direction,
+                first,
+                second,
+            },
+        }
+    }
+
+    /// Run `f` on a helper thread and fail the test if it hasn't returned
+    /// within a few seconds. Used for the resize tests below because the
+    /// failure mode we guard against is an infinite loop, which would
+    /// otherwise hang the whole test run instead of failing it.
+    fn must_terminate<F: FnOnce() + Send + 'static>(what: &str, f: F) {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            f();
+            tx.send(()).ok();
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(5)).is_ok(),
+            "{} did not terminate",
+            what
+        );
+    }
+
+    /// The split sizes recorded in a tab's tree can disagree with the
+    /// size that the tab believes it has (the tree is synced from a mux
+    /// server and the two are maintained separately). Shrinking a tab in
+    /// that state used to spin forever in adjust_x_size once every leaf
+    /// reached 1 column but the tab still had columns left to remove.
+    #[test]
+    fn resize_terminates_when_tab_size_exceeds_split_sizes() {
+        must_terminate("shrinking an overstated horizontal split", || {
+            let tab = Tab::new(&cols(80, 24));
+            // Tree says the tab is 3 columns wide, tab says 80.
+            let root = split(
+                SplitDirection::Horizontal,
+                cols(1, 24),
+                cols(1, 24),
+                leaf(1, cols(1, 24)),
+                leaf(2, cols(1, 24)),
+            );
+            tab.sync_with_pane_tree(cols(80, 24), root, |entry| {
+                FakePane::new(entry.pane_id, entry.size)
+            });
+            tab.resize(cols(5, 24));
+            assert_eq!(2, tab.iter_panes().len());
+        });
+
+        must_terminate("shrinking an overstated vertical split", || {
+            let tab = Tab::new(&cols(80, 24));
+            // Tree says the tab is 3 rows tall, tab says 24.
+            let root = split(
+                SplitDirection::Vertical,
+                cols(80, 1),
+                cols(80, 1),
+                leaf(1, cols(80, 1)),
+                leaf(2, cols(80, 1)),
+            );
+            tab.sync_with_pane_tree(cols(80, 24), root, |entry| {
+                FakePane::new(entry.pane_id, entry.size)
+            });
+            tab.resize(cols(80, 5));
+            assert_eq!(2, tab.iter_panes().len());
+        });
+    }
+
+    /// Same class of bug one level down: a parent split records its child
+    /// subtree as wider than the child's own split sizes add up to, so the
+    /// parent keeps asking the child to give up a column it doesn't have.
+    /// This is the shape of the tree (three panes side by side) that hung
+    /// wezterm-gui at 100% CPU while attaching to a remote mux.
+    #[test]
+    fn resize_terminates_when_parent_overstates_nested_split() {
+        must_terminate("shrinking a nested horizontal split", || {
+            let tab = Tab::new(&cols(65, 24));
+            // Inner split is really 3 columns wide but the parent thinks
+            // it is 10 (parent width: 54 + 10 + 1 = 65).
+            let inner = split(
+                SplitDirection::Horizontal,
+                cols(1, 24),
+                cols(1, 24),
+                leaf(2, cols(1, 24)),
+                leaf(3, cols(1, 24)),
+            );
+            let root = split(
+                SplitDirection::Horizontal,
+                cols(54, 24),
+                cols(10, 24),
+                leaf(1, cols(54, 24)),
+                inner,
+            );
+            tab.sync_with_pane_tree(cols(65, 24), root, |entry| {
+                FakePane::new(entry.pane_id, entry.size)
+            });
+            tab.resize(cols(5, 24));
+            assert_eq!(3, tab.iter_panes().len());
+        });
+
+        must_terminate("shrinking a nested vertical split", || {
+            let tab = Tab::new(&cols(80, 65));
+            let inner = split(
+                SplitDirection::Vertical,
+                cols(80, 1),
+                cols(80, 1),
+                leaf(2, cols(80, 1)),
+                leaf(3, cols(80, 1)),
+            );
+            let root = split(
+                SplitDirection::Vertical,
+                cols(80, 54),
+                cols(80, 10),
+                leaf(1, cols(80, 54)),
+                inner,
+            );
+            tab.sync_with_pane_tree(cols(80, 65), root, |entry| {
+                FakePane::new(entry.pane_id, entry.size)
+            });
+            tab.resize(cols(80, 5));
+            assert_eq!(3, tab.iter_panes().len());
+        });
     }
 
     fn is_send_and_sync<T: Send + Sync>() -> bool {


### PR DESCRIPTION
## Problem

`adjust_x_size` / `adjust_y_size` in `mux/src/tab.rs` shrink a tab one cell at a time inside `while x_adjust != 0`. The negative-direction branch only decrements a child when its recorded size is `> 1`, and never checks whether that child's subtree can actually shrink. When the sizes recorded in a `SplitDirectionAndSize` disagree with the subtree beneath it (the tree and the tab size are synced separately from a mux server), the loop reaches a node whose children are both at 1 cell while the delta is still non-zero, and it never exits.

In practice this pinned `wezterm-gui` at 100% CPU on the main thread while attaching to a remote `wezterm-mux-server` that had a tab with three panes side by side. The whole GUI froze and its unix socket stopped responding. Stack sample from macOS (`wezterm 20260607-082427-8afe0ad3`):

```
TermWindow::new_window::{{closure}}
  mux::tab::Tab::resize
    mux::tab::TabInner::resize
      mux::tab::adjust_x_size
        mux::tab::adjust_x_size   (looping)
```

## Fix

Guard each decrement with the child subtree's minimum size from `compute_min_size`, and return from the loop as soon as neither child can give up a cell. The function now terminates for any input, consistent or not, and behaves the same as before for consistent trees.

## Tests

Two new tests build deliberately inconsistent trees through `sync_with_pane_tree` and shrink them under a 5s timeout, so a regression fails instead of hanging the test run: an overstated root split and an overstated nested split, each in both directions. They fail on `main` and pass with this change. `cargo test -p mux` and `cargo fmt --all` are clean.

## Disclosure

The diagnosis, patch and tests were written with an AI coding assistant (Claude) driven by me, and I reviewed and ran them. Happy to adjust if the project prefers a different approach to such contributions (ref #7664).
