### PR TITLE
gui: add workspace-changed event

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -77,6 +77,8 @@ As features stabilize some brief notes about them will accumulate here.
   easier to spot the remaining candidates. Thanks to @mr-felixoid and @bew! #7752
 
 #### New
+* [workspace-changed](config/lua/gui-events/workspace-changed.md) event,
+  emitted when the active workspace changes, carrying both the new and the previous workspace name.
 * [command_palette_line_height](config/lua/config/command_palette_line_height.md)
   option to scale the vertical spacing of rows in the command palette,
   independently of [line_height](config/lua/config/line_height.md) which is for terminal cells only.

--- a/docs/config/lua/gui-events/workspace-changed.md
+++ b/docs/config/lua/gui-events/workspace-changed.md
@@ -1,0 +1,56 @@
+# `workspace-changed`
+
+{{since('nightly')}}
+
+The `workspace-changed` event is emitted when the active workspace changes,
+including when the workspace in front is renamed and when wezterm moves you off
+a workspace whose last window has closed.
+
+The first parameter is the name of the workspace that is now active.
+The second is the name of the workspace that was active before it.
+
+It is emitted once for the change.
+It does not fire for the workspace that is active at startup.
+
+The workspace that was active before may no longer exist: a rename retires the
+name it replaced, and a workspace whose last window has closed is gone by the
+time the change it caused is reported.
+
+The example below binds `ALT-l` to switching back to the workspace you came from.
+It records each previous name as it is reported,
+and checks that the name still exists before switching to it:
+
+```lua
+local wezterm = require 'wezterm'
+local act = wezterm.action
+local config = wezterm.config_builder()
+
+wezterm.on('workspace-changed', function(workspace, prior)
+  wezterm.GLOBAL.previous_workspace = prior
+end)
+
+config.keys = {
+  {
+    key = 'l',
+    mods = 'ALT',
+    action = wezterm.action_callback(function(window, pane)
+      local previous = wezterm.GLOBAL.previous_workspace
+      for _, name in ipairs(wezterm.mux.get_workspace_names()) do
+        if name == previous then
+          window:perform_action(
+            act.SwitchToWorkspace { name = previous },
+            pane
+          )
+          return
+        end
+      end
+    end),
+  },
+}
+
+return config
+```
+
+See also: [SwitchToWorkspace](../keyassignment/SwitchToWorkspace.md),
+[wezterm.mux.get_active_workspace](../wezterm.mux/get_active_workspace.md),
+[wezterm.mux.set_active_workspace](../wezterm.mux/set_active_workspace.md).

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -62,7 +62,11 @@ pub enum MuxNotification {
     WindowRemoved(WindowId),
     WindowInvalidated(WindowId),
     WindowWorkspaceChanged(WindowId),
-    ActiveWorkspaceChanged(Arc<ClientId>),
+    ActiveWorkspaceChanged {
+        client_id: Arc<ClientId>,
+        new_workspace: String,
+        old_workspace: String,
+    },
     Alert {
         pane_id: PaneId,
         alert: wezterm_term::Alert,
@@ -635,10 +639,23 @@ impl Mux {
     }
 
     pub fn set_active_workspace_for_client(&self, ident: &Arc<ClientId>, workspace: &str) {
+        let default_workspace = self.get_default_workspace();
         let mut clients = self.clients.write();
         if let Some(info) = clients.get_mut(&ident) {
-            info.active_workspace.replace(workspace.to_string());
-            self.notify(MuxNotification::ActiveWorkspaceChanged(ident.clone()));
+            // A client that has never been assigned a workspace is already on
+            // the default one, so that is the name this change replaces.
+            let old_workspace = info
+                .active_workspace
+                .replace(workspace.to_string())
+                .unwrap_or(default_workspace);
+            if old_workspace == workspace {
+                return;
+            }
+            self.notify(MuxNotification::ActiveWorkspaceChanged {
+                client_id: ident.clone(),
+                new_workspace: workspace.to_string(),
+                old_workspace,
+            });
         }
     }
 
@@ -667,9 +684,11 @@ impl Mux {
         for client in self.clients.write().values_mut() {
             if client.active_workspace.as_deref() == Some(old_workspace) {
                 client.active_workspace.replace(new_workspace.to_string());
-                self.notify(MuxNotification::ActiveWorkspaceChanged(
-                    client.client_id.clone(),
-                ));
+                self.notify(MuxNotification::ActiveWorkspaceChanged {
+                    client_id: client.client_id.clone(),
+                    new_workspace: new_workspace.to_string(),
+                    old_workspace: old_workspace.to_string(),
+                });
             }
         }
     }

--- a/wezterm-client/src/domain.rs
+++ b/wezterm-client/src/domain.rs
@@ -278,7 +278,7 @@ fn mux_notify_client_domain(local_domain_id: DomainId, notif: MuxNotification) -
     };
 
     match notif {
-        MuxNotification::ActiveWorkspaceChanged(_client_id) => {
+        MuxNotification::ActiveWorkspaceChanged { .. } => {
             // TODO: advice remote host of interesting workspaces
         }
         MuxNotification::WorkspaceRenamed {

--- a/wezterm-gui/src/frontend.rs
+++ b/wezterm-gui/src/frontend.rs
@@ -65,8 +65,32 @@ impl GuiFrontEnd {
                         .detach();
                     }
                 }
+                MuxNotification::ActiveWorkspaceChanged {
+                    client_id: changed_for,
+                    new_workspace,
+                    old_workspace,
+                } => {
+                    // Other mux clients keep their own active workspace.
+                    let mine = changed_for == client_id;
+                    // The lua config is main-thread only, and reporting after
+                    // the reconcile lets a handler see the windows the change
+                    // brought with it.
+                    promise::spawn::spawn_into_main_thread(async move {
+                        let fe = crate::frontend::front_end();
+                        if !fe.is_switching_workspace() {
+                            fe.reconcile_workspace();
+                        }
+                        if mine {
+                            promise::spawn::spawn(trigger_and_log_workspace_changed(
+                                new_workspace,
+                                old_workspace,
+                            ))
+                            .detach();
+                        }
+                    })
+                    .detach();
+                }
                 MuxNotification::WindowWorkspaceChanged(_)
-                | MuxNotification::ActiveWorkspaceChanged(_)
                 | MuxNotification::WindowCreated(_)
                 | MuxNotification::WindowRemoved(_) => {
                     promise::spawn::spawn_into_main_thread(async move {
@@ -483,6 +507,28 @@ impl GuiFrontEnd {
             }
         }
         None
+    }
+}
+
+async fn trigger_workspace_changed(
+    lua: Option<Rc<mlua::Lua>>,
+    workspace: String,
+    old_workspace: String,
+) -> anyhow::Result<()> {
+    if let Some(lua) = lua {
+        let args = lua.pack_multi((workspace, old_workspace))?;
+        config::lua::emit_event(&lua, ("workspace-changed".to_string(), args)).await?;
+    }
+    Ok(())
+}
+
+async fn trigger_and_log_workspace_changed(workspace: String, old_workspace: String) {
+    if let Err(err) = config::with_lua_config_on_main_thread(move |lua| {
+        trigger_workspace_changed(lua, workspace, old_workspace)
+    })
+    .await
+    {
+        log::error!("while processing workspace-changed event: {:#}", err);
     }
 }
 

--- a/wezterm-gui/src/termwindow/mod.rs
+++ b/wezterm-gui/src/termwindow/mod.rs
@@ -1316,7 +1316,7 @@ impl TermWindow {
                 | MuxNotification::WorkspaceRenamed { .. }
                 | MuxNotification::PaneRemoved(_)
                 | MuxNotification::WindowWorkspaceChanged(_)
-                | MuxNotification::ActiveWorkspaceChanged(_)
+                | MuxNotification::ActiveWorkspaceChanged { .. }
                 | MuxNotification::Empty
                 | MuxNotification::WindowCreated(_) => {}
             },
@@ -1521,7 +1521,7 @@ impl TermWindow {
             | MuxNotification::AssignClipboard { .. }
             | MuxNotification::SaveToDownloads { .. }
             | MuxNotification::WindowCreated(_)
-            | MuxNotification::ActiveWorkspaceChanged(_)
+            | MuxNotification::ActiveWorkspaceChanged { .. }
             | MuxNotification::WorkspaceRenamed { .. }
             | MuxNotification::Empty
             | MuxNotification::WindowWorkspaceChanged(_) => return true,

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -202,7 +202,7 @@ where
                 .await?;
                 stream.flush().await.context("flushing PDU to client")?;
             }
-            Ok(Item::Notif(MuxNotification::ActiveWorkspaceChanged(_))) => {}
+            Ok(Item::Notif(MuxNotification::ActiveWorkspaceChanged { .. })) => {}
             Ok(Item::Notif(MuxNotification::Empty)) => {}
             Err(err) => {
                 log::error!("process_async Err {}", err);


### PR DESCRIPTION
Adds a `workspace-changed` event, so a config can react when the active workspace changes. Motivation in #8126.

```lua
wezterm.on('workspace-changed', function(workspace, prior)
  -- prior is the workspace that was active before
end)
```

It is a gui event emitted once per switch rather than a window event.

