### PR TITLE
mux: unsubscribe the per-connection notification subscriber on disconnect

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -160,6 +160,11 @@ As features stabilize some brief notes about them will accumulate here.
   `CTRL-u` to kill back to the start of the line. Thanks to @bew! #8013
 
 #### Fixed
+* mux: `wezterm-mux-server` leaked a `Mux` notification subscriber, and the
+  unbounded channel it captures, for every client connection. Subscribers are
+  only reaped by `Mux::notify`, so a server with no attached client accumulated
+  them unboundedly; measured at 0.13 MB per connection, taking a server from
+  24 MB to 15 GB in 90 seconds under connection churn. #7363
 * macOS: Fix window border when opacity<1 and shadow enabled.
   Thanks to @Adams-Galaxy! #8038 #5158
 * perf: Terminal images were hashed three times each on the transmit path; the sha256

--- a/mux/src/lib.rs
+++ b/mux/src/lib.rs
@@ -697,7 +697,15 @@ impl Mux {
         self.clients.write().remove(client_id);
     }
 
-    pub fn subscribe<F>(&self, subscriber: F)
+    /// Register a notification subscriber, returning its id so that the
+    /// caller can `unsubscribe` when it goes away.
+    ///
+    /// Subscribers are otherwise only reaped by `notify`, which drops those
+    /// returning false. A mux with no attached client emits few or no
+    /// notifications, so a caller that does not unsubscribe leaks its
+    /// subscriber (and anything the closure captures, such as a channel
+    /// sender and its queue) for as long as the mux stays quiet.
+    pub fn subscribe<F>(&self, subscriber: F) -> usize
     where
         F: Fn(MuxNotification) -> bool + 'static + Send + Sync,
     {
@@ -705,6 +713,12 @@ impl Mux {
         self.subscribers
             .write()
             .insert(sub_id, Box::new(subscriber));
+        sub_id
+    }
+
+    /// Remove a subscriber previously registered via `subscribe`.
+    pub fn unsubscribe(&self, sub_id: usize) {
+        self.subscribers.write().remove(&sub_id);
     }
 
     pub fn notify(&self, notification: MuxNotification) {

--- a/wezterm-mux-server-impl/src/dispatch.rs
+++ b/wezterm-mux-server-impl/src/dispatch.rs
@@ -58,11 +58,25 @@ where
     });
     let mut handler = SessionHandler::new(pdu_sender);
 
