### PR TITLE
fix(macos): disable throttling during blocking macos resize events

### DIFF
--- a/window/src/os/macos/window.rs
+++ b/window/src/os/macos/window.rs
@@ -3131,7 +3131,23 @@ impl WindowView {
                 return;
             }
 
-            if inner.paint_throttled {
+            if inner.live_resizing {
+                // The macos zoom (https://developer.apple.com/documentation/appkit/nswindow/zoom(_:) call when invoked
+                // via menu bar double click causes app kit to set the main thread run loop mode to
+                // the undocumented private `_NSMoveTimerRunLoopMode` which is not in the Default mode event selector.
+                //
+                // This causes the max_fps timer that disables throttling to not be run until AFTER
+                // window maximizing has completed. This leads to a snapping effect where the
+                // background is painted only AFTER the animation has completed.
+                //
+                // To fix that we just disable fps throttling during the maximize animation to
+                // ensure a consistent background painting.
+                //
+                // Related:
+                // https://www.mattrajca.com/2016/09/15/on-run-loops-modal-ui-and-buttery-smooth-scrolling.html
+                inner.events.dispatch(WindowEvent::NeedRepaint);
+                inner.invalidated = false;
+            } else if inner.paint_throttled {
                 inner.invalidated = true;
             } else {
                 inner.events.dispatch(WindowEvent::NeedRepaint);


### PR DESCRIPTION
fixes: https://github.com/wezterm/wezterm/issues/3299

https://github.com/user-attachments/assets/60f8c745-1c9e-49c0-9965-082b06aeed4d

This one was a bit tricky, it boils down to an annoying undocumented interaction between specifically maximize calls that invoke NSWindow:zoom https://developer.apple.com/documentation/appkit/nswindow/zoom(_:) and appkits event loop run mode when combined with `max_fps` throttling.

This line here https://github.com/wezterm/wezterm/blob/d2f3f05b38f26a872f4b0bfbb3d2eaa7bdfc1b0b/window/src/os/macos/window.rs#L3144 Schedules the "unthrottling" of the render loop for after it completes via the SpawnQueue https://github.com/wezterm/wezterm/blob/d2f3f05b38f26a872f4b0bfbb3d2eaa7bdfc1b0b/window/src/spawn.rs#L193

The observer however is only created with `kCFRunLoopCommonModes` as its observed modes. When an app kit maximize is invoked it switches the event loop into `_NSMoveTimerRunLoopMode` for the duration of the animation. Meaning that the "Unthrottle" callbacks are never executed until after the animation is complete, essentially locking out rendering. 

The simplest fix i could come up with was to simply disable fps throttling during a resize operation on macos via `live_resizing` which appears to be inline with suggested fixes for this. 

https://stackoverflow.com/questions/3535786/how-to-detect-nswindow-maximize-or-zoom-event

The alternative fix i also validated was simply add another event loop watcher for that app kit mode to the SpawnQueue like this

```diff
diff --git a/window/src/spawn.rs b/window/src/spawn.rs
index 5363ef4b1..82b4e08a0 100644
--- a/window/src/spawn.rs
+++ b/window/src/spawn.rs
@@ -1,7 +1,7 @@
 #[cfg(windows)]
 use crate::os::windows::event::EventHandle;
 #[cfg(target_os = "macos")]
-use core_foundation::runloop::*;
+use core_foundation::{base::TCFType, runloop::*, string::CFString};
 use promise::spawn::{Runnable, SpawnFunc};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
@@ -205,7 +205,9 @@ impl SpawnQueue {
             )
         };
         unsafe {
             CFRunLoopAddObserver(CFRunLoopGetMain(), observer, kCFRunLoopCommonModes);
+            let move_timer_mode = CFString::from_static_string("_NSMoveTimerRunLoopMode");
+            CFRunLoopAddObserver(CFRunLoopGetMain(), observer, move_timer_mode.as_concrete_TypeRef());
         }
 
         Ok(Self {
``` 

This will work but it is an implicit reliance on undocumented private app kit strings and is fragile. 

> [!NOTE] 
> **LLM Disclosure**
> Gpt-6-astra in pi was utilized to help research and trace the failure mode. 
> All code, comments and descriptions were typed by hand. 