### PR TITLE
term: Fix HTS panic when the cursor is past the right edge

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -160,6 +160,8 @@ As features stabilize some brief notes about them will accumulate here.
   `CTRL-u` to kill back to the start of the line. Thanks to @bew! #8013
 
 #### Fixed
+* HTS panicked with an index out of bounds when it ran with the cursor parked
+  one column past the right edge. #8134
 * macOS: Fix window border when opacity<1 and shadow enabled.
   Thanks to @Adams-Galaxy! #8038 #5158
 * perf: Terminal images were hashed three times each on the transmit path; the sha256

--- a/term/src/terminalstate/mod.rs
+++ b/term/src/terminalstate/mod.rs
@@ -74,7 +74,13 @@ impl TabStop {
     }
 
     fn set_tab_stop(&mut self, col: usize) {
-        self.tabs[col] = true;
+        // The cursor is allowed to sit one column past the right edge,
+        // so col can legitimately be out of range; there is no column
+        // there to hold a tab stop, so ignore it, just as we do when
+        // clearing a tab stop at the active position.
+        if let Some(t) = self.tabs.get_mut(col) {
+            *t = true;
+        }
     }
 
     fn find_prev_tab_stop(&self, col: usize) -> Option<usize> {

--- a/term/src/test/c1.rs
+++ b/term/src/test/c1.rs
@@ -60,6 +60,18 @@ fn test_hts() {
 }
 
 #[test]
+fn test_hts_past_right_edge() {
+    // CUP is allowed to park the cursor one column past the right edge,
+    // so HTS can be asked to set a tab stop on a column that does not
+    // exist. That has to be ignored rather than panicking.
+    let mut term = TestTerm::new(3, 8, 0);
+    term.cup(8, 0);
+    let seqno = term.current_seqno();
+    term.print("\x1bH");
+    term.assert_cursor_pos(8, 0, None, Some(seqno));
+}
+
+#[test]
 fn test_ri() {
     let mut term = TestTerm::new(4, 2, 0);
     term.print("a\r\nb\r\nc\r\nd.");


### PR DESCRIPTION
Closes #8134.

## Summary

`HTS` aborts the terminal with `index out of bounds: the len is N but the index is N` when it runs with the cursor one column past the right edge. On an 8 column screen the whole reproducer is 5 bytes: `\x1b[;9H\x88`, which is `CUP` to column 9 followed by C1 `HTS`. The 7-bit `\x1bH` form does the same. Neither sequence is a problem on its own.

## Root cause

`set_cursor_pos` in `term/src/terminalstate/mod.rs` deliberately allows an absolute column of `physical_cols`, one past the last real column, and says why in a comment at the clamp: it keeps a cursor that belongs to a wrapped line from being forgotten across a resize or rewrap. So `cursor.x == physical_cols` is a valid state.

`TabStop::set_tab_stop` (`term/src/terminalstate/mod.rs:76`) indexed the tab stop array directly with `self.tabs[col] = true`. `TabStop::new` fills that array with exactly `screen_width` entries and `TabStop::resize` only ever grows it, so on a screen that has never been wider, `tabs.len() == physical_cols` and the index is out of range by one. `c1_hts` is the only caller, and it passes `self.cursor.x` unfiltered.

## Fix

`set_tab_stop` now goes through `get_mut` and ignores a column that does not exist. That is already what `TabStop::clear` does for the inverse operation, `TBC` at the active position, twenty lines further down in the same `impl` block, so the two now agree: a column past the right edge holds no tab stop and neither sets nor clears one. Every in-range column behaves exactly as before.

## Verification

`cargo test -p wezterm-term` on this branch: `test result: ok. 54 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out`, plus `0 passed` doc-tests.

The new test `term/src/test/c1.rs::test_hts_past_right_edge` run against the unmodified `set_tab_stop`, with everything else in this branch in place: `thread 'test::c1::test_hts_past_right_edge' panicked at term/src/terminalstate/mod.rs:77:18: index out of bounds: the len is 8 but the index is 8`, `test result: FAILED. 1 passed; 1 failed`. The existing `test_hts` passes in both directions, so the regression test is pinning the new behavior and not the old.

`rustfmt --edition 2018 --check term/src/terminalstate/mod.rs term/src/test/c1.rs` reports no diff. This machine has stable rustfmt 1.9.0 rather than nightly, so the nightly-only `imports_granularity` setting in `.rustfmt.toml` was skipped with a warning; neither file changes any imports.