-    {
+    // Unsubscribe when this connection goes away. Without this the subscriber
+    // (and the unbounded channel it captures) stays registered until some
+    // notification happens to fire and `Mux::notify` reaps it. A mux with no
+    // attached client is quiet, so subscribers from short-lived connections
+    // accumulate unboundedly.
+    struct SubscriptionGuard(usize);
+    impl Drop for SubscriptionGuard {
+        fn drop(&mut self) {
+            if let Some(mux) = Mux::try_get() {
+                mux.unsubscribe(self.0);
+            }
+        }
+    }
+
+    let _subscription = {
         let mux = Mux::get();
         let tx = item_tx.clone();
-        mux.subscribe(move |n| tx.try_send(Item::Notif(n)).is_ok());
-    }
+        SubscriptionGuard(mux.subscribe(move |n| tx.try_send(Item::Notif(n)).is_ok()))
+    };
 
     loop {
         let rx_msg = item_rx.recv();


### PR DESCRIPTION
## The bug

`wezterm-mux-server` leaks a `Mux` notification subscriber, and the unbounded
channel that subscriber captures, for **every client connection**.

`wezterm-mux-server-impl/src/dispatch.rs` subscribes once per connection:

```rust
{
    let mux = Mux::get();
    let tx = item_tx.clone();
    mux.subscribe(move |n| tx.try_send(Item::Notif(n)).is_ok());
}
```

Nothing unsubscribes when `process_async` returns. The only place subscribers
are ever removed is `Mux::notify` (`mux/src/lib.rs`):

```rust
pub fn notify(&self, notification: MuxNotification) {
    let mut subscribers = self.subscribers.write();
    subscribers.retain(|_, notify| notify(notification.clone()));
}
```

So a dead subscriber is reaped only if a notification happens to fire. A mux
server with no attached client and idle panes is quiet, so subscribers
accumulate without bound, each pinning a `smol::channel` whose
`ConcurrentQueue` ring buffer is preallocated.

## Why it looks so inconsistent in the wild

This explains the behaviour reported in #7363, including the part that makes it
hard to reproduce:

* It leaks hard until the **first** client attaches, then goes essentially flat
  and **releases** everything, because an attached client generates constant
  notifications and `retain` reaps every dead subscriber in one pass. On my box
  attaching released 774 / 795 / 713 / 2685 MB instantly, at the moment of
  attach.
* This matches @OderDochNicht's report that a restarted `wezterm connect server`
  sometimes sits at 130 MB for ten minutes and sometimes reaches 10 GB in eight.
  It depends on whether anything attached.
* Feeding lots of output to a mux does **not** reproduce it. Only connection
  churn does. That is why it resisted diagnosis.

Sampling the leaked heap of a live 7.34 GB server showed 96.3% zero bytes,
which is the signature of preallocated, mostly-empty queue buffers rather than
retained terminal content.

## Measurements

Isolated mux server, sequential `wezterm cli list-clients` connections:

| Build | Leaked per connection |
|---|---|
| `20240203-110809-5046fc22` | 0.131 MB |
| `main` @ 4fbd6b8e (unpatched) | 0.112 MB |
| `main` @ 4fbd6b8e + this patch | **0.004 MB** |

Under an 8-worker parallel connection hammer, the unpatched server went from
**24.5 MB to 15,003 MB in 90 seconds**. Patched, it went from 22 MB to 26 MB.

heaptrack on the unpatched build attributes the leak to:

```
ConcurrentQueue<dispatch::Item>::push
async_channel::Sender<dispatch::Item>::try_send
wezterm_mux_server_impl::dispatch::process_async   dispatch.rs:55
PduSender::send                                    sessionhandler.rs:27
SessionHandler::process_one                        sessionhandler.rs:266
```

11.26 MB leaked over 399 allocations for a 400-connection run.

## The fix

1. `Mux::subscribe` returns the `sub_id` it already generates.
2. New `Mux::unsubscribe(sub_id)`.
3. `dispatch.rs` holds a `SubscriptionGuard` whose `Drop` unsubscribes, so it
   runs on every exit path including the early `return Ok(())` on client
   disconnect.

The return-value change is additive; existing callers that ignore it are
unaffected. `cargo check --workspace` is clean, including `wezterm-gui`.

## Real-world result

Running the patched server as my daily mux on a 28 GB box:

| | 24h before | 20h after |
|---|---|---|
| Server killed at a 16 GB guard threshold | 10 times | 0 |
| Peak RSS | 16,244 MB | **51 MB** |

That covered 570 samples with no client attached, which is the state that
previously leaked at 176-199 MB/min.

## Notes for the maintainer

* An alternative shape would be for `subscribe` to return an RAII guard
  directly rather than a bare id. That is a larger API change, so I kept this
  minimal. Happy to switch if you prefer it.
* The other `Mux::subscribe` call sites (`wezterm-gui/src/frontend.rs`,
  `wezterm-gui/src/termwindow/mod.rs`, `wezterm-client/src/domain.rs`,
  `mux/src/tmux_commands.rs`) also never unsubscribe. Those are longer-lived so
  the impact is much smaller, but `termwindow` subscribes per window and windows
  do close. I left them alone to keep this focused.

Refs #7363. I believe this accounts for the reports there, but I have not
ruled out other leak paths in the mux, so I have not used a closing keyword.
