### PR TITLE
Feature: expand background size "contain" option

### DIFF
--- a/config/src/background.rs
+++ b/config/src/background.rs
@@ -138,7 +138,7 @@ pub enum BackgroundSize {
     /// Scales image as large as possible without cropping or stretching.
     /// If the container is larger than the image, tiles the image unless
     /// the correspond `repeat` is NoRepeat.
-    Contain,
+    Contain(Option<Dimension>),
     /// Scale the image (preserving aspect ratio) to the smallest possible
     /// size to the fill the container leaving no empty space.
     /// If the aspect ratio differs from the background, the image is
@@ -155,9 +155,27 @@ impl FromDynamic for BackgroundSize {
     ) -> Result<Self, wezterm_dynamic::Error> {
         match value {
             Value::String(label) => match label.as_str() {
-                "Contain" => return Ok(Self::Contain),
                 "Cover" => return Ok(Self::Cover),
-                _ => {}
+                other => {
+                    if other.starts_with("Contain") {
+                        let mut dim = None;
+                        if let Some((_, dim_str)) = other.split_once("Contain,") {
+                            match PixelUnit::from_dynamic(&dim_str.to_dynamic(), options) {
+                                Ok(pix) => dim = Some(pix.into()),
+                                Err(_) => {
+                                    return Err(wezterm_dynamic::Error::Message(format!(
+                                        "expected a string of \
+                                        the form '123px' where 'px' is a unit and \
+                                        can be one of 'px', '%', 'pt' or 'cell', \
+                                        but got {}",
+                                        dim_str
+                                    )))
+                                }
+                            }
+                        }
+                        return Ok(Self::Contain(dim));
+                    }
+                }
             },
             _ => {}
         }
@@ -179,7 +197,11 @@ impl ToDynamic for BackgroundSize {
     fn to_dynamic(&self) -> Value {
         let s = match self {
             Self::Cover => "Cover".to_string(),
-            Self::Contain => "Contain".to_string(),
+            Self::Contain(None) => "Contain".to_string(),
+            Self::Contain(Some(d)) => match d.to_dynamic() {
+                Value::String(s) => format!("Contain,{s}"),
+                _ => unreachable!(),
+            },
             Self::Dimension(d) => return d.to_dynamic(),
         };
         Value::String(s)

--- a/docs/config/lua/config/background.md
+++ b/docs/config/lua/config/background.md
@@ -62,7 +62,7 @@ A layer is a lua table with the following fields:
 * `hsb` - a hue, saturation, brightness transformation that can be used to adjust those attributes of the layer. See [foreground_text_hsb](foreground_text_hsb.md) for more information about this kind of transform.
 * `height` - controls the height of the image. The following values are accepted:
     * `"Cover"` (this is the default) - Scales the image, preserving aspect ratio, to the smallest possible size to fill the viewport, leaving no empty space.  If the aspect ratio of the viewport differs from the image, the image is cropped.
-    * `"Contain"` - Scales the image as large as possible without cropping or stretching. If the viewport is larger than the image, tiles the image unless `repeat_y` is set to `"NoRepeat"`.
+    * `"Contain"` - Scales the image as large as possible without cropping or stretching. If the viewport is larger than the image, tiles the image unless `repeat_y` is set to `"NoRepeat"`. Additionally, it can take an argument after a comma that affects the size of the box to contain the image in (e.g. `"Contain,50%"` will constrain the image to half of the viewport's height).
     * `123` - specifies a height of `123` pixels
     * `"50%"` - specifies a size of `50%` of the viewport height
     * `"2cell"` - specifies a size equivalent to `2` rows

--- a/wezterm-gui/src/termwindow/background.rs
+++ b/wezterm-gui/src/termwindow/background.rs
@@ -441,9 +441,6 @@ impl crate::TermWindow {
         let tex_width = sprite.coords.width() as f32;
         let tex_height = sprite.coords.height() as f32;
 
-        let scale_width = pixel_width / tex_width as f32;
-        let scale_height = pixel_height / tex_height as f32;
-
         let h_context = DimensionContext {
             dpi: self.dimensions.dpi as f32,
             pixel_max: pixel_width,
@@ -453,6 +450,18 @@ impl crate::TermWindow {
             dpi: self.dimensions.dpi as f32,
             pixel_max: pixel_height,
             pixel_cell: self.render_metrics.cell_size.height as f32,
+        };
+
+        let scale_width = if let BackgroundSize::Contain(Some(dim)) = layer.def.width {
+            dim.evaluate_as_pixels(h_context) / tex_width as f32
+        } else {
+            pixel_width / tex_width as f32
+        };
+
+        let scale_height = if let BackgroundSize::Contain(Some(dim)) = layer.def.height {
+            dim.evaluate_as_pixels(v_context) / tex_height as f32
+        } else {
+            pixel_height / tex_height as f32
         };
 
         // log::info!("tex {tex_width}x{tex_height} aspect={aspect}");
@@ -469,13 +478,13 @@ impl crate::TermWindow {
         };
 
         let width = match layer.def.width {
-            BackgroundSize::Contain => min_aspect_width as f32,
+            BackgroundSize::Contain(_) => min_aspect_width as f32,
             BackgroundSize::Cover => max_aspect_width as f32,
             BackgroundSize::Dimension(n) => n.evaluate_as_pixels(h_context),
         };
 
         let height = match layer.def.height {
-            BackgroundSize::Contain => min_aspect_height as f32,
+            BackgroundSize::Contain(_) => min_aspect_height as f32,
             BackgroundSize::Cover => max_aspect_height as f32,
             BackgroundSize::Dimension(n) => n.evaluate_as_pixels(v_context),
         };


### PR DESCRIPTION
Expands the setting as I described in #8135.

Now, if you set background height to `"Contain,50%"`, it will look like this:
<img width="1912" height="1040" alt="image" src="https://github.com/user-attachments/assets/454c74d8-4bf4-4d13-bcd1-86129db88f85" />

Thought I'd check the code to see how hard it would be to implement this myself and it turned out to be trivial.