### PR TITLE
fix some rustc lints

### DIFF
--- a/async_ossl/src/lib.rs
+++ b/async_ossl/src/lib.rs
@@ -42,7 +42,7 @@ impl std::os::windows::io::AsRawSocket for AsyncSslStream {
 
 #[cfg(windows)]
 impl std::os::windows::io::AsSocket for AsyncSslStream {
-    fn as_socket(&self) -> std::os::windows::io::BorrowedSocket {
+    fn as_socket(&self) -> std::os::windows::io::BorrowedSocket<'_> {
         self.s.get_ref().as_socket()
     }
 }

--- a/lfucache/src/lib.rs
+++ b/lfucache/src/lib.rs
@@ -348,7 +348,7 @@ mod test {
         }
     }
 
-    fn frequency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<K, V>> {
+    fn frequency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<'_, K, V>> {
         let mut entries = vec![];
         for item in cache.frequency_index.iter() {
             entries.push(EntryData::new(item));
@@ -356,7 +356,7 @@ mod test {
         entries
     }
 
-    fn recency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<K, V>> {
+    fn recency_order<K, V, S>(cache: &LfuCache<K, V, S>) -> Vec<EntryData<'_, K, V>> {
         let mut entries = vec![];
         for item in cache.recency_index.iter() {
             entries.push(EntryData::new(item));

--- a/mux/src/tab.rs
+++ b/mux/src/tab.rs
@@ -2279,7 +2279,7 @@ mod test {
         fn reader(&self) -> anyhow::Result<Option<Box<dyn std::io::Read + Send>>> {
             Ok(None)
         }
-        fn writer(&self) -> MappedMutexGuard<dyn std::io::Write> {
+        fn writer(&self) -> MappedMutexGuard<'_, dyn std::io::Write> {
             unimplemented!()
         }
         fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {

--- a/procinfo/src/windows.rs
+++ b/procinfo/src/windows.rs
@@ -34,7 +34,7 @@ impl Snapshot {
         }
     }
 
-    pub fn iter(&self) -> ProcIter {
+    pub fn iter(&self) -> ProcIter<'_> {
         ProcIter {
             snapshot: &self,
             first: true,

--- a/termwiz/src/terminal/windows.rs
+++ b/termwiz/src/terminal/windows.rs
@@ -758,7 +758,7 @@ impl Terminal for WindowsTerminal {
         })
     }
 
-    fn probe_capabilities(&mut self) -> Option<ProbeCapabilities> {
+    fn probe_capabilities(&mut self) -> Option<ProbeCapabilities<'_>> {
         Some(ProbeCapabilities::new(
             &mut self.input_handle,
             &mut self.output_handle,

--- a/wezterm-char-props/src/widechar_width.rs
+++ b/wezterm-char-props/src/widechar_width.rs
@@ -1668,7 +1668,7 @@ impl WcLookupTable {
 
 #[cfg(test)]
 mod test {
-    use super::*;
+    use crate::widechar_width::WcWidth;
 
     #[test]
     fn basics() {

--- a/wezterm-client/src/client.rs
+++ b/wezterm-client/src/client.rs
@@ -578,7 +578,7 @@ impl AsRawSocket for SshStream {
 
 #[cfg(windows)]
 impl AsSocket for SshStream {
-    fn as_socket(&self) -> BorrowedSocket {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
         self.stdout.as_socket()
     }
 }

--- a/wezterm-toast-notification/src/macos.rs
+++ b/wezterm-toast-notification/src/macos.rs
@@ -95,11 +95,11 @@ impl Drop for NotifDelegate {
 }
 
 const CENTER: LazyLock<Retained<UNUserNotificationCenter>> =
-    LazyLock::new(|| unsafe { UNUserNotificationCenter::currentNotificationCenter() });
+    LazyLock::new(UNUserNotificationCenter::currentNotificationCenter);
 
 pub fn initialize() {
     static INIT: Once = Once::new();
-    INIT.call_once(|| unsafe {
+    INIT.call_once(|| {
         CENTER.requestAuthorizationWithOptions_completionHandler(
             UNAuthorizationOptions::Alert
                 | UNAuthorizationOptions::Provisional

--- a/wezterm-uds/src/lib.rs
+++ b/wezterm-uds/src/lib.rs
@@ -69,7 +69,7 @@ impl AsRawSocket for UnixStream {
 }
 #[cfg(windows)]
 impl AsSocket for UnixStream {
-    fn as_socket(&self) -> BorrowedSocket {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
         self.0.as_socket()
     }
 }


### PR DESCRIPTION
Ensure the following exits without warnings:

```sh
cargo check -q --workspace
```